### PR TITLE
Add management tracer that gets registered to management routes

### DIFF
--- a/config/install.go
+++ b/config/install.go
@@ -21,11 +21,12 @@ import (
 // Install specifies the base install configuration fields that should be included in all witchcraft-go-server server
 // install configurations.
 type Install struct {
-	ProductName          string        `yaml:"product-name,omitempty"`
-	Server               Server        `yaml:"server,omitempty"`
-	MetricsEmitFrequency time.Duration `yaml:"metrics-emit-frequency,omitempty"`
-	TraceSampleRate      *float64      `yaml:"trace-sample-rate,omitempty"`
-	UseConsoleLog        bool          `yaml:"use-console-log,omitempty"`
+	ProductName               string        `yaml:"product-name,omitempty"`
+	Server                    Server        `yaml:"server,omitempty"`
+	MetricsEmitFrequency      time.Duration `yaml:"metrics-emit-frequency,omitempty"`
+	TraceSampleRate           *float64      `yaml:"trace-sample-rate,omitempty"`
+	ManagementTraceSampleRate *float64      `yaml:"management-trace-sample-rate,omitempty"`
+	UseConsoleLog             bool          `yaml:"use-console-log,omitempty"`
 }
 
 type Server struct {

--- a/config/install_test.go
+++ b/config/install_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
+)
+
+func TestInstallConfig(t *testing.T) {
+	conf := `
+product-name: productName
+trace-sample-rate: 0.5
+management-trace-sample-rate: 0.6
+use-console-log: true
+metrics-emit-frequency: 1s
+server:
+  address: address
+  port: 10
+  management-port: 11
+  context-path: ContextPath
+  client-ca-files:
+    - a
+    - b
+  cert-file: certFile
+  key-file: keyFile
+`
+	var install Install
+	err := yaml.Unmarshal([]byte(conf), &install)
+	assert.NoError(t, err)
+	assert.Equal(t, Install{
+		ProductName: "productName",
+		Server: Server{
+			Address:        "address",
+			Port:           10,
+			ManagementPort: 11,
+			ContextPath:    "ContextPath",
+			ClientCAFiles:  []string{"a", "b"},
+			CertFile:       "certFile",
+			KeyFile:        "keyFile",
+		},
+		MetricsEmitFrequency:      time.Second,
+		TraceSampleRate:           asFloat(0.5),
+		ManagementTraceSampleRate: asFloat(0.6),
+		UseConsoleLog:             true,
+	}, install)
+}
+
+func asFloat(f float64) *float64 {
+	return &f
+}

--- a/config/install_test.go
+++ b/config/install_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/witchcraft/trace_test.go
+++ b/witchcraft/trace_test.go
@@ -56,7 +56,7 @@ func TestSamplerForRate(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprint(test.rate), func(t *testing.T) {
-			sampler := (&Server{}).samplerForRate(test.rate)
+			sampler := traceSamplerFromSampleRate(test.rate)
 			for i, id := range []uint64{
 				0x0000000000000000,
 				0x1111111111111111,

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -145,9 +145,15 @@ type Server struct {
 	// be the package from which "Start" was called.
 	svcLogOrigin *string
 
-	// traceSampler is the function that is used to determine whether or not a trace should be sampled. If nil, the
-	// default behavior is to sample every trace.
-	traceSampler func(id uint64) bool
+	// applicationTraceSampler is the function that is used to determine whether or not a trace should be sampled.
+	// This applies to routes registered under the application port and the context passed to the initialize function
+	// If nil, the default behavior is to sample every trace.
+	applicationTraceSampler wtracing.Sampler
+
+	// managementTraceSampler is the function that is used to determine whether or not a trace should be sampled.
+	// This applies to routes registered under the management port
+	// If nil, the default behavior is to sample no traces.
+	managementTraceSampler wtracing.Sampler
 
 	// disableKeepAlives disables keep-alives.
 	disableKeepAlives bool
@@ -374,11 +380,28 @@ func (s *Server) WithRouterImplProvider(routerImplProvider func() wrouter.Router
 	return s
 }
 
-// WithTraceSampler configures the server's trace log tracer to use the specified traceSampler function to make a
+// WithTraceSampler configures the server's application trace log tracer to use the specified traceSampler function to make a
 // determination on whether or not a trace should be sampled (if such a decision needs to be made).
-func (s *Server) WithTraceSampler(traceSampler func(id uint64) bool) *Server {
-	s.traceSampler = traceSampler
+func (s *Server) WithTraceSampler(traceSampler wtracing.Sampler) *Server {
+	s.applicationTraceSampler = traceSampler
 	return s
+}
+
+// WithTraceSamplerRate is convenience for creating an application traceSampler based off a sample rate
+func (s *Server) WithTraceSamplerRate(sampleRate float64) *Server {
+	return s.WithTraceSampler(traceSamplerFromSampleRate(sampleRate))
+}
+
+// WithManagementTraceSampler configures the server's management trace log tracer to use the specified traceSampler function to make a
+// determination on whether or not a trace should be sampled (if such a decision needs to be made).
+func (s *Server) WithManagementTraceSampler(traceSampler wtracing.Sampler) *Server {
+	s.managementTraceSampler = traceSampler
+	return s
+}
+
+// WithManagementTraceSamplerRate is convenience for creating a management traceSampler based off a sample rate
+func (s *Server) WithManagementTraceSamplerRate(sampleRate float64) *Server {
+	return s.WithManagementTraceSampler(traceSamplerFromSampleRate(sampleRate))
 }
 
 // WithSigQuitHandlerWriter sets the output for the goroutine dump on SIGQUIT.
@@ -527,10 +550,10 @@ func (s *Server) Start() (rErr error) {
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
 	// add middleware
-	s.addMiddleware(router.RootRouter(), metricsRegistry, s.defaultTracerOptions(baseInstallCfg.ProductName, baseInstallCfg.Server.Address, baseInstallCfg.Server.Port, baseInstallCfg.TraceSampleRate))
+	s.addMiddleware(router.RootRouter(), metricsRegistry, s.getApplicationTracingOptions(baseInstallCfg))
 	if mgmtRouter != router {
 		// add middleware to management router as well if it is distinct
-		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, s.defaultTracerOptions(baseInstallCfg.ProductName, baseInstallCfg.Server.Address, baseInstallCfg.Server.ManagementPort, baseInstallCfg.TraceSampleRate))
+		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, s.getManagementTracingOptions(baseInstallCfg))
 	}
 
 	// handle built-in runtime config changes
@@ -554,7 +577,7 @@ func (s *Server) Start() (rErr error) {
 		if s.trcLogger != nil {
 			traceReporter = s.trcLogger
 		}
-		tracer, err := wzipkin.NewTracer(traceReporter, s.defaultTracerOptions(baseInstallCfg.ProductName, baseInstallCfg.Server.Address, baseInstallCfg.Server.Port, baseInstallCfg.TraceSampleRate)...)
+		tracer, err := wzipkin.NewTracer(traceReporter, s.getApplicationTracingOptions(baseInstallCfg)...)
 		if err != nil {
 			return err
 		}
@@ -799,44 +822,54 @@ func stopServer(s *Server, stopper func(s *http.Server) error) error {
 	return stopper(s.httpServer)
 }
 
-func (s *Server) defaultTracerOptions(serviceName, address string, port int, sampleRate *float64) []wtracing.TracerOption {
-	var options []wtracing.TracerOption
+func (s *Server) getApplicationTracingOptions(install config.Install) []wtracing.TracerOption {
+	return getTracingOptions(s.applicationTraceSampler, install, alwaysSample, install.Server.Port, install.TraceSampleRate)
+}
+
+func (s *Server) getManagementTracingOptions(install config.Install) []wtracing.TracerOption {
+	return getTracingOptions(s.managementTraceSampler, install, neverSample, install.Server.ManagementPort, install.ManagementTraceSampleRate)
+}
+
+func getTracingOptions(configuredSampler wtracing.Sampler, install config.Install, fallbackSampler wtracing.Sampler, port int, sampleRate *float64) []wtracing.TracerOption {
 	endpoint := &wtracing.Endpoint{
-		ServiceName: serviceName,
+		ServiceName: install.ProductName,
 		Port:        uint16(port),
 	}
-	if parsedIP := net.ParseIP(address); len(parsedIP) > 0 {
+	if parsedIP := net.ParseIP(install.Server.Address); len(parsedIP) > 0 {
 		if parsedIP.To4() != nil {
 			endpoint.IPv4 = parsedIP
 		} else {
 			endpoint.IPv6 = parsedIP
 		}
 	}
-	options = append(options, wtracing.WithLocalEndpoint(endpoint))
-	if s.traceSampler != nil {
-		options = append(options, wtracing.WithSampler(s.traceSampler))
-	} else if sampleRate != nil {
-		options = append(options, wtracing.WithSampler(s.samplerForRate(*sampleRate)))
+	return []wtracing.TracerOption{
+		wtracing.WithLocalEndpoint(endpoint),
+		getSamplingTraceOption(configuredSampler, fallbackSampler, sampleRate),
 	}
-	return options
 }
 
-func (s *Server) samplerForRate(sampleRate float64) wtracing.Sampler {
+func getSamplingTraceOption(configuredSampler wtracing.Sampler, fallbackSampler wtracing.Sampler, sampleRate *float64) wtracing.TracerOption {
+	if configuredSampler != nil {
+		return wtracing.WithSampler(configuredSampler)
+	} else if sampleRate != nil {
+		wtracing.WithSampler(traceSamplerFromSampleRate(*sampleRate))
+	}
+	return wtracing.WithSampler(fallbackSampler)
+}
+
+func traceSamplerFromSampleRate(sampleRate float64) wtracing.Sampler {
 	if sampleRate <= 0 {
-		if s.svcLogger != nil {
-			s.svcLogger.Info("Trace logging will be disabled due to trace-sample-rate <= 0")
-		}
-		return func(id uint64) bool { return false }
+		return neverSample
 	}
 	if sampleRate >= 1 {
-		if s.svcLogger != nil {
-			s.svcLogger.Info("Trace logging will sample all traces due to trace-sample-rate >= 1")
-		}
-		return func(id uint64) bool { return true }
+		return alwaysSample
 	}
-
 	boundary := uint64(sampleRate * float64(math.MaxUint64)) // does not overflow because we already checked bounds
 	return func(id uint64) bool {
 		return id < boundary
 	}
 }
+
+func neverSample(id uint64) bool { return false }
+
+func alwaysSample(id uint64) bool { return true }

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -387,7 +387,7 @@ func (s *Server) WithTraceSampler(traceSampler wtracing.Sampler) *Server {
 	return s
 }
 
-// WithTraceSamplerRate is convenience for creating an application traceSampler based off a sample rate
+// WithTraceSamplerRate is a convenience function for creating an application traceSampler based off a sample rate
 func (s *Server) WithTraceSamplerRate(sampleRate float64) *Server {
 	return s.WithTraceSampler(traceSamplerFromSampleRate(sampleRate))
 }
@@ -399,7 +399,7 @@ func (s *Server) WithManagementTraceSampler(traceSampler wtracing.Sampler) *Serv
 	return s
 }
 
-// WithManagementTraceSamplerRate is convenience for creating a management traceSampler based off a sample rate
+// WithManagementTraceSamplerRate is a convenience function for creating a management traceSampler based off a sample rate
 func (s *Server) WithManagementTraceSamplerRate(sampleRate float64) *Server {
 	return s.WithManagementTraceSampler(traceSamplerFromSampleRate(sampleRate))
 }


### PR DESCRIPTION
- Addressed https://github.com/palantir/witchcraft-go-server/issues/122
- Add identical configurability to the application and management tracer
- The management tracer defaults to no tracing
- Add `WithManagementTraceSamplerRate` and `WithTraceSamplerRate` helper functions. (not tied to this, but seemed like a natural extension). Can remove if you prefer
- Explicitly add a `alwaysTrace` option to the application tracer if no others are set. Before this relied on an implementation detail of wtracing
- Add a management trace rate to the install config and write a test for all on the install config
- Happy to add whatever additional testing you prefer, I captured the current testing coverage of the applicationTracer with the managementTracer, but there was not a ton there and can add additional tests if you have suggestions 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/123)
<!-- Reviewable:end -->
