### PR TITLE
Refactor periodic healthcheck

### DIFF
--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -20,51 +20,81 @@ import (
 	"sync"
 	"time"
 
-	conjurehealth "github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-server/status"
-	"github.com/palantir/witchcraft-go-server/status/health"
 )
 
+type Source interface {
+	Check(ctx context.Context) (state health.HealthState, params map[string]interface{})
+}
+
 type healthCheckSource struct {
-	gracePeriodReset         time.Time
-	numRunsDuringGracePeriod int
-	lastErr                  error
-	poll                     func() error
-	gracePeriod              time.Duration
-	retryInterval            time.Duration
-	checkType                conjurehealth.CheckType
-	mutex                    sync.RWMutex
+	// static
+	source        Source
+	gracePeriod   time.Duration
+	retryInterval time.Duration
+	checkType     health.CheckType
+
+	// mutable
+	mutex           sync.RWMutex
+	lastResult      *health.HealthCheckResult
+	lastResultTime  time.Time
+	lastSuccess     *health.HealthCheckResult
+	lastSuccessTime time.Time
 }
 
 // NewHealthCheckSource creates a health check source that calls poll every retryInterval in a goroutine. The goroutine
 // is cancelled if ctx is cancelled. If gracePeriod elapses without poll returning nil, the returned health check
 // source will give a health status of error. checkType is the key to be used in the health result returned by the
 // health check source.
-func NewHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, checkType conjurehealth.CheckType, poll func() error) status.HealthCheckSource {
+func NewHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, checkType health.CheckType, poll func() error) status.HealthCheckSource {
+	return FromHealthCheckSource(ctx, gracePeriod, retryInterval, checkType, &defaultHealthCheckSource{poll: poll})
+}
+
+// FromHealthCheckSource creates a health check source that calls source.Check every retryInterval in a goroutine. The goroutine
+// is cancelled if ctx is cancelled. If gracePeriod elapses without Check returning HEALTHY, the returned health check
+// source will give a health status of error. checkType is the key to be used in the health result returned by the
+// health check source.
+func FromHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, checkType health.CheckType, source Source) status.HealthCheckSource {
 	checker := &healthCheckSource{
-		gracePeriodReset: time.Now(),
-		lastErr:          nil,
-		gracePeriod:      gracePeriod,
-		retryInterval:    retryInterval,
-		checkType:        checkType,
-		poll:             poll,
+		gracePeriod:   gracePeriod,
+		retryInterval: retryInterval,
+		checkType:     checkType,
+		source:        source,
 	}
-	go checker.runPoll(ctx)
+	go wapp.RunWithRecoveryLogging(ctx, checker.runPoll)
 	return checker
 }
 
