### PR TITLE
Add interfaces for window package's health check source implementations.

### DIFF
--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -44,8 +44,6 @@ type baseHealthCheckSource struct {
 	itemsToCheckFn    ItemsToCheckFn
 }
 
-var _ status.HealthCheckSource = &baseHealthCheckSource{}
-
 // MustNewBaseHealthCheckSource returns the result of calling NewBaseHealthCheckSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {

--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -23,23 +23,32 @@ import (
 	"github.com/palantir/witchcraft-go-server/status"
 )
 
+// ItemSubmitter allows components of code whose functionality dictates health status to just consume this single-method interface.
+type ItemSubmitter interface {
+	Submit(interface{})
+}
 
+// BaseHealthCheckSource determines health status based on user-submitted items.
+type BaseHealthCheckSource interface {
+	ItemSubmitter
+	status.HealthCheckSource
+}
 
 // ItemsToCheckFn is a function that constructs a HealthCheckResult from a set of items.
 type ItemsToCheckFn func(ctx context.Context, items []ItemWithTimestamp) health.HealthCheckResult
 
-// BaseHealthCheckSource is a HealthCheckSource that polls a TimeWindowedStore.
+// baseHealthCheckSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns a HealthStatus created using an ItemsToCheckFn.
-type BaseHealthCheckSource struct {
+type baseHealthCheckSource struct {
 	timeWindowedStore *TimeWindowedStore
 	itemsToCheckFn    ItemsToCheckFn
 }
 
-var _ status.HealthCheckSource = &BaseHealthCheckSource{}
+var _ status.HealthCheckSource = &baseHealthCheckSource{}
 
 // MustNewBaseHealthCheckSource returns the result of calling NewBaseHealthCheckSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) *BaseHealthCheckSource {
+func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {
 	source, err := NewBaseHealthCheckSource(windowSize, itemsToCheckFn)
 	if err != nil {
 		panic(err)
@@ -47,10 +56,10 @@ func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn Items
 	return source
 }
 
-// NewBaseHealthCheckSource creates a BaseHealthCheckSource
+// NewBaseHealthCheckSource creates a baseHealthCheckSource
 // with a sliding window of size windowSize and uses the itemsToCheckFn.
 // windowSize must be a positive value and itemsToCheckFn must not be nil, otherwise returns error.
-func NewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) (*BaseHealthCheckSource, error) {
+func NewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) (BaseHealthCheckSource, error) {
 	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
 	if err != nil {
 		return nil, err
@@ -58,19 +67,19 @@ func NewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCh
 	if itemsToCheckFn == nil {
 		return nil, werror.Error("itemsToCheckFn cannot be nil")
 	}
-	return &BaseHealthCheckSource{
+	return &baseHealthCheckSource{
 		timeWindowedStore: timeWindowedStore,
 		itemsToCheckFn:    itemsToCheckFn,
 	}, nil
 }
 
 // Submit submits an item.
-func (b *BaseHealthCheckSource) Submit(item interface{}) {
+func (b *baseHealthCheckSource) Submit(item interface{}) {
 	b.timeWindowedStore.Submit(item)
 }
 
 // HealthStatus polls the items inside the window and creates a HealthStatus using the ItemsToCheckFn.
-func (b *BaseHealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (b *baseHealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	checkResult := b.itemsToCheckFn(ctx, b.timeWindowedStore.ItemsInWindow())
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{

--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -23,6 +23,8 @@ import (
 	"github.com/palantir/witchcraft-go-server/status"
 )
 
+
+
 // ItemsToCheckFn is a function that constructs a HealthCheckResult from a set of items.
 type ItemsToCheckFn func(ctx context.Context, items []ItemWithTimestamp) health.HealthCheckResult
 

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -42,8 +42,6 @@ type unhealthyIfAtLeastOneErrorSource struct {
 	checkType         health.CheckType
 }
 
-var _ status.HealthCheckSource = &unhealthyIfAtLeastOneErrorSource{}
-
 // MustNewUnhealthyIfAtLeastOneErrorSource returns the result of calling NewUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
@@ -99,8 +97,6 @@ type healthyIfNotAllErrorsSource struct {
 	timeWindowedStore *TimeWindowedStore
 	checkType         health.CheckType
 }
-
-var _ status.HealthCheckSource = &healthyIfNotAllErrorsSource{}
 
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -23,19 +23,30 @@ import (
 	whealth "github.com/palantir/witchcraft-go-server/status/health"
 )
 
-// UnhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
+// ErrorSubmitter allows components whose functionality dictates a portion of health status to only consume this interface.
+type ErrorSubmitter interface {
+	Submit(error)
+}
+
+// ErrorHealthCheckSource is a health check source with statuses determined by submitted errors.
+type ErrorHealthCheckSource interface {
+	ErrorSubmitter
+	status.HealthCheckSource
+}
+
+// unhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns the first non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
-type UnhealthyIfAtLeastOneErrorSource struct {
+type unhealthyIfAtLeastOneErrorSource struct {
 	timeWindowedStore *TimeWindowedStore
 	checkType         health.CheckType
 }
 
-var _ status.HealthCheckSource = &UnhealthyIfAtLeastOneErrorSource{}
+var _ status.HealthCheckSource = &unhealthyIfAtLeastOneErrorSource{}
 
 // MustNewUnhealthyIfAtLeastOneErrorSource returns the result of calling NewUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) *UnhealthyIfAtLeastOneErrorSource {
+func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
 	source, err := NewUnhealthyIfAtLeastOneErrorSource(checkType, windowSize)
 	if err != nil {
 		panic(err)
@@ -43,26 +54,26 @@ func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowS
 	return source
 }
 
-// NewUnhealthyIfAtLeastOneErrorSource creates an UnhealthyIfAtLeastOneErrorSource
+// NewUnhealthyIfAtLeastOneErrorSource creates an unhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
-func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (*UnhealthyIfAtLeastOneErrorSource, error) {
+func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
 	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
 	if err != nil {
 		return nil, err
 	}
-	return &UnhealthyIfAtLeastOneErrorSource{
+	return &unhealthyIfAtLeastOneErrorSource{
 		timeWindowedStore: timeWindowedStore,
 		checkType:         checkType,
 	}, nil
 }
 
 // Submit submits an error.
-func (u *UnhealthyIfAtLeastOneErrorSource) Submit(err error) {
+func (u *unhealthyIfAtLeastOneErrorSource) Submit(err error) {
 	u.timeWindowedStore.Submit(err)
 }
 
-func (u *UnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
+func (u *unhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
 	items := u.timeWindowedStore.ItemsInWindow()
 	for _, item := range items {
 		if item.Item != nil {
@@ -73,7 +84,7 @@ func (u *UnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResu
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
-func (u *UnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (u *unhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			u.checkType: u.itemsToCheck(),
@@ -81,19 +92,19 @@ func (u *UnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) hea
 	}
 }
 
-// HealthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
+// healthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns, if there are only non-nil errors, the first non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
-type HealthyIfNotAllErrorsSource struct {
+type healthyIfNotAllErrorsSource struct {
 	timeWindowedStore *TimeWindowedStore
 	checkType         health.CheckType
 }
 
-var _ status.HealthCheckSource = &HealthyIfNotAllErrorsSource{}
+var _ status.HealthCheckSource = &healthyIfNotAllErrorsSource{}
 
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) *HealthyIfNotAllErrorsSource {
+func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
 	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
 	if err != nil {
 		panic(err)
@@ -101,26 +112,26 @@ func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize t
 	return source
 }
 
-// NewHealthyIfNotAllErrorsSource creates an HealthyIfNotAllErrorsSource
+// NewHealthyIfNotAllErrorsSource creates an healthyIfNotAllErrorsSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
-func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (*HealthyIfNotAllErrorsSource, error) {
+func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
 	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
 	if err != nil {
 		return nil, err
 	}
-	return &HealthyIfNotAllErrorsSource{
+	return &healthyIfNotAllErrorsSource{
 		timeWindowedStore: timeWindowedStore,
 		checkType:         checkType,
 	}, nil
 }
 
 // Submit submits an error.
-func (h *HealthyIfNotAllErrorsSource) Submit(err error) {
+func (h *healthyIfNotAllErrorsSource) Submit(err error) {
 	h.timeWindowedStore.Submit(err)
 }
 
-func (h *HealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
+func (h *healthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
 	items := h.timeWindowedStore.ItemsInWindow()
 	if len(items) == 0 {
 		return whealth.HealthyHealthCheckResult(h.checkType)
@@ -134,7 +145,7 @@ func (h *HealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
-func (h *HealthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			h.checkType: h.itemsToCheck(),

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -50,8 +50,6 @@ type multiKeyUnhealthyIfAtLeastOneErrorSource struct {
 	messageInCaseOfError string
 }
 
-var _ status.HealthCheckSource = &multiKeyUnhealthyIfAtLeastOneErrorSource{}
-
 // MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource returns the result of calling NewMultiKeyUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -23,6 +23,15 @@ import (
 	whealth "github.com/palantir/witchcraft-go-server/status/health"
 )
 
+type KeyedErrorSubmitter interface {
+	Submit(key string, err error)
+}
+
+type KeyedErrorHealthCheckSource interface {
+	KeyedErrorSubmitter
+	status.HealthCheckSource
+}
+
 // keyErrorPair is a struct that keeps a key as a string and an err.
 type keyErrorPair struct {
 	// key is an identifier for a resource.
@@ -31,21 +40,21 @@ type keyErrorPair struct {
 	err error
 }
 
-// MultiKeyUnhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
+// multiKeyUnhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns unhealthy if there is a non-nil error for at least one key.
 // The Params field of the HealthCheckResult is the first error message for each key mapped by the key for all unhealthy keys.
 // If there are no items, returns healthy.
-type MultiKeyUnhealthyIfAtLeastOneErrorSource struct {
+type multiKeyUnhealthyIfAtLeastOneErrorSource struct {
 	timeWindowedStore    *TimeWindowedStore
 	checkType            health.CheckType
 	messageInCaseOfError string
 }
 
-var _ status.HealthCheckSource = &MultiKeyUnhealthyIfAtLeastOneErrorSource{}
+var _ status.HealthCheckSource = &multiKeyUnhealthyIfAtLeastOneErrorSource{}
 
 // MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource returns the result of calling NewMultiKeyUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) *MultiKeyUnhealthyIfAtLeastOneErrorSource {
+func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
 	source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		panic(err)
@@ -53,15 +62,15 @@ func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType,
 	return source
 }
 
-// NewMultiKeyUnhealthyIfAtLeastOneErrorSource creates an MultiKeyUnhealthyIfAtLeastOneErrorSource
+// NewMultiKeyUnhealthyIfAtLeastOneErrorSource creates an multiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
-func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (*MultiKeyUnhealthyIfAtLeastOneErrorSource, error) {
+func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
 	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
 	if err != nil {
 		return nil, err
 	}
-	return &MultiKeyUnhealthyIfAtLeastOneErrorSource{
+	return &multiKeyUnhealthyIfAtLeastOneErrorSource{
 		timeWindowedStore:    timeWindowedStore,
 		checkType:            checkType,
 		messageInCaseOfError: messageInCaseOfError,
@@ -69,14 +78,14 @@ func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, mes
 }
 
 // Submit submits an item as a key error pair.
-func (m *MultiKeyUnhealthyIfAtLeastOneErrorSource) Submit(key string, err error) {
+func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) Submit(key string, err error) {
 	m.timeWindowedStore.Submit(keyErrorPair{
 		key: key,
 		err: err,
 	})
 }
 
-func (m *MultiKeyUnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
+func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
 	items := m.timeWindowedStore.ItemsInWindow()
 	params := make(map[string]interface{})
 	for _, item := range items {
@@ -100,7 +109,7 @@ func (m *MultiKeyUnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthC
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
-func (m *MultiKeyUnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			m.checkType: m.itemsToCheck(),
@@ -108,21 +117,21 @@ func (m *MultiKeyUnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Cont
 	}
 }
 
-// MultiKeyHealthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
+// multiKeyHealthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns unhealthy if there is at least one key with only non-nil errors.
 // The Params field of the HealthCheckResult is the first error message for each key mapped by the key for all unhealthy keys.
 // If there are no items, returns healthy.
-type MultiKeyHealthyIfNotAllErrorsSource struct {
+type multiKeyHealthyIfNotAllErrorsSource struct {
 	timeWindowedStore    *TimeWindowedStore
 	checkType            health.CheckType
 	messageInCaseOfError string
 }
 
-var _ status.HealthCheckSource = &MultiKeyHealthyIfNotAllErrorsSource{}
+var _ status.HealthCheckSource = &multiKeyHealthyIfNotAllErrorsSource{}
 
 // MustNewMultiKeyHealthyIfNotAllErrorsSource returns the result of calling NewMultiKeyHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) *MultiKeyHealthyIfNotAllErrorsSource {
+func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
 	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		panic(err)
@@ -130,15 +139,15 @@ func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, mess
 	return source
 }
 
-// NewMultiKeyHealthyIfNotAllErrorsSource creates an MultiKeyUnhealthyIfAtLeastOneErrorSource
+// NewMultiKeyHealthyIfNotAllErrorsSource creates an multiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
-func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (*MultiKeyHealthyIfNotAllErrorsSource, error) {
+func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
 	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
 	if err != nil {
 		return nil, err
 	}
-	return &MultiKeyHealthyIfNotAllErrorsSource{
+	return &multiKeyHealthyIfNotAllErrorsSource{
 		timeWindowedStore:    timeWindowedStore,
 		checkType:            checkType,
 		messageInCaseOfError: messageInCaseOfError,
@@ -146,14 +155,14 @@ func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageI
 }
 
 // Submit submits an item as a key error pair.
-func (m *MultiKeyHealthyIfNotAllErrorsSource) Submit(key string, err error) {
+func (m *multiKeyHealthyIfNotAllErrorsSource) Submit(key string, err error) {
 	m.timeWindowedStore.Submit(keyErrorPair{
 		key: key,
 		err: err,
 	})
 }
 
-func (m *MultiKeyHealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
+func (m *multiKeyHealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
 	items := m.timeWindowedStore.ItemsInWindow()
 	params := make(map[string]interface{})
 	hasSuccess := make(map[string]struct{})
@@ -183,7 +192,7 @@ func (m *MultiKeyHealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckR
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
-func (m *MultiKeyHealthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
+func (m *multiKeyHealthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			m.checkType: m.itemsToCheck(),


### PR DESCRIPTION
### Motivation
At the moment, consumers of these health check source implementations either have to take in the fully struct:
```
func NewFoo(source *window.UnhealthyIfAtLeastOneErrorSource) Foo {...}
```
... or the submit function:
```
func NewFoo(submitErrFunc func(err)) Foo {...}
```
This PR allows consumers to simply take a ErrorSubmitter of KeyedErrorSubmitter interface:
```
func NewFoo(healthCheckErrorSubmitter window.ErrorSubmitter) Foo {...}
```
This results in less leakage of the implementation of the window package's health check sources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/132)
<!-- Reviewable:end -->
