### PR TITLE
Add inflight request ratelimiter middleware

### DIFF
--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -38,6 +38,9 @@ func TestNewInflightLimitMiddleware(t *testing.T) {
 	requireHealthy := func(msg string) {
 		require.Equal(t, string(health.HealthStateHealthy), string(healthComponent.Status()), msg)
 	}
+	requireRepairing := func(msg string) {
+		require.Equal(t, string(health.HealthStateRepairing), string(healthComponent.Status()), msg)
+	}
 
 	limiter := ratelimit.NewInFlightRequestLimitMiddleware(2, ratelimit.MatchMutating, healthComponent)
 
@@ -112,9 +115,12 @@ func TestNewInflightLimitMiddleware(t *testing.T) {
 
 	resp3 := doPost()
 	require.Equal(t, http.StatusTooManyRequests, resp3.StatusCode, "expected third POST request to be rate limited")
+	requireRepairing("expected repairing after throttled response")
 
 	require.Equal(t, http.StatusOK, doGet().StatusCode, "expected get request to be successful")
 	require.Equal(t, http.StatusOK, doGet().StatusCode, "expected get request to be successful")
+
+	requireRepairing("expected unchanged health after unmatched response")
 
 	// free the waiting requests, which should return 200
 	closeWait()

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/status/reporter"
 	"github.com/palantir/witchcraft-go-server/witchcraft"
 	"github.com/palantir/witchcraft-go-server/witchcraft/ratelimit"
+	"github.com/palantir/witchcraft-go-server/witchcraft/refreshable"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +43,7 @@ func TestNewInflightLimitMiddleware(t *testing.T) {
 		require.Equal(t, string(health.HealthStateRepairing), string(healthComponent.Status()), msg)
 	}
 
-	limiter := ratelimit.NewInFlightRequestLimitMiddleware(2, ratelimit.MatchMutating, healthComponent)
+	limiter := ratelimit.NewInFlightRequestLimitMiddleware(refreshable.NewInt(refreshable.NewDefaultRefreshable(2)), ratelimit.MatchMutating, healthComponent)
 
 	wait, closeWait := context.WithCancel(context.Background())
 	defer closeWait()

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/palantir/pkg/httpserver"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status/reporter"
+	"github.com/palantir/witchcraft-go-server/witchcraft"
+	"github.com/palantir/witchcraft-go-server/witchcraft/ratelimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInflightLimitMiddleware(t *testing.T) {
+	healthReporter := reporter.NewHealthReporter()
+	healthComponent, err := healthReporter.InitializeHealthComponent("INFLIGHT_MUTATING_REQUESTS")
+	require.NoError(t, err)
+	requireHealthy := func(msg string) {
+		require.Equal(t, string(health.HealthStateHealthy), string(healthComponent.Status()), msg)
+	}
+	requireRepairing := func(msg string) {
+		require.Equal(t, string(health.HealthStateRepairing), string(healthComponent.Status()), msg)
+	}
+
+	limiter := ratelimit.NewInflightLimitMiddleware(2, ratelimit.MatchMutating, healthComponent)
+
+	wait, closeWait := context.WithCancel(context.Background())
+	defer closeWait()
+
+	initFn := func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+		info.Router.RootRouter().AddRouteHandlerMiddleware(limiter)
+		if err := info.Router.Get("/get", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+		})); err != nil {
+			return nil, err
+		}
+		if err := info.Router.Post("/post", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			<-wait.Done()
+			rw.WriteHeader(http.StatusOK)
+		})); err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, initFn, ioutil.Discard, createTestServer)
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	client := testServerClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	doGet := func() *http.Response {
+		getURL := fmt.Sprintf("https://localhost:%d/%s/get", port, basePath)
+		request, err := http.NewRequest(http.MethodGet, getURL, nil)
+		if err != nil {
+			panic(err)
+		}
+		resp, err := client.Do(request.WithContext(ctx))
+		if err != nil {
+			panic(err)
+		}
+		return resp
+	}
+	doPost := func() *http.Response {
+		postURL := fmt.Sprintf("https://localhost:%d/%s/post", port, basePath)
+		request, err := http.NewRequest(http.MethodPost, postURL, nil)
+		if err != nil {
+			panic(err)
+		}
+		resp, err := client.Do(request.WithContext(ctx))
+		if err != nil {
+			panic(err)
+		}
+		return resp
+	}
+
+	// Fill up rate limit
+	resp1c := make(chan *http.Response)
+	requireHealthy("expected healthy before the first request")
+	go func() { resp1c <- doPost() }()
+	resp2c := make(chan *http.Response)
+	requireHealthy("expected healthy before the second request")
+	go func() { resp2c <- doPost() }()
+
+	time.Sleep(time.Millisecond) // let things settle
+	requireHealthy("expected healthy before the third request")
+
+	resp3 := doPost()
+	require.Equal(t, http.StatusTooManyRequests, resp3.StatusCode, "expected third POST request to be rate limited")
+	requireRepairing("expected repairing after throttled response")
+
+	require.Equal(t, http.StatusOK, doGet().StatusCode, "expected get request to be successful")
+	require.Equal(t, http.StatusOK, doGet().StatusCode, "expected get request to be successful")
+
+	requireRepairing("expected unchanged health after unmatched response")
+
+	// free the waiting requests, which should return 200
+	closeWait()
+	resp1 := <-resp1c
+	assert.Equal(t, http.StatusOK, resp1.StatusCode, "expected blocked request 1 to return 200 when unblocked")
+	resp2 := <-resp2c
+	assert.Equal(t, http.StatusOK, resp2.StatusCode, "expected blocked request 2 to return 200 when unblocked")
+
+	// we should now be unblocked and healthy
+	require.Equal(t, http.StatusOK, doPost().StatusCode, "expected fourth POST request to be unblocked")
+	requireHealthy("expected healthy after accepted request")
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/witchcraft/ratelimit/middleware.go
+++ b/witchcraft/ratelimit/middleware.go
@@ -100,7 +100,6 @@ func (l *limiter) increment(ctx context.Context) (throttled bool) {
 	return true
 }
 
