### PR TITLE
remove internal negroni go.mod

### DIFF
--- a/witchcraft/internal/negroni/go.mod
+++ b/witchcraft/internal/negroni/go.mod
@@ -1,1 +1,0 @@
-module github.com/urfave/negroni


### PR DESCRIPTION
having this breaks using witchcraft-go-server with modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/57)
<!-- Reviewable:end -->
