### PR TITLE
Feature: add support for blacklisting metric type values

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -118,3 +118,92 @@ func TestEmitMetrics(t *testing.T) {
 	default:
 	}
 }
+
+// TestMetricTypeValueBlacklist tests that if a metric type value is blacklisted, all metric of that type does not
+// contain any of the blacklisted keys.
+func TestMetricTypeValueBlacklist(t *testing.T) {
+	logOutputBuffer := &bytes.Buffer{}
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+
+	// ensure that registry used in this test is unique/does not have any past metrics registered on it
+	metrics.DefaultMetricsRegistry = metrics.NewRootMetricsRegistry()
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, func(ctx context.Context, info witchcraft.InitInfo) (deferFn func(), rErr error) {
+		ctx = metrics.AddTags(ctx, metrics.MustNewTag("key", "val"))
+		metrics.FromContext(ctx).Counter("my-counter").Inc(13)
+		return nil, info.Router.Post("/error", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(500)
+		}))
+	}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
+		installCfg.MetricsEmitFrequency = 100 * time.Millisecond
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithMetricTypeValuesBlacklist(map[string]map[string]struct{}{
+			"histogram": {"count": {}},
+		})
+	})
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	// Make POST that will 404 to trigger request size and error rate metrics
+	_, err = testServerClient().Post(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, "error"), "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+
+	// Allow the metric emitter to do its thing.
+	time.Sleep(150 * time.Millisecond)
+
+	parts := strings.Split(logOutputBuffer.String(), "\n")
+	var metricLogs []logging.MetricLogV1
+	for _, curr := range parts {
+		if strings.Contains(curr, `"metric.1"`) {
+			var currLog logging.MetricLogV1
+			require.NoError(t, json.Unmarshal([]byte(curr), &currLog))
+			metricLogs = append(metricLogs, currLog)
+		}
+	}
+
+	var seenMyCounter, seenResponseTimer, seenResponseSize, seenRequestSize, seenResponseError bool
+	for _, metricLog := range metricLogs {
+		switch metricLog.MetricName {
+		case "my-counter":
+			seenMyCounter = true
+			assert.Equal(t, "counter", metricLog.MetricType, "my-counter metric had incorrect type")
+			assert.Equal(t, map[string]interface{}{"count": json.Number("13")}, metricLog.Values)
+			assert.Equal(t, map[string]string{"key": "val"}, metricLog.Tags)
+		case "server.response":
+			seenResponseTimer = true
+			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotZero(t, metricLog.Values["mean"])
+			assert.NotZero(t, metricLog.Values["max"])
+			assert.NotZero(t, metricLog.Values["min"])
+		case "server.request.size":
+			seenRequestSize = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
+			// there should be no value for "count" because it is blacklisted for the histogram type
+			assert.Nil(t, metricLog.Values["count"])
+		case "server.response.size":
+			seenResponseSize = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
+			// there should be no value for "count" because it is blacklisted for the histogram type
+			assert.Nil(t, metricLog.Values["count"])
+		case "server.response.error":
+			seenResponseError = true
+			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
+		default:
+			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
+		}
+	}
+	assert.True(t, seenMyCounter, "my-counter metric was not emitted")
+	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
+	assert.True(t, seenRequestSize, "server.request.size metric was not emitted")
+	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
+	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -88,43 +88,51 @@ func TestEmitMetrics(t *testing.T) {
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
 			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+
+			// keys are part of the default blacklist and should thus be nil
 			assert.Nil(t, metricLog.Values["1m"])
 			assert.Nil(t, metricLog.Values["5m"])
 			assert.Nil(t, metricLog.Values["15m"])
 			assert.Nil(t, metricLog.Values["meanRate"])
 			assert.Nil(t, metricLog.Values["min"])
-			assert.NotNil(t, metricLog.Values["max"])
 			assert.Nil(t, metricLog.Values["mean"])
 			assert.Nil(t, metricLog.Values["stddev"])
 			assert.Nil(t, metricLog.Values["p50"])
-			assert.NotNil(t, metricLog.Values["p95"])
-			assert.NotNil(t, metricLog.Values["p99"])
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.Nil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
-			assert.Nil(t, metricLog.Values["mean"])
-			assert.Nil(t, metricLog.Values["stddev"])
-			assert.Nil(t, metricLog.Values["p50"])
 			assert.NotNil(t, metricLog.Values["p95"])
 			assert.NotNil(t, metricLog.Values["p99"])
 			assert.NotNil(t, metricLog.Values["count"])
+
+			// keys are part of the default blacklist and should thus be nil
+			assert.Nil(t, metricLog.Values["min"])
+			assert.Nil(t, metricLog.Values["mean"])
+			assert.Nil(t, metricLog.Values["stddev"])
+			assert.Nil(t, metricLog.Values["p50"])
 		case "server.response.size":
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.Nil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
-			assert.Nil(t, metricLog.Values["mean"])
-			assert.Nil(t, metricLog.Values["stddev"])
-			assert.Nil(t, metricLog.Values["p50"])
 			assert.NotNil(t, metricLog.Values["p95"])
 			assert.NotNil(t, metricLog.Values["p99"])
 			assert.NotNil(t, metricLog.Values["count"])
+
+			// keys are part of the default blacklist and should thus be nil
+			assert.Nil(t, metricLog.Values["min"])
+			assert.Nil(t, metricLog.Values["mean"])
+			assert.Nil(t, metricLog.Values["stddev"])
+			assert.Nil(t, metricLog.Values["p50"])
 		case "server.response.error":
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
 			assert.NotNil(t, metricLog.Values["count"])
+
+			// keys are part of the default blacklist and should thus be nil
 			assert.Nil(t, metricLog.Values["1m"])
 			assert.Nil(t, metricLog.Values["5m"])
 			assert.Nil(t, metricLog.Values["15m"])
@@ -199,6 +207,8 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		case "server.response":
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
+
+			// blacklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["count"])
 			assert.NotNil(t, metricLog.Values["1m"])
 			assert.NotNil(t, metricLog.Values["5m"])
@@ -214,6 +224,8 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
+
+			// blacklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
 			assert.NotNil(t, metricLog.Values["mean"])
@@ -225,6 +237,8 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		case "server.response.size":
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
+
+			// blacklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
 			assert.NotNil(t, metricLog.Values["mean"])
@@ -236,6 +250,8 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		case "server.response.error":
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
+
+			// blacklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["count"])
 			assert.NotNil(t, metricLog.Values["1m"])
 			assert.NotNil(t, metricLog.Values["5m"])

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -87,22 +87,48 @@ func TestEmitMetrics(t *testing.T) {
 		case "server.response":
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
-			assert.Nil(t, metricLog.Values["mean"])
-			assert.NotZero(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.Nil(t, metricLog.Values["1m"])
+			assert.Nil(t, metricLog.Values["5m"])
+			assert.Nil(t, metricLog.Values["15m"])
+			assert.Nil(t, metricLog.Values["meanRate"])
 			assert.Nil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.Nil(t, metricLog.Values["mean"])
+			assert.Nil(t, metricLog.Values["stddev"])
+			assert.Nil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.Nil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.Nil(t, metricLog.Values["mean"])
+			assert.Nil(t, metricLog.Values["stddev"])
+			assert.Nil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
 		case "server.response.size":
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.Nil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.Nil(t, metricLog.Values["mean"])
+			assert.Nil(t, metricLog.Values["stddev"])
+			assert.Nil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
 		case "server.response.error":
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.Nil(t, metricLog.Values["1m"])
+			assert.Nil(t, metricLog.Values["5m"])
+			assert.Nil(t, metricLog.Values["15m"])
+			assert.Nil(t, metricLog.Values["mean"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
 		}
@@ -173,22 +199,48 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		case "server.response":
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
-			assert.NotZero(t, metricLog.Values["mean"])
-			assert.NotZero(t, metricLog.Values["max"])
-			assert.NotZero(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["1m"])
+			assert.NotNil(t, metricLog.Values["5m"])
+			assert.NotNil(t, metricLog.Values["15m"])
+			assert.NotNil(t, metricLog.Values["meanRate"])
+			assert.NotNil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["mean"])
+			assert.NotNil(t, metricLog.Values["stddev"])
+			assert.NotNil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["mean"])
+			assert.NotNil(t, metricLog.Values["stddev"])
+			assert.NotNil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
 		case "server.response.size":
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["mean"])
+			assert.NotNil(t, metricLog.Values["stddev"])
+			assert.NotNil(t, metricLog.Values["p50"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
 		case "server.response.error":
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["1m"])
+			assert.NotNil(t, metricLog.Values["5m"])
+			assert.NotNil(t, metricLog.Values["15m"])
+			assert.NotNil(t, metricLog.Values["mean"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
 		}
@@ -260,10 +312,10 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		case "server.response":
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
-			assert.NotZero(t, metricLog.Values["mean"])
-			assert.NotZero(t, metricLog.Values["max"])
-			assert.NotZero(t, metricLog.Values["min"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["mean"])
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["min"])
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
@@ -277,7 +329,7 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		case "server.response.error":
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
-			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Values["count"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
 		}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -139,7 +139,7 @@ type Server struct {
 
 	// metricTypeValuesBlacklist specifies the values for a metric type that should be omitted from metric output. For
 	// example, if the map is set to {"timer":{"5m":{}}}, then the value for "5m" will be omitted from all timer metric
-	// output.
+	// output. If nil, the default value is the map returned by defaultMetricTypeValuesBlacklist().
 	metricTypeValuesBlacklist map[string]map[string]struct{}
 
 	// specifies the TLS client authentication mode used by the server. If not specified, the default value is

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -137,6 +137,11 @@ type Server struct {
 	// seconds if an interval is not specified in configuration).
 	disableGoRuntimeMetrics bool
 
+	// metricTypeValuesBlacklist specifies the values for a metric type that should be omitted from metric output. For
+	// example, if the map is set to {"timer":{"5m":{}}}, then the value for "5m" will be omitted from all timer metric
+	// output.
+	metricTypeValuesBlacklist map[string]map[string]struct{}
+
 	// specifies the TLS client authentication mode used by the server. If not specified, the default value is
 	// tls.NoClientCert.
 	clientAuth tls.ClientAuthType
@@ -434,6 +439,21 @@ func (s *Server) WithDisableKeepAlives() *Server {
 // WithDisableGoRuntimeMetrics disables the server's enabled-by-default collection of runtime memory statistics.
 func (s *Server) WithDisableGoRuntimeMetrics() *Server {
 	s.disableGoRuntimeMetrics = true
+	return s
+}
+
+// WithMetricTypeValuesBlacklist sets the value of the metric type value blacklist to be the same as the provided value
+// (the content is copied).
+func (s *Server) WithMetricTypeValuesBlacklist(blacklist map[string]map[string]struct{}) *Server {
+	newBlacklist := make(map[string]map[string]struct{}, len(blacklist))
+	for k, v := range blacklist {
+		newVal := make(map[string]struct{}, len(v))
+		for kk := range v {
+			newVal[kk] = struct{}{}
+		}
+		newBlacklist[k] = newVal
+	}
+	s.metricTypeValuesBlacklist = newBlacklist
 	return s
 }
 


### PR DESCRIPTION
Adds WithMetricTypeValuesBlacklist function to server that allows
specifying values that should not be emitted to the metric logs
on a per-metric basis.

Fixes #127

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/128)
<!-- Reviewable:end -->
