### PR TITLE
Set server state to idle on stop

### DIFF
--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -448,6 +448,8 @@ func (s *Server) Start() (rErr error) {
 	if err := s.stateManager.Start(); err != nil {
 		return err
 	}
+	// Run() function only terminates after server stops, so reset state at that point
+	defer s.stateManager.setState(ServerIdle)
 
 	// set provider for ECV key
 	if s.ecvKeyProvider == nil {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -743,6 +743,7 @@ func stopServer(s *Server, stopper func(s *http.Server) error) error {
 	if s.State() != ServerRunning {
 		return werror.Error("server is not running")
 	}
+	s.stateManager.setState(ServerIdle)
 	return stopper(s.httpServer)
 }
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -448,8 +448,12 @@ func (s *Server) Start() (rErr error) {
 	if err := s.stateManager.Start(); err != nil {
 		return err
 	}
-	// Run() function only terminates after server stops, so reset state at that point
-	defer s.stateManager.setState(ServerIdle)
+	// Reset state if server terminated without calling s.Close() or s.Shutdown()
+	defer func() {
+		if s.State() != ServerIdle {
+			s.stateManager.setState(ServerIdle)
+		}
+	}()
 
 	// set provider for ECV key
 	if s.ecvKeyProvider == nil {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -448,8 +448,6 @@ func (s *Server) Start() (rErr error) {
 	if err := s.stateManager.Start(); err != nil {
 		return err
 	}
-	// Run() function only terminates after server stops, so reset state at that point
-	defer s.stateManager.setState(ServerIdle)
 
 	// set provider for ECV key
 	if s.ecvKeyProvider == nil {


### PR DESCRIPTION
This ensures that the server properly begins responding with a `503 Service Unavailable` once the stop process is initiated, rather than current state where it only responds in this manner after `server.Start()` returns and the server has fully stopped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/62)
<!-- Reviewable:end -->
