### PR TITLE
Refactor health reporter components

### DIFF
--- a/status/reporter/component.go
+++ b/status/reporter/component.go
@@ -70,11 +70,12 @@ func (r *healthComponent) Status() health.HealthState {
 
 // Returns the entire HealthCheckResult for the component
 func (r *healthComponent) GetHealthCheck() health.HealthCheckResult {
-	var message string
+	var message *string
 	params := make(map[string]interface{}, len(r.params))
 
 	if r.message != nil {
-		message = *r.message
+		messageCopy := *r.message
+		message = &messageCopy
 	}
 	for key, value := range r.params {
 		params[key] = value
@@ -83,7 +84,7 @@ func (r *healthComponent) GetHealthCheck() health.HealthCheckResult {
 	return health.HealthCheckResult{
 		Type:    r.name,
 		State:   r.state,
-		Message: &message,
+		Message: message,
 		Params:  params,
 	}
 }

--- a/status/reporter/component.go
+++ b/status/reporter/component.go
@@ -15,6 +15,8 @@
 package reporter
 
 import (
+	"sync"
+
 	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
 )
 
@@ -38,6 +40,8 @@ const (
 )
 
 type healthComponent struct {
+	sync.Mutex
+
 	name    health.CheckType
 	state   health.HealthState
 	message *string
@@ -58,6 +62,9 @@ func (r *healthComponent) Error(err error) {
 }
 
 func (r *healthComponent) SetHealth(healthState health.HealthState, message *string, params map[string]interface{}) {
+	r.Lock()
+	defer r.Unlock()
+
 	r.state = healthState
 	r.message = message
 	r.params = params
@@ -70,6 +77,9 @@ func (r *healthComponent) Status() health.HealthState {
 
 // Returns the entire HealthCheckResult for the component
 func (r *healthComponent) GetHealthCheck() health.HealthCheckResult {
+	r.Lock()
+	defer r.Unlock()
+
 	var message *string
 	params := make(map[string]interface{}, len(r.params))
 

--- a/status/reporter/component.go
+++ b/status/reporter/component.go
@@ -70,10 +70,18 @@ func (r *healthComponent) Status() health.HealthState {
 
 // Returns the entire HealthCheckResult for the component
 func (r *healthComponent) GetHealthCheck() health.HealthCheckResult {
+	var message string
+	params := make(map[string]interface{}, len(r.params))
+
+	message = *r.message
+	for key, value := range r.params {
+		params[key] = value
+	}
+
 	return health.HealthCheckResult{
 		Type:    r.name,
 		State:   r.state,
-		Message: r.message,
-		Params:  r.params,
+		Message: &message,
+		Params:  params,
 	}
 }

--- a/status/reporter/component.go
+++ b/status/reporter/component.go
@@ -73,7 +73,9 @@ func (r *healthComponent) GetHealthCheck() health.HealthCheckResult {
 	var message string
 	params := make(map[string]interface{}, len(r.params))
 
-	message = *r.message
+	if r.message != nil {
+		message = *r.message
+	}
 	for key, value := range r.params {
 		params[key] = value
 	}

--- a/status/reporter/component_test.go
+++ b/status/reporter/component_test.go
@@ -85,3 +85,21 @@ func TestNonCompliantName(t *testing.T) {
 	_, err := healthReporter.InitializeHealthComponent(invalidComponent)
 	assert.Error(t, err)
 }
+
+func TestGetHealthCheckCopy(t *testing.T) {
+	component, _ := setup(t)
+	originalMessage := "originalMessage"
+	component.SetHealth(HealthyState, &originalMessage, map[string]interface{}{"originalParamKey": "originalParamValue"})
+	componentResult := component.GetHealthCheck()
+
+	message := "modifiedMessage"
+	componentResult.Type = "modifiedType"
+	componentResult.State = ErrorState
+	*componentResult.Message = message
+	componentResult.Params["modifiedParamKey"] = "modifiedParamValue"
+
+	assert.NotEqual(t, component.(*healthComponent).name, componentResult.Type)
+	assert.NotEqual(t, component.(*healthComponent).state, componentResult.State)
+	assert.NotEqual(t, component.(*healthComponent).message, componentResult.Message)
+	assert.NotEqual(t, component.(*healthComponent).params, componentResult.Params)
+}

--- a/status/reporter/component_test.go
+++ b/status/reporter/component_test.go
@@ -15,6 +15,7 @@
 package reporter
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -49,18 +50,20 @@ func TestWarningSetting(t *testing.T) {
 	component, healthReporter := setup(t)
 	component.Warning("warning message")
 	assert.Equal(t, WarningState, component.Status())
-	status, found := healthReporter.getHealthCheck(validComponent)
+	status := healthReporter.HealthStatus(context.TODO())
+	componentStatus, found := status.Checks[validComponent]
 	assert.True(t, found)
-	assert.Equal(t, "warning message", *status.Message)
+	assert.Equal(t, "warning message", *componentStatus.Message)
 }
 
 func TestErrorSetting(t *testing.T) {
 	component, healthReporter := setup(t)
 	component.Error(errors.New("err"))
 	assert.Equal(t, ErrorState, component.Status())
-	status, found := healthReporter.getHealthCheck(validComponent)
+	status := healthReporter.HealthStatus(context.TODO())
+	componentStatus, found := status.Checks[validComponent]
 	assert.True(t, found)
-	assert.Equal(t, "err", *status.Message)
+	assert.Equal(t, "err", *componentStatus.Message)
 }
 
 func TestSetHealthAndGetHealthResult(t *testing.T) {

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -104,7 +104,7 @@ func TestUnregisterThenGetComponentStatus(t *testing.T) {
 	_, present := reporter.GetHealthComponent(validComponent)
 	assert.False(t, present)
 
-	assert.NotPanics(t, func() {component.Status()})
+	assert.NotPanics(t, func() { component.Status() })
 }
 
 func TestUnregisterOnUninitialized(t *testing.T) {

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -157,6 +157,20 @@ func TestUnregisterThenGet(t *testing.T) {
 	assert.False(t, present)
 }
 
+func TestUnregisterThenGetComponentStatus(t *testing.T) {
+	reporter := newHealthReporter()
+	component, err := reporter.InitializeHealthComponent(validComponent)
+	assert.NotNil(t, component)
+	assert.NoError(t, err)
+
+	assert.True(t, reporter.UnregisterHealthComponent(validComponent))
+
+	_, present := reporter.GetHealthComponent(validComponent)
+	assert.False(t, present)
+
+	assert.NotPanics(t, func() {component.Status()})
+}
+
 func TestUnregisterOnUninitialized(t *testing.T) {
 	reporter := newHealthReporter()
 	assert.False(t, reporter.UnregisterHealthComponent(validComponent))

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -15,6 +15,7 @@
 package reporter
 
 import (
+	"context"
 	"testing"
 
 	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
@@ -23,61 +24,38 @@ import (
 
 const testCheckType = health.CheckType("TEST")
 
-func TestSetHealthy(t *testing.T) {
-	reporter := newHealthReporter()
-	reporter.setHealthCheck(testCheckType, health.HealthCheckResult{
-		Type:  testCheckType,
-		State: health.HealthStateHealthy,
-	})
-
-	assert.Equal(t, reporter.currentStatus.Checks[testCheckType].State, health.HealthStateHealthy)
-}
-
-func TestSetError(t *testing.T) {
-	reporter := newHealthReporter()
-	reporter.setHealthCheck(testCheckType, health.HealthCheckResult{
-		Type:  testCheckType,
-		State: health.HealthStateError,
-	})
-
-	assert.Equal(t, reporter.currentStatus.Checks[testCheckType].State, health.HealthStateError)
-}
-
 func TestGetHealthy(t *testing.T) {
 	reporter := newHealthReporter()
-	reporter.currentStatus = health.HealthStatus{
-		Checks: map[health.CheckType]health.HealthCheckResult{
-			testCheckType: {
-				Type:  testCheckType,
-				State: health.HealthStateHealthy,
-			},
+	reporter.healthComponents = map[health.CheckType]HealthComponent{
+		testCheckType: &healthComponent{
+			name:  testCheckType,
+			state: health.HealthStateHealthy,
 		},
 	}
 
 	status, found := reporter.getHealthCheck(testCheckType)
 	assert.True(t, found)
-	assert.Equal(t, status.State, health.HealthStateHealthy)
+	assert.Equal(t, status.State, HealthyState)
 }
 
 func TestGetError(t *testing.T) {
 	reporter := newHealthReporter()
-	reporter.currentStatus = health.HealthStatus{
-		Checks: map[health.CheckType]health.HealthCheckResult{
-			testCheckType: {
-				Type:  testCheckType,
-				State: health.HealthStateError,
-			},
+	reporter.healthComponents = map[health.CheckType]HealthComponent{
+		testCheckType: &healthComponent{
+			name:  testCheckType,
+			state: ErrorState,
 		},
 	}
 
 	status, found := reporter.getHealthCheck(testCheckType)
 	assert.True(t, found)
-	assert.Equal(t, status.State, health.HealthStateError)
+	assert.Equal(t, status.State, ErrorState)
 }
 
 func TestGetNotFound(t *testing.T) {
 	reporter := NewHealthReporter()
-	_, found := reporter.getHealthCheck(testCheckType)
+	status := reporter.HealthStatus(context.TODO())
+	_, found := status.Checks[testCheckType]
 	assert.False(t, found)
 }
 
@@ -101,48 +79,6 @@ func TestInitializeThenGet(t *testing.T) {
 	fromGet, ok := reporter.GetHealthComponent(validComponent)
 	assert.True(t, ok)
 	assert.Equal(t, fromGet, component)
-}
-
-// Test that setHealthCheckAndComponentIfAbsent is idempotent
-func TestSetIfNotExist(t *testing.T) {
-	reporter := newHealthReporter()
-	iterations := 10
-	testNames := []string{"a", "b", "c", "d", "e", "f", "g"}
-	returnChan := make(chan bool, iterations*len(testNames))
-	for _, n := range testNames {
-		checkType := health.CheckType(n)
-		status := health.HealthCheckResult{
-			Type:  checkType,
-			State: StartingState,
-		}
-		component := &healthComponent{
-			checkType,
-			reporter,
-		}
-		for i := 0; i < iterations; i++ {
-			go func() {
-				returnChan <- reporter.setHealthCheckAndComponentIfAbsent(checkType, component, status)
-			}()
-		}
-	}
-	sets := 0
-	total := 0
-	for r := range returnChan {
-		if r {
-			sets++
-		}
-		total++
-		if total == iterations*len(testNames) {
-			assert.Equal(t, len(testNames), sets)
-			for _, n := range testNames {
-				status, found := reporter.getHealthCheck(health.CheckType(n))
-				assert.True(t, found)
-				assert.Equal(t, StartingState, status.State)
-			}
-			return
-		}
-	}
-	assert.Fail(t, "Did get the correct number of total calls", total)
 }
 
 func TestUnregisterThenGet(t *testing.T) {


### PR DESCRIPTION
## Before this PR:
  * Use of a health component after calling `UnregisterHealthComponent` had some undesirable behavior. The health component still had a reference to the reporter that created it, and could modify the reporter `currentStatus`, even after it had been removed during unregistration. Also, it could cause panics from calls to a components `Status` call, with a confusing error message that the component had never been registered.

## After this PR:
  * Health components are more independent from the health reporter, storing all of the data necessary to create their own health check result. Instead of storing state in addition to the health components, the reporter only stores the components and lets them track their state independently. This prevents both of the behaviors above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/95)
<!-- Reviewable:end -->
