### PR TITLE
Add a configuration point for the servers metrics registry emitter

### DIFF
--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -441,8 +441,8 @@ func (s *Server) WithDisableGoRuntimeMetrics() *Server {
 	return s
 }
 
-// WithMetricsEmissionFunc sets the servers metrics visitor which is used to emit metrics from the servers registry.
-func (s *Server) WithMetricEmissionFunc(visitorProvider MetricsVisitorProvider) *Server {
+// WithMetricVisitorProvider sets the servers metrics visitor which is used to emit metrics from the servers registry.
+func (s *Server) WithMetricVisitorProvider(visitorProvider MetricsVisitorProvider) *Server {
 	s.metricsVisitor = visitorProvider(s)
 	return s
 }


### PR DESCRIPTION
Allow users to provide a custom metrics visitor by writing a `MetricsVisitorProvider`. This would allow users to limit the values or tags emitted for metrics which might have prohibitively high cardinalities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/131)
<!-- Reviewable:end -->
