### PR TITLE
Added a sliding window based health check

### DIFF
--- a/status/health/window/window_event_storer.go
+++ b/status/health/window/window_event_storer.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"sync"
+	"time"
+
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+// Event is a struct that keeps a generic payload describing an event and a timestamp for when the event happened.
+type Event struct {
+	// Time is the time the event was submitted.
+	Time time.Time
+	// Payload is any generic information about this event.
+	Payload interface{}
+}
+
+// TimeWindowedEventStorer is a thread-safe struct that stores submitted events
+// and supports polling for all events submitted within the last windowSize period.
+// When any operation is made, all out-of-date events are pruned out of memory.
+type TimeWindowedEventStorer struct {
+	events      []Event
+	eventsMutex sync.Mutex
+	windowSize  time.Duration
+}
+
+// NewTimeWindowedEventStorer creates a new TimeWindowedEventStorer with the provided windowSize.
+func NewTimeWindowedEventStorer(windowSize time.Duration) (*TimeWindowedEventStorer, error) {
+	if windowSize <= 0 {
+		return nil, werror.Error("attempted to create a sliding window with non positive size")
+	}
+	return &TimeWindowedEventStorer{
+		windowSize: windowSize,
+	}, nil
+}
+
+func (t *TimeWindowedEventStorer) pruneOldEvents() {
+	currentTime := time.Now()
+	newStartIndex := 0
+	for index, entry := range t.events {
+		if currentTime.Sub(entry.Time) <= t.windowSize {
+			break
+		}
+		newStartIndex = index + 1
+	}
+	t.events = t.events[newStartIndex:]
+}
+
+// SubmitEvent prunes all out-of-date events out of memory and then adds a new one.
+func (t *TimeWindowedEventStorer) SubmitEvent(payload interface{}) {
+	t.eventsMutex.Lock()
+	defer t.eventsMutex.Unlock()
+
+	t.pruneOldEvents()
+	t.events = append(t.events, Event{
+		Time:    time.Now(),
+		Payload: payload,
+	})
+}
+
+// GetEventsInWindow prunes all out-of-date events out of memory and then returns all up-to-date events.
+func (t *TimeWindowedEventStorer) GetEventsInWindow() []Event {
+	t.eventsMutex.Lock()
+	defer t.eventsMutex.Unlock()
+
+	t.pruneOldEvents()
+	return t.events
+}

--- a/status/health/window/window_event_storer_test.go
+++ b/status/health/window/window_event_storer_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeWindowedEventStorer_ErrorOnCreate(t *testing.T) {
+	_, err := NewTimeWindowedEventStorer(0)
+	assert.Error(t, err)
+}
+
+func TestTimeWindowedEventStorer_NoEvents(t *testing.T) {
+	manager, err := NewTimeWindowedEventStorer(time.Millisecond)
+	assert.NoError(t, err)
+	errors := manager.GetEventsInWindow()
+	assert.Nil(t, errors)
+}
+
+func TestTimeWindowedEventStorer_AllEventsUpToDate(t *testing.T) {
+	manager, err := NewTimeWindowedEventStorer(time.Second)
+	assert.NoError(t, err)
+	manager.SubmitEvent("payload #1")
+	manager.SubmitEvent("payload #2")
+	manager.SubmitEvent("payload #3")
+	events := manager.GetEventsInWindow()
+	assert.EqualValues(t, len(events), 3)
+	assert.EqualValues(t, "payload #1", events[0].Payload)
+	assert.EqualValues(t, "payload #2", events[1].Payload)
+	assert.EqualValues(t, "payload #3", events[2].Payload)
+}
+
+func TestTimeWindowedEventStorer_AllEventsOutOfDate(t *testing.T) {
+	manager, err := NewTimeWindowedEventStorer(50 * time.Millisecond)
+	assert.NoError(t, err)
+	manager.SubmitEvent("payload #1")
+	manager.SubmitEvent("payload #2")
+	manager.SubmitEvent("payload #3")
+	<-time.After(100 * time.Millisecond)
+	events := manager.GetEventsInWindow()
+	assert.Empty(t, events)
+}
+
+func TestTimeWindowedEventStorer_SomeEventsOutOfDate(t *testing.T) {
+	manager, err := NewTimeWindowedEventStorer(500 * time.Millisecond)
+	assert.NoError(t, err)
+	manager.SubmitEvent("payload #1")
+	manager.SubmitEvent("payload #2")
+	<-time.After(time.Second)
+	manager.SubmitEvent("payload #3")
+	manager.SubmitEvent("payload #4")
+	events := manager.GetEventsInWindow()
+	assert.EqualValues(t, len(events), 2)
+	assert.EqualValues(t, "payload #3", events[0].Payload)
+	assert.EqualValues(t, "payload #4", events[1].Payload)
+}


### PR DESCRIPTION
resolves https://github.com/palantir/witchcraft-go-server/issues/113
Sliding window based health checks are an extremely common pattern in Rubix controllers, so we have decided to add this to a shared library. Preferably witchcraft.

Tested by adding unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/112)
<!-- Reviewable:end -->
