### PR TITLE
Call cleanup before returning in error cases

### DIFF
--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -516,7 +516,6 @@ func (s *Server) Start() (rErr error) {
 		if err != nil {
 			return err
 		}
-		
 	}
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -510,12 +510,13 @@ func (s *Server) Start() (rErr error) {
 				RuntimeConfig: refreshableRuntimeCfg,
 			},
 		)
-		if err != nil {
-			return err
-		}
 		if cleanupFn != nil {
 			defer cleanupFn()
 		}
+		if err != nil {
+			return err
+		}
+		
 	}
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any


### PR DESCRIPTION
InitFunc might have initialized some resources and then hit an error. We should probably call cleanup regardless of whether we hit an error or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/19)
<!-- Reviewable:end -->
