### PR TITLE
Add a heartbeat based health check source

### DIFF
--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -25,7 +25,8 @@ import (
 )
 
 // HealthCheckSource is a thread-safe HealthCheckSource based on heartbeats.
-// This is used to monitor if something is continuously running by receiving heartbeats (pings) with timeouts.
+// Heartbeats are submitted manually using the Heartbeat or the HeartbeatIfSuccess functions.
+// This is used to monitor if some process is continuously running by receiving heartbeats (pings) with timeouts.
 // If no heartbeats are observed within the last heartbeatTimeout time frame, returns unhealthy. Otherwise, returns healthy.
 // A startup grace period can also be specified, where the check will return repairing if no heartbeats
 // were observed but the source was created within the last startupTimeout time frame.
@@ -97,7 +98,7 @@ func NewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Dura
 // If it was, returns healthy. If not, returns unhealthy.
 // If there were no heartbeats submitted, checks if the source started within the last startupTimeout time frame.
 // If it was, returns repairing. If not, returns unhealthy.
-func (h *HealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (h *HealthCheckSource) HealthStatus(_ context.Context) health.HealthStatus {
 	h.heartbeatMutex.RLock()
 	defer h.heartbeatMutex.RUnlock()
 	curTime := time.Now()

--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heartbeat
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status"
+)
+
+// HealthCheckSource is a thread-safe HealthCheckSource based on heartbeats.
+// This is used to monitor if something is continuously running by receiving heartbeats (pings) with timeouts.
+// If no heartbeats are observed within the last heartbeatTimeout time frame, returns unhealthy. Otherwise, returns healthy.
+// A startup grace period can also be specified, where the check will return repairing if no heartbeats
+// were observed but the source was created within the last startupTimeout time frame.
+type HealthCheckSource struct {
+	lastHeartbeatTime time.Time
+	heartbeatTimeout  time.Duration
+	heartbeatMutex    sync.RWMutex
+
+	sourceStartupTime time.Time
+	startupTimeout    time.Duration
+
+	checkType health.CheckType
+}
+
+var _ status.HealthCheckSource = &HealthCheckSource{}
+
+// MustNewHealthCheckSourceWithStartupGracePeriod creates a HealthCheckSource with the specified
+// heartbeatTimeout and startupTimeout. The returning HealthCheckResult is of type checkType.
+// Panics if heartbeatTimeout is non-positive or if startupTimeout is negative.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) *HealthCheckSource {
+	healthCheckSource, err := NewHealthCheckSourceWithStartupGracePeriod(checkType, heartbeatTimeout, startupTimeout)
+	if err != nil {
+		panic(err)
+	}
+	return healthCheckSource
+}
+
+// NewHealthCheckSourceWithStartupGracePeriod creates a HealthCheckSource with the specified
+// heartbeatTimeout and startupTimeout. The returning HealthCheckResult is of type checkType.
+// Returns an error if heartbeatTimeout is non-positive or if startupTimeout is negative.
+func NewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) (*HealthCheckSource, error) {
+	if heartbeatTimeout <= 0 {
+		return nil, werror.Error("heartbeatTimeout must be positive")
+	}
+	if startupTimeout < 0 {
+		return nil, werror.Error("startupTimeout cannot be negative")
+	}
+	return &HealthCheckSource{
+		heartbeatTimeout:  heartbeatTimeout,
+		sourceStartupTime: time.Now(),
+		startupTimeout:    startupTimeout,
+		checkType:         checkType,
+	}, nil
+}
+
+// MustNewHealthCheckSource creates a HealthCheckSource with the specified
+// heartbeatTimeout and zero as startupTimeout. The returning HealthCheckResult is of type checkType.
+// Panics if heartbeatTimeout is non-positive.
+// Should only be used in instances where the inputs are statically defined and known to be valid.
+func MustNewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Duration) *HealthCheckSource {
+	healthCheckSource, err := NewHealthCheckSource(checkType, heartbeatTimeout)
+	if err != nil {
+		panic(err)
+	}
+	return healthCheckSource
+}
+
+// NewHealthCheckSource creates a HealthCheckSource with the specified
+// heartbeatTimeout and zero as startupTimeout. The returning HealthCheckResult is of type checkType.
+// Returns an error if heartbeatTimeout is non-positive.
+func NewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Duration) (*HealthCheckSource, error) {
+	return NewHealthCheckSourceWithStartupGracePeriod(checkType, heartbeatTimeout, 0)
+}
+
+// HealthStatus constructs a HealthStatus object based on the submitted heartbeats.
+// First checks if there were any heartbeats submitted.
+// If there were any heartbeats submitted, checks if the latest one was submitted within the last heartbeatTimeout time frame.
+// If it was, returns healthy. If not, returns unhealthy.
+// If there were no heartbeats submitted, checks if the source started within the last startupTimeout time frame.
+// If it was, returns repairing. If not, returns unhealthy.
+func (h *HealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	h.heartbeatMutex.RLock()
+	defer h.heartbeatMutex.RUnlock()
+	curTime := time.Now()
+
+	if h.lastHeartbeatTime.IsZero() {
+		params := map[string]interface{}{
+			"sourceStartupTime": h.sourceStartupTime.String(),
+			"startupTimeout":    h.startupTimeout.String(),
+		}
+		if curTime.Sub(h.sourceStartupTime) < h.startupTimeout {
+			message := "Waiting for initial heartbeat"
+			return health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					h.checkType: {
+						Type:    h.checkType,
+						State:   health.HealthStateRepairing,
+						Message: &message,
+						Params:  params,
+					},
+				},
+			}
+		}
+
+		message := "No heartbeats since startup"
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				h.checkType: {
+					Type:    h.checkType,
+					State:   health.HealthStateError,
+					Message: &message,
+					Params:  params,
+				},
+			},
+		}
+	}
+
+	params := map[string]interface{}{
+		"lastHeartbeatTime": h.lastHeartbeatTime.String(),
+		"heartbeatTimeout":  h.heartbeatTimeout.String(),
+	}
+	if curTime.Sub(h.lastHeartbeatTime) < h.heartbeatTimeout {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				h.checkType: {
+					Type:   h.checkType,
+					State:  health.HealthStateHealthy,
+					Params: params,
+				},
+			},
+		}
+	}
+
+	message := "Last heartbeat was too long ago"
+	return health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			h.checkType: {
+				Type:    h.checkType,
+				State:   health.HealthStateError,
+				Message: &message,
+				Params:  params,
+			},
+		},
+	}
+}
+
+// Heartbeat submits a heartbeat.
+func (h *HealthCheckSource) Heartbeat() {
+	h.heartbeatMutex.Lock()
+	defer h.heartbeatMutex.Unlock()
+	h.lastHeartbeatTime = time.Now()
+}
+
+// HeartbeatIfSuccess submits a heartbeat if err is nil.
+func (h *HealthCheckSource) HeartbeatIfSuccess(err error) {
+	if err != nil {
+		return
+	}
+	h.Heartbeat()
+}

