### PR TITLE
Fix health source "last success" behavior

### DIFF
--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -149,6 +149,12 @@ func (h *healthCheckSource) doPoll(ctx context.Context) {
 			lastResult:     resultWithTime.result,
 			lastResultTime: resultWithTime.time,
 		}
+		// populate last success state from previous state (if present)
+		if previousState, ok := h.checkStates[resultWithTime.result.Type]; ok {
+			newState.lastSuccess = previousState.lastSuccess
+			newState.lastSuccessTime = previousState.lastSuccessTime
+		}
+		// if current result is successful, update success state
 		if resultWithTime.result.State == health.HealthStateHealthy {
 			newState.lastSuccess = resultWithTime.result
 			newState.lastSuccessTime = resultWithTime.time

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -341,3 +341,75 @@ func TestHealthCheckSource_HealthStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestFromHealthCheckSource(t *testing.T) {
+	ctx := context.Background()
+	gracePeriod := 100 * time.Millisecond
+	var gracePeriodTimer *time.Timer
+	retryInterval := 10 * time.Millisecond
+
+	counter := 0
+	doneChan := make(chan struct{})
+
+	// configure source with the following properties:
+	//   * check runs every 10 milliseconds
+	//   * grace period is 100 milliseconds
+	//   * first health check returns healthy state
+	//   * all subsequent checks return error state
+	//   * sends on "doneChan" after health check has returned at least twice
+	source := FromHealthCheckSource(ctx, gracePeriod, retryInterval, Source{
+		Checks: map[health.CheckType]CheckFunc{
+			checkType: func(ctx context.Context) *health.HealthCheckResult {
+				defer func() {
+					counter++
+				}()
+
+				if counter == 0 {
+					return &health.HealthCheckResult{
+						Type:    checkType,
+						State:   health.HealthStateHealthy,
+						Message: stringPtr("Healthy state"),
+					}
+				}
+
+				// send on done channel after function has returned error state at least once
+				if counter == 2 {
+					// start grace period timer: when timer fires, last success will be outside of grace period
+					gracePeriodTimer = time.NewTimer(gracePeriod)
+					doneChan <- struct{}{}
+				}
+
+				return &health.HealthCheckResult{
+					Type:    checkType,
+					State:   health.HealthStateError,
+					Message: stringPtr("Error state"),
+				}
+			},
+		},
+	})
+
+	// wait until health check has returned healthy and then unhealthy
+	<-doneChan
+	status := source.HealthStatus(ctx)
+
+	// health check should be healthy: even though health source returned error state most recently, it returned
+	// healthy state within the grace period
+	assert.Equal(t, map[health.CheckType]health.HealthCheckResult{
+		checkType: {
+			Type:    checkType,
+			State:   health.HealthStateHealthy,
+			Message: stringPtr("Healthy state"),
+		},
+	}, status.Checks)
+
+	// health check should be unhealthy: last time health source returned healthy was more than grace period
+	<-gracePeriodTimer.C
+	status = source.HealthStatus(ctx)
+	assert.Equal(t, map[health.CheckType]health.HealthCheckResult{
+		checkType: {
+			Type:    checkType,
+			State:   health.HealthStateError,
+			Message: stringPtr("No successful checks during 100ms grace period: Error state"),
+		},
+	}, status.Checks)
+}

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -364,16 +364,16 @@ func TestFromHealthCheckSource(t *testing.T) {
 					counter++
 				}()
 
-				if counter == 0 {
+				switch counter {
+				// return healthy state if counter is 0
+				case 0:
 					return &health.HealthCheckResult{
 						Type:    checkType,
 						State:   health.HealthStateHealthy,
 						Message: stringPtr("Healthy state"),
 					}
-				}
-
 				// send on done channel after function has returned error state at least once
-				if counter == 2 {
+				case 2:
 					// start grace period timer: when timer fires, last success will be outside of grace period
 					gracePeriodTimer = time.NewTimer(gracePeriod)
 					doneChan <- struct{}{}


### PR DESCRIPTION
Ensure that, if the check has returned a healthy status within
the grace period, the over-all check returns healthy.

Fixes #89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/90)
<!-- Reviewable:end -->
