### PR TITLE
Add UnregisterHealthComponent to HealthReporter

### DIFF
--- a/status/reporter/reporter.go
+++ b/status/reporter/reporter.go
@@ -32,6 +32,7 @@ type HealthReporter interface {
 	status.HealthCheckSource
 	InitializeHealthComponent(name string) (HealthComponent, error)
 	GetHealthComponent(name string) (HealthComponent, bool)
+	UnregisterHealthComponent(name string) error
 
 	setHealthCheck(component health.CheckType, status health.HealthCheckResult)
 	setHealthCheckAndComponentIfAbsent(componentName health.CheckType, component HealthComponent, status health.HealthCheckResult) bool
@@ -91,6 +92,17 @@ func (r *healthReporter) GetHealthComponent(name string) (HealthComponent, bool)
 	defer r.mutex.RUnlock()
 	c, ok := r.healthComponents[health.CheckType(name)]
 	return c, ok
+}
+
+func (r *healthReporter) UnregisterHealthComponent(name string) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	componentName := health.CheckType(name)
+	delete(r.healthComponents, componentName)
+	delete(r.currentStatus.Checks, componentName)
+
+	return nil
 }
 
 // HealthStatus returns a copy of the current HealthStatus, and cannot be used to modify the current state

--- a/status/reporter/reporter.go
+++ b/status/reporter/reporter.go
@@ -94,6 +94,7 @@ func (r *healthReporter) GetHealthComponent(name string) (HealthComponent, bool)
 	return c, ok
 }
 
+// UnregisterHealthComponent - Removes a health component by name if already initialized.
 func (r *healthReporter) UnregisterHealthComponent(name string) error {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/status/reporter/reporter.go
+++ b/status/reporter/reporter.go
@@ -103,14 +103,14 @@ func (r *healthReporter) UnregisterHealthComponent(name string) bool {
 	componentName := health.CheckType(name)
 
 	if _, present := r.healthComponents[componentName]; present {
+		delete(r.healthComponents, componentName)
 		changesMade = true
 	}
-	delete(r.healthComponents, componentName)
 
 	if _, present := r.currentStatus.Checks[componentName]; present {
+		delete(r.currentStatus.Checks, componentName)
 		changesMade = true
 	}
-	delete(r.currentStatus.Checks, componentName)
 
 	return changesMade
 }

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -151,7 +151,7 @@ func TestUnregisterThenGet(t *testing.T) {
 	assert.NotNil(t, component)
 	assert.NoError(t, err)
 
-	assert.NoError(t, reporter.UnregisterHealthComponent(validComponent))
+	assert.True(t, reporter.UnregisterHealthComponent(validComponent))
 
 	_, present := reporter.GetHealthComponent(validComponent)
 	assert.False(t, present)
@@ -159,5 +159,5 @@ func TestUnregisterThenGet(t *testing.T) {
 
 func TestUnregisterOnUninitialized(t *testing.T) {
 	reporter := newHealthReporter()
-	assert.NoError(t, reporter.UnregisterHealthComponent(validComponent))
+	assert.False(t, reporter.UnregisterHealthComponent(validComponent))
 }

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -144,3 +144,20 @@ func TestSetIfNotExist(t *testing.T) {
 	}
 	assert.Fail(t, "Did get the correct number of total calls", total)
 }
+
+func TestUnregisterThenGet(t *testing.T) {
+	reporter := newHealthReporter()
+	component, err := reporter.InitializeHealthComponent(validComponent)
+	assert.NotNil(t, component)
+	assert.NoError(t, err)
+
+	assert.NoError(t, reporter.UnregisterHealthComponent(validComponent))
+
+	_, present := reporter.GetHealthComponent(validComponent)
+	assert.False(t, present)
+}
+
+func TestUnregisterOnUninitialized(t *testing.T) {
+	reporter := newHealthReporter()
+	assert.NoError(t, reporter.UnregisterHealthComponent(validComponent))
+}


### PR DESCRIPTION
Closes #55 

Before this PR:
-
- There was no way to remove a previously initialized health component, which is tricky when tracking health of components whose existence can vary over time.

After this PR:
-
- HealthReporter now exposes an UnregisterHealthComponent function that is responsible for removing a HealthComponent by name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/56)
<!-- Reviewable:end -->
