### PR TITLE
Add `periodic.Option` type for running initial poll before waiting.

### DIFF
--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package periodic
 
 type Option interface {

--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -6,7 +6,7 @@ type Option interface {
 
 type optionFn func(source *healthCheckSource)
 
-func(fn optionFn) apply(source *healthCheckSource) {
+func (fn optionFn) apply(source *healthCheckSource) {
 	fn(source)
 }
 

--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -1,0 +1,17 @@
+package periodic
+
+type Option interface {
+	apply(source *healthCheckSource)
+}
+
+type optionFn func(source *healthCheckSource)
+
+func(fn optionFn) apply(source *healthCheckSource) {
+	fn(source)
+}
+
+func WithInitialPoll() Option {
+	return optionFn(func(source *healthCheckSource) {
+		source.initialPoll = true
+	})
+}

--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -24,6 +24,8 @@ func (fn optionFn) apply(source *healthCheckSource) {
 	fn(source)
 }
 
+// WithInitialPoll configures the health check source to poll immediately instead of waiting for the duration of
+// the check's specified retry interval.
 func WithInitialPoll() Option {
 	return optionFn(func(source *healthCheckSource) {
 		source.initialPoll = true

--- a/status/health/periodic/options_test.go
+++ b/status/health/periodic/options_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package periodic
 
 import (

--- a/status/health/periodic/options_test.go
+++ b/status/health/periodic/options_test.go
@@ -1,0 +1,29 @@
+package periodic
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithInitialPoll(t *testing.T) {
+	var pollAlwaysErr = func() error {
+		return fmt.Errorf("error")
+	}
+	periodicCheckWithInitialPoll := NewHealthCheckSource(
+		context.Background(),
+		time.Minute,
+		time.Second,
+		"CHECK_TYPE",
+		pollAlwaysErr,
+		WithInitialPoll())
+	<-time.After(time.Second)
+	healthStatus := periodicCheckWithInitialPoll.HealthStatus(context.Background())
+	check, ok := healthStatus.Checks["CHECK_TYPE"]
+	assert.True(t, ok)
+	assert.Equal(t, health.HealthStateError, check.State)
+}

--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -113,11 +113,11 @@ func (h *healthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 }
 
 func (h *healthCheckSource) runPoll(ctx context.Context) {
+	ticker := time.NewTicker(h.retryInterval)
+	defer ticker.Stop()
 	if h.initialPoll {
 		h.doPoll(ctx)
 	}
-	ticker := time.NewTicker(h.retryInterval)
-	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():

--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -43,6 +43,7 @@ type healthCheckSource struct {
 	source        Source
 	gracePeriod   time.Duration
 	retryInterval time.Duration
+	initialPoll bool
 
 	// mutable
 	mutex       sync.RWMutex
@@ -53,20 +54,23 @@ type healthCheckSource struct {
 // is cancelled if ctx is cancelled. If gracePeriod elapses without poll returning nil, the returned health check
 // source will give a health status of error. checkType is the key to be used in the health result returned by the
 // health check source.
-func NewHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, checkType health.CheckType, poll func() error) status.HealthCheckSource {
-	return FromHealthCheckSource(ctx, gracePeriod, retryInterval, newDefaultHealthCheckSource(checkType, poll))
+func NewHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, checkType health.CheckType, poll func() error, options ...Option) status.HealthCheckSource {
+	return FromHealthCheckSource(ctx, gracePeriod, retryInterval, newDefaultHealthCheckSource(checkType, poll), options...)
 }
 
 // FromHealthCheckSource creates a health check source that calls the the provided Source.Checks functions every
 // retryInterval in a goroutine. The goroutine is cancelled if ctx is cancelled. For each check, if gracePeriod elapses
 // without CheckFunc returning HEALTHY, the returned health check source's HealthStatus will return a HealthCheckResult
 // of error.
-func FromHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, source Source) status.HealthCheckSource {
+func FromHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, source Source, options ...Option) status.HealthCheckSource {
 	checker := &healthCheckSource{
 		source:        source,
 		gracePeriod:   gracePeriod,
 		retryInterval: retryInterval,
 		checkStates:   map[health.CheckType]*checkState{},
+	}
+	for _, option := range options {
+		option.apply(checker)
 	}
 	go wapp.RunWithRecoveryLogging(ctx, checker.runPoll)
 	return checker
@@ -109,6 +113,9 @@ func (h *healthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 }
 
 func (h *healthCheckSource) runPoll(ctx context.Context) {
+	if h.initialPoll {
+		h.doPoll(ctx)
+	}
 	ticker := time.NewTicker(h.retryInterval)
 	defer ticker.Stop()
 	for {

--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -43,7 +43,7 @@ type healthCheckSource struct {
 	source        Source
 	gracePeriod   time.Duration
 	retryInterval time.Duration
-	initialPoll bool
+	initialPoll   bool
 
 	// mutable
 	mutex       sync.RWMutex


### PR DESCRIPTION
Sometimes it's undesirable to wait for a poll period to run a periodic health check - this introduces the `periodic.Option` type and the `WithInitialPoll()` option to enable calling the `poll` method without waiting for the poll period.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/94)
<!-- Reviewable:end -->