-func (h *healthCheckSource) HealthStatus(ctx context.Context) conjurehealth.HealthStatus {
+func (h *healthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	h.mutex.RLock()
-	defer func() {
-		h.mutex.RUnlock()
-	}()
-	if time.Now().Sub(h.gracePeriodReset) > h.gracePeriod {
-		if h.numRunsDuringGracePeriod > 0 {
-			return toHealthStatus(health.UnhealthyHealthCheckResult(h.checkType, fmt.Sprintf("have not seen a success during grace period, grace period reset: %s, grace period duration: %s, last error: %s", h.gracePeriodReset.String(), h.gracePeriod.String(), h.lastError())))
-		}
-		return toHealthStatus(health.UnhealthyHealthCheckResult(h.checkType, fmt.Sprintf("have not completed a poll during grace period, grace period reset: %s, grace period duration: %s", h.gracePeriodReset.String(), h.gracePeriod.String())))
+	defer h.mutex.RUnlock()
+
+	if h.lastResult == nil {
+		return toHealthStatus(health.HealthCheckResult{
+			Type:    h.checkType,
+			State:   health.HealthStateRepairing,
+			Message: stringPtr("Check has not yet run"),
+		})
 	}
-	return toHealthStatus(health.HealthyHealthCheckResult(h.checkType))
+
+	var result health.HealthCheckResult
+	switch {
+	case time.Since(h.lastSuccessTime) <= h.gracePeriod:
+		result = *h.lastSuccess
+	case time.Since(h.lastResultTime) <= h.gracePeriod:
+		result = *h.lastResult
+		result.Message = stringPtr(fmt.Sprintf("No successful checks during %s grace period", h.gracePeriod.String()))
+	default:
+		result = *h.lastResult
+		result.Message = stringPtr(fmt.Sprintf("No completed checks during %s grace period", h.gracePeriod.String()))
+		// Mark REPAIRING if we were healthy before expiration.
+		if result.State == health.HealthStateHealthy {
+			result.State = health.HealthStateRepairing
+		}
+	}
+	return toHealthStatus(result)
 }
 
 func (h *healthCheckSource) runPoll(ctx context.Context) {
@@ -73,37 +103,59 @@ func (h *healthCheckSource) runPoll(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		default:
+		}
+
+		select {
+		case <-ctx.Done():
+			return
 		case <-ticker.C:
-			h.doPoll()
+			h.doPoll(ctx)
 		}
 	}
 }
 
-func (h *healthCheckSource) doPoll() {
-	err := h.poll()
+func (h *healthCheckSource) doPoll(ctx context.Context) {
+	// Run check
+	state, params := h.source.Check(ctx)
+	t := time.Now()
+	result := &health.HealthCheckResult{
+		Type:   h.checkType,
+		State:  state,
+		Params: params,
+	}
+	// Update cached state
 	h.mutex.Lock()
-	defer func() {
-		h.mutex.Unlock()
-	}()
-	h.lastErr = err
-	if err == nil {
-		h.gracePeriodReset = time.Now()
-		h.numRunsDuringGracePeriod = 0
+	defer h.mutex.Unlock()
+
+	h.lastResult = result
+	h.lastResultTime = t
+	if state == health.HealthStateHealthy {
+		h.lastSuccess = result
+		h.lastSuccessTime = t
 	}
-	h.numRunsDuringGracePeriod++
 }
 
-func (h *healthCheckSource) lastError() string {
-	if h.lastErr == nil {
-		return ""
-	}
-	return h.lastErr.Error()
-}
-
-func toHealthStatus(result conjurehealth.HealthCheckResult) conjurehealth.HealthStatus {
-	return conjurehealth.HealthStatus{
-		Checks: map[conjurehealth.CheckType]conjurehealth.HealthCheckResult{
+func toHealthStatus(result health.HealthCheckResult) health.HealthStatus {
+	return health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
 			result.Type: result,
 		},
 	}
+}
+
+type defaultHealthCheckSource struct {
+	poll func() error
+}
+
+func (d *defaultHealthCheckSource) Check(_ context.Context) (state health.HealthState, params map[string]interface{}) {
+	err := d.poll()
+	if err != nil {
+		return health.HealthStateError, map[string]interface{}{"error": err.Error()}
+	}
+	return health.HealthStateHealthy, nil
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package periodic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	checkType = "TEST_CHECK"
+)
+
+func TestHealthCheckSource_HealthStatus(t *testing.T) {
+	for _, test := range []struct {
+		Name     string
+		State    *healthCheckSource
+		Expected health.HealthStatus
+	}{
+		{
+			Name: "Last result successful",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Minute,
+				lastResult: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastResultTime: time.Now(),
+				lastSuccess: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastSuccessTime: time.Now(),
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:  checkType,
+						State: health.HealthStateHealthy,
+					},
+				},
+			},
+		},
+		{
+			Name: "Last success within grace period",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Hour,
+				lastResult: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateError,
+				},
+				lastResultTime: time.Now(),
+				lastSuccess: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastSuccessTime: time.Now().Add(-5 * time.Minute),
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:  checkType,
+						State: health.HealthStateHealthy,
+					},
+				},
+			},
+		},
+		{
+			Name: "Last success outside grace period",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Minute,
+				lastResult: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateError,
+				},
+				lastResultTime: time.Now(),
+				lastSuccess: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastSuccessTime: time.Now().Add(-5 * time.Minute),
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:    checkType,
+						State:   health.HealthStateError,
+						Message: stringPtr("No successful checks during 1m0s grace period"),
+					},
+				},
+			},
+		},
+		{
+			Name: "No runs within grace period, last was success",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Minute,
+				lastResult: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastResultTime: time.Now().Add(-5 * time.Minute),
+				lastSuccess: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastSuccessTime: time.Now().Add(-5 * time.Minute),
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:    checkType,
+						State:   health.HealthStateRepairing,
+						Message: stringPtr("No completed checks during 1m0s grace period"),
+					},
+				},
+			},
+		},
+		{
+			Name: "No runs within grace period, last was error",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Minute,
+				lastResult: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateError,
+				},
+				lastResultTime: time.Now().Add(-3 * time.Minute),
+				lastSuccess: &health.HealthCheckResult{
+					Type:  checkType,
+					State: health.HealthStateHealthy,
+				},
+				lastSuccessTime: time.Now().Add(-5 * time.Minute),
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:    checkType,
+						State:   health.HealthStateError,
+						Message: stringPtr("No completed checks during 1m0s grace period"),
+					},
+				},
+			},
+		},
+		{
+			Name: "Never started",
+			State: &healthCheckSource{
+				checkType:   checkType,
+				gracePeriod: time.Minute,
+			},
+			Expected: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					checkType: {
+						Type:    checkType,
+						State:   health.HealthStateRepairing,
+						Message: stringPtr("Check has not yet run"),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			result := test.State.HealthStatus(context.Background())
+			assert.Equal(t, test.Expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Updates the periodic healthcheck package:
* Allow supplying non-error states and params via `Source` interface
* Set to REPAIRING before first run and when a success state expires
* Add tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/77)
<!-- Reviewable:end -->
