### PR TITLE
Map logger runtime update down to only logger configuration

### DIFF
--- a/witchcraft/refreshable/refreshable_file.go
+++ b/witchcraft/refreshable/refreshable_file.go
@@ -81,7 +81,7 @@ func (d *fileRefreshable) watchForChanges(ctx context.Context) error {
 				if event.Op == fsnotify.Write || event.Op == fsnotify.Create || event.Op == fsnotify.Rename {
 					fileBytes, err := ioutil.ReadFile(d.filePath)
 					if err != nil {
-						svc1log.FromContext(ctx).Warn("Failed to read file bytes to update refreshable")
+						svc1log.FromContext(ctx).Warn("Failed to read file bytes to update refreshable", svc1log.Stacktrace(err))
 						continue
 					}
 					loadedChecksum := sha256.Sum256(fileBytes)

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -512,9 +512,10 @@ func (s *Server) Start() (rErr error) {
 	}
 
 	// handle built-in runtime config changes
-	unsubscribe := baseRefreshableRuntimeCfg.Subscribe(func(in interface{}) {
-		baseRuntimeCfg := in.(config.Runtime)
-		if loggerCfg := baseRuntimeCfg.LoggerConfig; loggerCfg != nil {
+	unsubscribe := baseRefreshableRuntimeCfg.Map(func(in interface{}) interface{} {
+		return in.(config.Runtime).LoggerConfig
+	}).Subscribe(func(in interface{}) {
+		if loggerCfg := in.(*config.LoggerConfig); loggerCfg != nil {
 			s.svcLogger.SetLevel(loggerCfg.Level)
 		}
 	})


### PR DESCRIPTION
Also adds stacktrace param in refreshable_file.go that I noticed was missing

Fixes #51

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/68)
<!-- Reviewable:end -->
