### PR TITLE
Add must constructors for sliding window health checks

### DIFF
--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -35,6 +35,16 @@ type BaseHealthCheckSource struct {
 
 var _ status.HealthCheckSource = &BaseHealthCheckSource{}
 
+// MustNewBaseHealthCheckSource returns the result of calling NewBaseHealthCheckSource, but panics if it returns an error.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) *BaseHealthCheckSource {
+	source, err := NewBaseHealthCheckSource(windowSize, itemsToCheckFn)
+	if err != nil {
+		panic(err)
+	}
+	return source
+}
+
 // NewBaseHealthCheckSource creates a BaseHealthCheckSource
 // with a sliding window of size windowSize and uses the itemsToCheckFn.
 // windowSize must be a positive value and itemsToCheckFn must not be nil, otherwise returns error.

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -33,6 +33,16 @@ type UnhealthyIfAtLeastOneErrorSource struct {
 
 var _ status.HealthCheckSource = &UnhealthyIfAtLeastOneErrorSource{}
 
+// MustNewUnhealthyIfAtLeastOneErrorSource returns the result of calling NewUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) *UnhealthyIfAtLeastOneErrorSource {
+	source, err := NewUnhealthyIfAtLeastOneErrorSource(checkType, windowSize)
+	if err != nil {
+		panic(err)
+	}
+	return source
+}
+
 // NewUnhealthyIfAtLeastOneErrorSource creates an UnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
@@ -80,6 +90,16 @@ type HealthyIfNotAllErrorsSource struct {
 }
 
 var _ status.HealthCheckSource = &HealthyIfNotAllErrorsSource{}
+
+// MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) *HealthyIfNotAllErrorsSource {
+	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
+	if err != nil {
+		panic(err)
+	}
+	return source
+}
 
 // NewHealthyIfNotAllErrorsSource creates an HealthyIfNotAllErrorsSource
 // with a sliding window of size windowSize and uses the checkType.

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -43,6 +43,16 @@ type MultiKeyUnhealthyIfAtLeastOneErrorSource struct {
 
 var _ status.HealthCheckSource = &MultiKeyUnhealthyIfAtLeastOneErrorSource{}
 
+// MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource returns the result of calling NewMultiKeyUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) *MultiKeyUnhealthyIfAtLeastOneErrorSource {
+	source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType, messageInCaseOfError, windowSize)
+	if err != nil {
+		panic(err)
+	}
+	return source
+}
+
 // NewMultiKeyUnhealthyIfAtLeastOneErrorSource creates an MultiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
@@ -109,6 +119,16 @@ type MultiKeyHealthyIfNotAllErrorsSource struct {
 }
 
 var _ status.HealthCheckSource = &MultiKeyHealthyIfNotAllErrorsSource{}
+
+// MustNewMultiKeyHealthyIfNotAllErrorsSource returns the result of calling NewMultiKeyHealthyIfNotAllErrorsSource, but panics if it returns an error.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) *MultiKeyHealthyIfNotAllErrorsSource {
+	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(checkType, messageInCaseOfError, windowSize)
+	if err != nil {
+		panic(err)
+	}
+	return source
+}
 
 // NewMultiKeyHealthyIfNotAllErrorsSource creates an MultiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.


### PR DESCRIPTION
Most of these constructors will be used in initialization, which will mean their parameters will be statically defined.
Added the Must constructors to simplify code in such cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/119)
<!-- Reviewable:end -->
