### PR TITLE
wrouter: Subrouters can have params

### DIFF
--- a/witchcraft/multirouter.go
+++ b/witchcraft/multirouter.go
@@ -74,10 +74,10 @@ func (m *multiRouterImpl) Delete(path string, handler http.Handler, params ...wr
 	return m.mainRouter.Delete(path, handler, params...)
 }
 
-func (m *multiRouterImpl) Subrouter(path string) wrouter.Router {
+func (m *multiRouterImpl) Subrouter(path string, params ...wrouter.RouteParam) wrouter.Router {
 	return &multiRouterImpl{
-		mainRouter: m.mainRouter.Subrouter(path),
-		mgmtRouter: m.mgmtRouter.Subrouter(path),
+		mainRouter: m.mainRouter.Subrouter(path, params...),
+		mgmtRouter: m.mgmtRouter.Subrouter(path, params...),
 	}
 }
 

--- a/wrouter/router.go
+++ b/wrouter/router.go
@@ -49,7 +49,7 @@ type Router interface {
 	// Subrouter returns a new Router that is a child of this Router. A child router is effectively an alias to the root
 	// router -- any routes registered on the child router are registered on the root router with all of the prefixes up
 	// to the child router.
-	Subrouter(path string) Router
+	Subrouter(path string, params ...RouteParam) Router
 
 	// Path returns the path stored by this router. The path is empty for the root router, while subrouters will return
 	// only the portion of the path managed by the subrouter.

--- a/wrouter/router_root.go
+++ b/wrouter/router_root.go
@@ -170,10 +170,11 @@ func (r *rootRouter) Delete(path string, handler http.Handler, params ...RoutePa
 	return r.Register(http.MethodDelete, path, handler, params...)
 }
 
-func (r *rootRouter) Subrouter(path string) Router {
+func (r *rootRouter) Subrouter(path string, params ...RouteParam) Router {
 	return &subrouter{
 		rPath:   path,
 		rParent: r,
+		params:  params,
 	}
 }
 

--- a/wrouter/router_sub.go
+++ b/wrouter/router_sub.go
@@ -24,11 +24,12 @@ import (
 type subrouter struct {
 	rPath   string
 	rParent Router
+	params  []RouteParam
 }
 
 func (s *subrouter) Register(method, path string, handler http.Handler, params ...RouteParam) error {
 	rootRouter, basePath := s.getRootRouterAndPath()
-	return rootRouter.Register(method, fmt.Sprint(basePath, path), handler, params...)
+	return rootRouter.Register(method, fmt.Sprint(basePath, path), handler, append(s.params, params...)...)
 }
 
 func (s *subrouter) RegisteredRoutes() []RouteSpec {
@@ -67,10 +68,11 @@ func (s *subrouter) Delete(path string, handler http.Handler, params ...RoutePar
 	return s.Register(http.MethodDelete, path, handler, params...)
 }
 
-func (s *subrouter) Subrouter(path string) Router {
+func (s *subrouter) Subrouter(path string, params ...RouteParam) Router {
 	return &subrouter{
 		rPath:   path,
 		rParent: s,
+		params:  params,
 	}
 }
 


### PR DESCRIPTION
It's nice to not duplicate path params for subpaths of a subrouter that contains path params.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/64)
<!-- Reviewable:end -->