--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -25,8 +25,8 @@ import (
 )
 
 // HealthCheckSource is a thread-safe HealthCheckSource based on heartbeats.
-// Heartbeats are submitted manually using the Heartbeat or the HeartbeatIfSuccess functions.
 // This is used to monitor if some process is continuously running by receiving heartbeats (pings) with timeouts.
+// Heartbeats are submitted manually using the Heartbeat or the HeartbeatIfSuccess functions.
 // If no heartbeats are observed within the last heartbeatTimeout time frame, returns unhealthy. Otherwise, returns healthy.
 // A startup grace period can also be specified, where the check will return repairing if no heartbeats
 // were observed but the source was created within the last startupTimeout time frame.

--- a/status/health/heartbeat/source_test.go
+++ b/status/health/heartbeat/source_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package heartbeat
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testCheckType health.CheckType = "TEST_CHECK"
+)
+
+func TestHealthCheckSource_NoHeartbeats_Repairing(t *testing.T) {
+	source, err := NewHealthCheckSourceWithStartupGracePeriod(testCheckType, 25*time.Millisecond, 25*time.Millisecond)
+	require.NoError(t, err)
+	status := source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck := status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateRepairing, check.State)
+}
+
+func TestHealthCheckSource_NoHeartbeats_Error(t *testing.T) {
+	source, err := NewHealthCheckSourceWithStartupGracePeriod(testCheckType, 25*time.Millisecond, 25*time.Millisecond)
+	require.NoError(t, err)
+	<-time.After(50 * time.Millisecond)
+	status := source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck := status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateError, check.State)
+}
+
+func TestHealthCheckSource_WithHeartbeats_Healthy(t *testing.T) {
+	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	require.NoError(t, err)
+	source.Heartbeat()
+	status := source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck := status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateHealthy, check.State)
+}
+
+func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
+	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	require.NoError(t, err)
+	source.Heartbeat()
+	<-time.After(50 * time.Millisecond)
+	status := source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck := status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateError, check.State)
+}
+
+func TestHealthCheckSource_WithHeartbeats_HealthyThenErrorThenHealthy(t *testing.T) {
+	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	require.NoError(t, err)
+	source.Heartbeat()
+	status := source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck := status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateHealthy, check.State)
+
+	<-time.After(50 * time.Millisecond)
+	status = source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck = status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateError, check.State)
+
+	source.Heartbeat()
+	status = source.HealthStatus(context.Background())
+	require.Equal(t, 1, len(status.Checks))
+	check, hasCheck = status.Checks[testCheckType]
+	require.True(t, hasCheck)
+	assert.Equal(t, health.HealthStateHealthy, check.State)
+}


### PR DESCRIPTION
This is another extremely common pattern for health checks in Rubix.
Abstracting it into witchcraft-go-server.
Tested with unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/121)
<!-- Reviewable:end -->
