### PR TITLE
lock around getting the health component status

### DIFF
--- a/status/reporter/component.go
+++ b/status/reporter/component.go
@@ -40,7 +40,7 @@ const (
 )
 
 type healthComponent struct {
-	sync.Mutex
+	sync.RWMutex
 
 	name    health.CheckType
 	state   health.HealthState
@@ -72,6 +72,9 @@ func (r *healthComponent) SetHealth(healthState health.HealthState, message *str
 
 // Returns the health status for the health component
 func (r *healthComponent) Status() health.HealthState {
+	r.RLock()
+	defer r.RUnlock()
+
 	return r.state
 }
 


### PR DESCRIPTION
There is currently a data race between setting and getting the `healthComponent` status since the locking only existed upon setting the health. 

This change updates the mutex to a RWLock and adds additional read locking when getting the health status.

cc @andybradshaw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/100)
<!-- Reviewable:end -->