-
 // increment subtracts 1 from the current counter. If the new value is under the Limit,
 // l.Health is set to HEALTHY (if not already in that state).
 func (l *limiter) decrement(ctx context.Context) {

--- a/witchcraft/ratelimit/middleware.go
+++ b/witchcraft/ratelimit/middleware.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ratelimit
+
+import (
+	"net/http"
+	"sync/atomic"
+
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status/reporter"
+	"github.com/palantir/witchcraft-go-server/wrouter"
+)
+
+type MatchFunc func(req *http.Request, vals wrouter.RequestVals) bool
+
+var MatchReadonly MatchFunc = func(req *http.Request, vals wrouter.RequestVals) bool {
+	return req.Method == http.MethodGet || req.Method == http.MethodHead || req.Method == http.MethodOptions
+}
+
+var MatchMutating MatchFunc = func(req *http.Request, vals wrouter.RequestVals) bool {
+	return req.Method == http.MethodPost || req.Method == http.MethodPut || req.Method == http.MethodDelete || req.Method == http.MethodPatch
+}
+
+// NewInflightLimitMiddleware returns a middleware which counts and limits the number of
+// inflight requests that match a the provided MatchFunc filter. If health is non-nil,
+// it will be set to REPAIRING when the middleware returns StatusTooManyRequests (429),
+//
+// TODO: We should set the Retry-After header based on how many requests we're rejecting.
+//		 Maybe enqueue requests in a channel for a few seconds in case other requests return quickly?
+func NewInflightLimitMiddleware(limit int64, matches MatchFunc, healthcheck reporter.HealthComponent) wrouter.RouteHandlerMiddleware {
+	l := &limiter{
+		Limit:   limit,
+		Matches: matches,
+		Health:  healthcheck,
+	}
+	healthcheck.Healthy()
+	return l.ServeHTTP
+}
+
+type limiter struct {
+	Limit   int64
+	Matches MatchFunc
+	Health  reporter.HealthComponent
+
+	current int64
+}
+
+func (l *limiter) ServeHTTP(rw http.ResponseWriter, req *http.Request, reqVals wrouter.RequestVals, next wrouter.RouteRequestHandler) {
+	if l.Matches(req, reqVals) {
+		current := atomic.AddInt64(&l.current, 1)
+		defer atomic.AddInt64(&l.current, -1)
+
+		if current > l.Limit {
+			msg := "Throttling due to too many inflight requests"
+			if l.Health != nil && l.Health.Status() != health.HealthStateRepairing {
+				l.Health.SetHealth(health.HealthStateRepairing, &msg, nil)
+			}
+			svc1log.FromContext(req.Context()).Warn(msg,
+				svc1log.SafeParam("current", current),
+				svc1log.SafeParam("limit", l.Limit))
+
+			// Return early, triggering failover or exponential backoff.
+			http.Error(rw, msg, http.StatusTooManyRequests)
+			return
+		}
+
+		// Mark ourselves healthy!
+		if l.Health != nil && l.Health.Status() != health.HealthStateHealthy {
+			l.Health.Healthy()
+		}
+	}
+	next(rw, req, reqVals)
+}


### PR DESCRIPTION
An optional middleware for returning 429 when there are too many requests in flight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/67)
<!-- Reviewable:end -->
