### PR TITLE
Lock refreshable subscribers only

### DIFF
--- a/witchcraft/refreshable/refreshable_default.go
+++ b/witchcraft/refreshable/refreshable_default.go
@@ -17,21 +17,25 @@ package refreshable
 import (
 	"reflect"
 	"sync"
+	"sync/atomic"
 
 	"github.com/palantir/witchcraft-go-error"
 )
 
 type DefaultRefreshable struct {
-	sync.RWMutex
-
 	typ         reflect.Type
+	current     *atomic.Value
+
+	sync.RWMutex // protects subscribers
 	subscribers []*func(interface{})
-	current     interface{}
 }
 
 func NewDefaultRefreshable(val interface{}) *DefaultRefreshable {
+	current := atomic.Value{}
+	current.Store(val)
+
 	return &DefaultRefreshable{
-		current: val,
+		current: &current,
 		typ:     reflect.TypeOf(val),
 	}
 }
@@ -46,10 +50,11 @@ func (d *DefaultRefreshable) Update(val interface{}) error {
 			werror.SafeParam("providedType", valType))
 	}
 
-	if reflect.DeepEqual(d.current, val) {
+	if reflect.DeepEqual(d.current.Load(), val) {
 		return nil
 	}
-	d.current = val
+	d.current.Store(val)
+
 	for _, sub := range d.subscribers {
 		(*sub)(val)
 	}
@@ -57,9 +62,7 @@ func (d *DefaultRefreshable) Update(val interface{}) error {
 }
 
 func (d *DefaultRefreshable) Current() interface{} {
-	d.RLock()
-	defer d.RUnlock()
-	return d.current
+	return d.current.Load()
 }
 
 func (d *DefaultRefreshable) Subscribe(consumer func(interface{})) (unsubscribe func()) {

--- a/witchcraft/refreshable/refreshable_default.go
+++ b/witchcraft/refreshable/refreshable_default.go
@@ -26,7 +26,7 @@ type DefaultRefreshable struct {
 	typ         reflect.Type
 	current     *atomic.Value
 
-	sync.RWMutex // protects subscribers
+	sync.Mutex // protects subscribers
 	subscribers []*func(interface{})
 }
 

--- a/witchcraft/refreshable/refreshable_default.go
+++ b/witchcraft/refreshable/refreshable_default.go
@@ -23,10 +23,10 @@ import (
 )
 
 type DefaultRefreshable struct {
-	typ         reflect.Type
-	current     *atomic.Value
+	typ     reflect.Type
+	current *atomic.Value
 
-	sync.Mutex // protects subscribers
+	sync.Mutex  // protects subscribers
 	subscribers []*func(interface{})
 }
 


### PR DESCRIPTION
This removes unnecessary locking on the current value, replacing the locking with an atomic value store. This avoids deadlocking in the case where, on `Update`, the subscriber callback synchronously calls `Current()` on the refreshable or its parent while the refreshable is still locked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/79)
<!-- Reviewable:end -->
