### PR TITLE
Fix timing bug in periodic package

### DIFF
--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -138,9 +138,11 @@ func (h *healthCheckSource) doPoll(ctx context.Context) {
 	// Run checks
 	resultsWithTimes := make([]resultWithTime, 0, len(h.source.Checks))
 	for _, check := range h.source.Checks {
+		// run check before assigning to assure that the "time.Now()" value reflects when check was completed (rather than when it was started)
+		checkVal := check(ctx)
 		resultsWithTimes = append(resultsWithTimes, resultWithTime{
 			time:   time.Now(),
-			result: check(ctx),
+			result: checkVal,
 		})
 	}
 

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -352,7 +352,7 @@ func TestHealthCheckSource_HealthStatus(t *testing.T) {
 //   * Third check returns unhealthy (t=130ms, counter=2)
 //   * TEST: health status should be unhealthy due to no success within grace period (checking at roughly t=130ms, so there was a check that occurred within the grace period, but no successful check within the grace period)
 //   * Wait until grace period has elapsed (t=230ms)
-//   * TEST: health status should be unhealthy due to no check within grace period (checking at roughly t=220ms, so there is no check that occurred within the grace period)
+//   * TEST: health status should be unhealthy due to no check within grace period (checking at roughly t=230ms, so there is no check that occurred within the grace period)
 func TestFromHealthCheckSource(t *testing.T) {
 	ctx := context.Background()
 	gracePeriod := 100 * time.Millisecond

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -342,48 +342,84 @@ func TestHealthCheckSource_HealthStatus(t *testing.T) {
 	}
 }
 
+// Test does the following:
+//   * Starts health check source with 10ms retry interval and 100ms grace period
+//   * First health check returns healthy (t=10ms, counter=0)
+//   * Second health check returns unhealthy (t=20ms, counter=1)
+//   * When third health check is run, pause the health check routine and signal that health should be checked (t=30ms)
+//   * TEST: health status should be healthy, counter=0 (checking at roughly t=30ms, so there was a healthy check within grace period)
+//   * Wait until grace period has elapsed since healthy check was returned (roughly t=130ms)
+//   * Third check returns unhealthy (t=130ms, counter=2)
+//   * TEST: health status should be unhealthy due to no success within grace period (checking at roughly t=130ms, so there was a check that occurred within the grace period, but no successful check within the grace period)
+//   * Wait until grace period has elapsed (t=230ms)
+//   * TEST: health status should be unhealthy due to no check within grace period (checking at roughly t=220ms, so there is no check that occurred within the grace period)
 func TestFromHealthCheckSource(t *testing.T) {
 	ctx := context.Background()
 	gracePeriod := 100 * time.Millisecond
-	var gracePeriodTimer *time.Timer
 	retryInterval := 10 * time.Millisecond
 
 	counter := 0
+	// health check sends on this channel on its third run (after it has returned healthy and then error)
 	doneChan := make(chan struct{})
+	// health check waits on this channel on its third run (after it has sent on doneChan)
+	pauseChan := make(chan struct{})
 
 	// configure source with the following properties:
 	//   * check runs every 10 milliseconds
 	//   * grace period is 100 milliseconds
-	//   * first health check returns healthy state
-	//   * all subsequent checks return error state
-	//   * sends on "doneChan" after health check has returned at least twice
+	//   * first run of health check returns healthy state
+	//   * second run of health check returns error state
+	//   * on third run of health check, pauses indefinitely (reads from channel that is not sent on again)
 	source := FromHealthCheckSource(ctx, gracePeriod, retryInterval, Source{
 		Checks: map[health.CheckType]CheckFunc{
-			checkType: func(ctx context.Context) *health.HealthCheckResult {
+			checkType: func(ctx context.Context) (rVal *health.HealthCheckResult) {
 				defer func() {
 					counter++
 				}()
 
 				switch counter {
-				// return healthy state if counter is 0
+				// return healthy state on first run
 				case 0:
 					return &health.HealthCheckResult{
 						Type:    checkType,
 						State:   health.HealthStateHealthy,
 						Message: stringPtr("Healthy state"),
+						Params: map[string]interface{}{
+							"counter": counter,
+						},
 					}
-				// send on done channel after function has returned error state at least once
+				// return error state on second run
+				case 1:
+					return &health.HealthCheckResult{
+						Type:    checkType,
+						State:   health.HealthStateError,
+						Message: stringPtr("Error state"),
+						Params: map[string]interface{}{
+							"counter": counter,
+						},
+					}
+				// on third run, send on doneChane and read from pauseChan
 				case 2:
-					// start grace period timer: when timer fires, last success will be outside of grace period
-					gracePeriodTimer = time.NewTimer(gracePeriod)
+					// signal that health can be checked
 					doneChan <- struct{}{}
+					// pause until health check has occurred
+					<-pauseChan
+					// return unhealthy
+					return &health.HealthCheckResult{
+						Type:    checkType,
+						State:   health.HealthStateError,
+						Message: stringPtr("Error state"),
+						Params: map[string]interface{}{
+							"counter": counter,
+						},
+					}
+				case 3:
+					// signal that health can be checked
+					doneChan <- struct{}{}
+					// pause (do not return)
+					<-pauseChan
 				}
-
-				return &health.HealthCheckResult{
-					Type:    checkType,
-					State:   health.HealthStateError,
-					Message: stringPtr("Error state"),
-				}
+				return nil
 			},
 		},
 	})
@@ -399,17 +435,43 @@ func TestFromHealthCheckSource(t *testing.T) {
 			Type:    checkType,
 			State:   health.HealthStateHealthy,
 			Message: stringPtr("Healthy state"),
+			Params: map[string]interface{}{
+				"counter": 0,
+			},
 		},
 	}, status.Checks)
 
-	// health check should be unhealthy: last time health source returned healthy was more than grace period
-	<-gracePeriodTimer.C
+	// health has been checked: wait for grace period to pass and then unpause the health routine
+	time.Sleep(gracePeriod)
+	pauseChan <- struct{}{}
+	<-doneChan
+
+	// health check should be unhealthy: the most recent check ran within the grace period, but the last success was before grace period
 	status = source.HealthStatus(ctx)
 	assert.Equal(t, map[health.CheckType]health.HealthCheckResult{
 		checkType: {
 			Type:    checkType,
 			State:   health.HealthStateError,
 			Message: stringPtr("No successful checks during 100ms grace period: Error state"),
+			Params: map[string]interface{}{
+				"counter": 2,
+			},
+		},
+	}, status.Checks)
+
+	// wait for grace period
+	time.Sleep(gracePeriod)
+
+	// health check should be unhealthy: no check ran within grace period, and last known status was unhealthy
+	status = source.HealthStatus(ctx)
+	assert.Equal(t, map[health.CheckType]health.HealthCheckResult{
+		checkType: {
+			Type:    checkType,
+			State:   health.HealthStateError,
+			Message: stringPtr("No completed checks during 100ms grace period: Error state"),
+			Params: map[string]interface{}{
+				"counter": 2,
+			},
 		},
 	}, status.Checks)
 }

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -364,12 +364,6 @@ func TestFromHealthCheckSource(t *testing.T) {
 	// health check waits on this channel on its third run (after it has sent on doneChan)
 	pauseChan := make(chan struct{})
 
-	// configure source with the following properties:
-	//   * check runs every 10 milliseconds
-	//   * grace period is 100 milliseconds
-	//   * first run of health check returns healthy state
-	//   * second run of health check returns error state
-	//   * on third run of health check, pauses indefinitely (reads from channel that is not sent on again)
 	source := FromHealthCheckSource(ctx, gracePeriod, retryInterval, Source{
 		Checks: map[health.CheckType]CheckFunc{
 			checkType: func(ctx context.Context) (rVal *health.HealthCheckResult) {

--- a/status/health/periodic/source_test.go
+++ b/status/health/periodic/source_test.go
@@ -397,7 +397,7 @@ func TestFromHealthCheckSource(t *testing.T) {
 							"counter": counter,
 						},
 					}
-				// on third run, send on doneChane and read from pauseChan
+				// on third run, send on doneChan and read from pauseChan
 				case 2:
 					// signal that health can be checked
 					doneChan <- struct{}{}


### PR DESCRIPTION
Ensure that recorded time corresponds to time that check has
completed/check result struct was created (rather than when the
check function was invoked). Also update test to be more deterministic.

Fixes #91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/92)
<!-- Reviewable:end -->
