### PR TITLE
Feature: add support for blacklisting metrics

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -115,3 +115,85 @@ func TestEmitMetrics(t *testing.T) {
 	default:
 	}
 }
+
+// TestMetricsBlacklist verifies that blacklisted metrics are not emitted.
+func TestMetricsBlacklist(t *testing.T) {
+	logOutputBuffer := &bytes.Buffer{}
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, func(ctx context.Context, info witchcraft.InitInfo) (deferFn func(), rErr error) {
+		ctx = metrics.AddTags(ctx, metrics.MustNewTag("key", "val"))
+		metrics.FromContext(ctx).Counter("my-counter").Inc(13)
+		return nil, info.Router.Post("/error", http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(500)
+		}))
+	}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
+		installCfg.MetricsEmitFrequency = 100 * time.Millisecond
+		server := createTestServer(t, initFn, installCfg, logOutputBuffer)
+		server.WithMetricsBlacklist(map[string]struct{}{
+			"my-counter":          {},
+			"server.request.size": {},
+		})
+		return server
+	})
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	// Make POST that will 404 to trigger request size and error rate metrics
+	_, err = testServerClient().Post(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, "error"), "application/json", strings.NewReader("{}"))
+	require.NoError(t, err)
+
+	// Allow the metric emitter to do its thing.
+	time.Sleep(150 * time.Millisecond)
+
+	parts := strings.Split(logOutputBuffer.String(), "\n")
+	var metricLogs []logging.MetricLogV1
+	for _, curr := range parts {
+		if strings.Contains(curr, `"metric.1"`) {
+			var currLog logging.MetricLogV1
+			require.NoError(t, json.Unmarshal([]byte(curr), &currLog))
+			metricLogs = append(metricLogs, currLog)
+		}
+	}
+
+	var seenMyCounter, seenResponseTimer, seenResponseSize, seenRequestSize, seenResponseError bool
+	for _, metricLog := range metricLogs {
+		switch metricLog.MetricName {
+		case "my-counter":
+			assert.Fail(t, "my-counter metric should not be emitted")
+		case "server.response":
+			seenResponseTimer = true
+			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
+			assert.NotZero(t, metricLog.Values["mean"])
+			assert.NotZero(t, metricLog.Values["max"])
+			assert.NotZero(t, metricLog.Values["min"])
+		case "server.request.size":
+			assert.Fail(t, "server.request.size metric should not be emitted")
+		case "server.response.size":
+			seenResponseSize = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
+		case "server.response.error":
+			seenResponseError = true
+			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
+		default:
+			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
+		}
+	}
+	assert.False(t, seenMyCounter, "my-counter metric was emitted")
+	assert.False(t, seenRequestSize, "server.request.size metric was emitted")
+
+	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
+	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
+	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -414,9 +414,6 @@ func TestMetricsBlacklist(t *testing.T) {
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
 			assert.NotZero(t, metricLog.Values["count"])
-			assert.NotZero(t, metricLog.Values["mean"])
-			assert.NotZero(t, metricLog.Values["max"])
-			assert.NotZero(t, metricLog.Values["min"])
 		case "server.request.size":
 			assert.Fail(t, "server.request.size metric should not be emitted")
 		case "server.response.size":

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -39,6 +39,10 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 	}
 
 	emitFn := func(metricID string, tags metrics.Tags, metricVal metrics.MetricVal) {
+		if _, blackListed := s.metricsBlacklist[metricID]; blackListed {
+			// skip emitting metric if it is blacklisted
+			return
+		}
 		s.metricLogger.Metric(metricID, metricVal.Type(), metric1log.Values(metricVal.Values()), metric1log.Tags(tags.ToMap()))
 	}
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -440,7 +440,10 @@ func (s *Server) WithDisableGoRuntimeMetrics() *Server {
 	return s
 }
 
-// WithMetricsBlacklist sets the metric blacklist to the provided set of metrics. The provided input is copied.
+// WithMetricsBlacklist sets the metric blacklist to the provided set of metrics. The provided metrics should be the
+// name of the metric (for example, "server.response.size"). The blacklist only supports blacklisting at the metric
+// level: blacklisting an individual metric value (such as "server.response.size.count") will not have any effect. The
+// provided input is copied.
 func (s *Server) WithMetricsBlacklist(blacklist map[string]struct{}) *Server {
 	metricsBlacklist := make(map[string]struct{})
 	for k, v := range blacklist {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -137,6 +137,9 @@ type Server struct {
 	// seconds if an interval is not specified in configuration).
 	disableGoRuntimeMetrics bool
 
+	// metricsBlacklist specifies the set of metrics that should not be emitted by the metric logger.
+	metricsBlacklist map[string]struct{}
+
 	// specifies the TLS client authentication mode used by the server. If not specified, the default value is
 	// tls.NoClientCert.
 	clientAuth tls.ClientAuthType
@@ -434,6 +437,16 @@ func (s *Server) WithDisableKeepAlives() *Server {
 // WithDisableGoRuntimeMetrics disables the server's enabled-by-default collection of runtime memory statistics.
 func (s *Server) WithDisableGoRuntimeMetrics() *Server {
 	s.disableGoRuntimeMetrics = true
+	return s
+}
+
+// WithMetricsBlacklist sets the metric blacklist to the provided set of metrics. The provided input is copied.
+func (s *Server) WithMetricsBlacklist(blacklist map[string]struct{}) *Server {
+	metricsBlacklist := make(map[string]struct{})
+	for k, v := range blacklist {
+		metricsBlacklist[k] = v
+	}
+	s.metricsBlacklist = metricsBlacklist
 	return s
 }
 


### PR DESCRIPTION
Adds WithMetricsBlacklist function to server that allows
specifying a set of metrics that should not be emitted.

Fixes #125

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/129)
<!-- Reviewable:end -->
