### PR TITLE
Optimize window based health check source memory consumption

### DIFF
--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -16,8 +16,10 @@ package window
 
 import (
 	"context"
+	"sync"
 	"time"
 
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-server/status"
 	whealth "github.com/palantir/witchcraft-go-server/status/health"
@@ -38,8 +40,8 @@ type ErrorHealthCheckSource interface {
 // It returns the first non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
 type unhealthyIfAtLeastOneErrorSource struct {
-	timeWindowedStore *TimeWindowedStore
-	checkType         health.CheckType
+	// unhealthyIfAtLeastOneErrorSource is a healthyIfNotAllErrorsSource that drops all successes.
+	source ErrorHealthCheckSource
 }
 
 // MustNewUnhealthyIfAtLeastOneErrorSource returns the result of calling NewUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
@@ -56,46 +58,38 @@ func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowS
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
 func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
+	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
 	if err != nil {
 		return nil, err
 	}
 	return &unhealthyIfAtLeastOneErrorSource{
-		timeWindowedStore: timeWindowedStore,
-		checkType:         checkType,
+		source: source,
 	}, nil
 }
 
 // Submit submits an error.
 func (u *unhealthyIfAtLeastOneErrorSource) Submit(err error) {
-	u.timeWindowedStore.Submit(err)
-}
-
-func (u *unhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
-	items := u.timeWindowedStore.ItemsInWindow()
-	for _, item := range items {
-		if item.Item != nil {
-			return whealth.UnhealthyHealthCheckResult(u.checkType, item.Item.(error).Error())
-		}
+	if err == nil {
+		return
 	}
-	return whealth.HealthyHealthCheckResult(u.checkType)
+	u.source.Submit(err)
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
 func (u *unhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
-	return health.HealthStatus{
-		Checks: map[health.CheckType]health.HealthCheckResult{
-			u.checkType: u.itemsToCheck(),
-		},
-	}
+	return u.source.HealthStatus(ctx)
 }
 
 // healthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
 // It returns, if there are only non-nil errors, the first non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
 type healthyIfNotAllErrorsSource struct {
-	timeWindowedStore *TimeWindowedStore
-	checkType         health.CheckType
+	windowSize      time.Duration
+	lastErrorTime   time.Time
+	lastError       error
+	lastSuccessTime time.Time
+	sourceMutex     sync.RWMutex
+	checkType       health.CheckType
 }
 
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
@@ -112,39 +106,43 @@ func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize t
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
 func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
-	if err != nil {
-		return nil, err
+	if windowSize <= 0 {
+		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &healthyIfNotAllErrorsSource{
-		timeWindowedStore: timeWindowedStore,
-		checkType:         checkType,
+		windowSize: windowSize,
+		checkType:  checkType,
 	}, nil
 }
 
 // Submit submits an error.
 func (h *healthyIfNotAllErrorsSource) Submit(err error) {
-	h.timeWindowedStore.Submit(err)
-}
-
-func (h *healthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
-	items := h.timeWindowedStore.ItemsInWindow()
-	if len(items) == 0 {
-		return whealth.HealthyHealthCheckResult(h.checkType)
+	h.sourceMutex.Lock()
+	defer h.sourceMutex.Unlock()
+	if err != nil {
+		h.lastError = err
+		h.lastErrorTime = time.Now()
+	} else {
+		h.lastSuccessTime = time.Now()
 	}
-	for _, item := range items {
-		if item.Item == nil {
-			return whealth.HealthyHealthCheckResult(h.checkType)
-		}
-	}
-	return whealth.UnhealthyHealthCheckResult(h.checkType, items[0].Item.(error).Error())
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
 func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	h.sourceMutex.RLock()
+	defer h.sourceMutex.RUnlock()
+	var healthCheckResult health.HealthCheckResult
+	curTime := time.Now()
+	if !h.lastSuccessTime.IsZero() && curTime.Sub(h.lastSuccessTime) < h.windowSize {
+		healthCheckResult = whealth.HealthyHealthCheckResult(h.checkType)
+	} else if h.lastError != nil && !h.lastErrorTime.IsZero() && curTime.Sub(h.lastErrorTime) < h.windowSize {
+		healthCheckResult = whealth.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error())
+	} else {
+		healthCheckResult = whealth.HealthyHealthCheckResult(h.checkType)
+	}
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
-			h.checkType: h.itemsToCheck(),
+			h.checkType: healthCheckResult,
 		},
 	}
 }

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -135,7 +135,7 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 	curTime := time.Now()
 	if !h.lastSuccessTime.IsZero() && curTime.Sub(h.lastSuccessTime) < h.windowSize {
 		healthCheckResult = whealth.HealthyHealthCheckResult(h.checkType)
-	} else if h.lastError != nil && !h.lastErrorTime.IsZero() && curTime.Sub(h.lastErrorTime) < h.windowSize {
+	} else if !h.lastErrorTime.IsZero() && curTime.Sub(h.lastErrorTime) < h.windowSize {
 		healthCheckResult = whealth.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error())
 	} else {
 		healthCheckResult = whealth.HealthyHealthCheckResult(h.checkType)

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -59,7 +59,7 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				werror.Error("Error #2"),
 				nil,
 			},
-			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #1"),
+			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -116,7 +116,7 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 				werror.Error("Error #1"),
 				werror.Error("Error #2"),
 			},
-			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #1"),
+			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -16,8 +16,10 @@ package window
 
 import (
 	"context"
+	"sync"
 	"time"
 
+	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-server/status"
 	whealth "github.com/palantir/witchcraft-go-server/status/health"
@@ -40,14 +42,14 @@ type keyErrorPair struct {
 	err error
 }
 
-// multiKeyUnhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
-// It returns unhealthy if there is a non-nil error for at least one key.
-// The Params field of the HealthCheckResult is the first error message for each key mapped by the key for all unhealthy keys.
-// If there are no items, returns healthy.
+// multiKeyUnhealthyIfAtLeastOneErrorSource is a HealthCheckSource that keeps the latest errors
+// for multiple keys submitted within the last windowSize time frame.
+// It returns unhealthy if there is a non-nil error for at least one key within the last windowSize time frame.
+// The Params field of the HealthCheckResult is the last error message for each key mapped by the key for all unhealthy keys.
+// If there are no items within the last windowSize time frame, returns healthy.
 type multiKeyUnhealthyIfAtLeastOneErrorSource struct {
-	timeWindowedStore    *TimeWindowedStore
-	checkType            health.CheckType
-	messageInCaseOfError string
+	// multiKeyUnhealthyIfAtLeastOneErrorSource is a multiKeyHealthyIfNotAllErrorsSource that drops all successes.
+	source KeyedErrorHealthCheckSource
 }
 
 // MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource returns the result of calling NewMultiKeyUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
@@ -64,63 +66,39 @@ func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType,
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
 func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
-	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
+	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		return nil, err
 	}
 	return &multiKeyUnhealthyIfAtLeastOneErrorSource{
-		timeWindowedStore:    timeWindowedStore,
-		checkType:            checkType,
-		messageInCaseOfError: messageInCaseOfError,
+		source: source,
 	}, nil
 }
 
 // Submit submits an item as a key error pair.
 func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) Submit(key string, err error) {
-	m.timeWindowedStore.Submit(keyErrorPair{
-		key: key,
-		err: err,
-	})
-}
-
-func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) itemsToCheck() health.HealthCheckResult {
-	items := m.timeWindowedStore.ItemsInWindow()
-	params := make(map[string]interface{})
-	for _, item := range items {
-		keyErrorPair := item.Item.(keyErrorPair)
-		if keyErrorPair.err == nil {
-			continue
-		}
-		if _, alreadyHasError := params[keyErrorPair.key]; !alreadyHasError {
-			params[keyErrorPair.key] = keyErrorPair.err.Error()
-		}
+	if err == nil {
+		return
 	}
-	if len(params) > 0 {
-		return health.HealthCheckResult{
-			Type:    m.checkType,
-			State:   health.HealthStateError,
-			Message: &m.messageInCaseOfError,
-			Params:  params,
-		}
-	}
-	return whealth.HealthyHealthCheckResult(m.checkType)
+	m.source.Submit(key, err)
 }
 
 // HealthStatus polls the items inside the window and creates the HealthStatus.
 func (m *multiKeyUnhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) health.HealthStatus {
-	return health.HealthStatus{
-		Checks: map[health.CheckType]health.HealthCheckResult{
-			m.checkType: m.itemsToCheck(),
-		},
-	}
+	return m.source.HealthStatus(ctx)
 }
 
-// multiKeyHealthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
-// It returns unhealthy if there is at least one key with only non-nil errors.
-// The Params field of the HealthCheckResult is the first error message for each key mapped by the key for all unhealthy keys.
-// If there are no items, returns healthy.
+// multiKeyHealthyIfNotAllErrorsSource is a HealthCheckSource that keeps the latest errors
+// for multiple keys submitted within the last windowSize time frame.
+// It returns unhealthy if there is at least one key with only non-nil errors within the last windowSize time frame.
+// The Params field of the HealthCheckResult is the last error message for each key mapped by the key for all unhealthy keys.
+// If there are no items within the last windowSize time frame, returns healthy.
 type multiKeyHealthyIfNotAllErrorsSource struct {
-	timeWindowedStore    *TimeWindowedStore
+	windowSize           time.Duration
+	errorStore           TimedKeyStore
+	successStore         TimedKeyStore
+	lastError            map[string]error
+	sourceMutex          sync.Mutex
 	checkType            health.CheckType
 	messageInCaseOfError string
 }
@@ -141,12 +119,14 @@ func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, mess
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
 func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
-	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
-	if err != nil {
-		return nil, err
+	if windowSize <= 0 {
+		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &multiKeyHealthyIfNotAllErrorsSource{
-		timeWindowedStore:    timeWindowedStore,
+		windowSize:           windowSize,
+		errorStore:           NewTimedKeyStore(),
+		successStore:         NewTimedKeyStore(),
+		lastError:            make(map[string]error),
 		checkType:            checkType,
 		messageInCaseOfError: messageInCaseOfError,
 	}, nil
@@ -154,46 +134,70 @@ func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageI
 
 // Submit submits an item as a key error pair.
 func (m *multiKeyHealthyIfNotAllErrorsSource) Submit(key string, err error) {
-	m.timeWindowedStore.Submit(keyErrorPair{
-		key: key,
-		err: err,
-	})
+	m.sourceMutex.Lock()
+	defer m.sourceMutex.Unlock()
+
+	m.pruneOldKeys(m.errorStore, m.lastError)
+	m.pruneOldKeys(m.successStore, nil)
+
+	if err == nil {
+		m.successStore.Add(key)
+	} else {
+		m.lastError[key] = err
+		m.errorStore.Add(key)
+	}
 }
 
-func (m *multiKeyHealthyIfNotAllErrorsSource) itemsToCheck() health.HealthCheckResult {
-	items := m.timeWindowedStore.ItemsInWindow()
+// HealthStatus polls the items inside the window and creates the HealthStatus.
+func (m *multiKeyHealthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	m.sourceMutex.Lock()
+	defer m.sourceMutex.Unlock()
+
+	m.pruneOldKeys(m.errorStore, m.lastError)
+	m.pruneOldKeys(m.successStore, nil)
+
 	params := make(map[string]interface{})
-	hasSuccess := make(map[string]struct{})
-	for _, item := range items {
-		keyErrorPair := item.Item.(keyErrorPair)
-		if _, keyHasSuccess := hasSuccess[keyErrorPair.key]; keyHasSuccess {
+	for _, key := range m.errorStore.List().Keys() {
+		if _, hasSuccess := m.successStore.Get(key); hasSuccess {
 			continue
 		}
-		if keyErrorPair.err == nil {
-			delete(params, keyErrorPair.key)
-			hasSuccess[keyErrorPair.key] = struct{}{}
-			continue
-		}
-		if _, alreadyHasError := params[keyErrorPair.key]; !alreadyHasError {
-			params[keyErrorPair.key] = keyErrorPair.err.Error()
-		}
+		params[key] = m.lastError[key].Error()
 	}
+
+	var healthCheckResult health.HealthCheckResult
 	if len(params) > 0 {
-		return health.HealthCheckResult{
+		healthCheckResult = health.HealthCheckResult{
 			Type:    m.checkType,
 			State:   health.HealthStateError,
 			Message: &m.messageInCaseOfError,
 			Params:  params,
 		}
+	} else {
+		healthCheckResult = whealth.HealthyHealthCheckResult(m.checkType)
 	}
-	return whealth.HealthyHealthCheckResult(m.checkType)
-}
 
-// HealthStatus polls the items inside the window and creates the HealthStatus.
-func (m *multiKeyHealthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.HealthStatus {
 	return health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
-			m.checkType: m.itemsToCheck(),
+			m.checkType: healthCheckResult,
 		},
+	}
+}
+
+func (m *multiKeyHealthyIfNotAllErrorsSource) pruneOldKeys(store TimedKeyStore, errors map[string]error) {
+	curTime := time.Now()
+	for {
+		oldest, exists := store.Oldest()
+		if !exists {
+			return
+		}
+
+		if curTime.Sub(oldest.Time) < m.windowSize {
+			return
+		}
+
+		store.Remove(oldest.Key)
+		if errors != nil {
+			delete(errors, oldest.Key)
+		}
 	}
 }

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -30,7 +30,7 @@ type KeyedErrorSubmitter interface {
 	Submit(key string, err error)
 }
 
-// ErrorHealthCheckSource is a health check source with statuses determined by submitted key error pairs.
+// KeyedErrorHealthCheckSource is a health check source with statuses determined by submitted key error pairs.
 type KeyedErrorHealthCheckSource interface {
 	KeyedErrorSubmitter
 	status.HealthCheckSource

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type keyErrorPair struct {
+	key string
+	err error
+}
+
 func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 	messageInCaseOfError := "message in case of error"
 	for _, testCase := range []struct {

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -82,7 +82,7 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 				Message: &messageInCaseOfError,
 				Params: map[string]interface{}{
 					"1": "Error #1 for key 1",
-					"2": "Error #1 for key 2",
+					"2": "Error #2 for key 2",
 					"3": "Error #1 for key 3",
 				},
 			},
@@ -156,7 +156,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 				Message: &messageInCaseOfError,
 				Params: map[string]interface{}{
 					"1": "Error #1 for key 1",
-					"2": "Error #1 for key 2",
+					"2": "Error #2 for key 2",
 				},
 			},
 		},
@@ -174,7 +174,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 				Message: &messageInCaseOfError,
 				Params: map[string]interface{}{
 					"1": "Error #1 for key 1",
-					"2": "Error #1 for key 2",
+					"2": "Error #2 for key 2",
 					"3": "Error #1 for key 3",
 				},
 			},

--- a/status/health/window/timed_key_store.go
+++ b/status/health/window/timed_key_store.go
@@ -40,12 +40,12 @@ func (t TimedKeys) Keys() []string {
 // Each key is unique within the store. Adding an already present key will cause the time of the key to be updated to
 // the current time. The position within the list will be updated accordingly.
 type TimedKeyStore interface {
-	// Add adds a new TimedKey to the end of the list with the timestamp set to the current time.
+	// Put adds a new TimedKey to the end of the list with the timestamp set to the current time.
 	// Adding an already present key will cause the current TimedKey to be updated to the current and to be sent to the end of the list.
-	Add(key string)
-	// Remove removes a TimedKey from the list. If the key doesn't exist, it is a no op.
+	Put(key string)
+	// Delete removes a TimedKey from the list. If the key doesn't exist, it is a no op.
 	// The second return value returns whether or not the key existed within the store.
-	Remove(key string) bool
+	Delete(key string) bool
 	// Get returns the TimedKey associated with the provided key if it exists. Returns empty struct otherwise.
 	// The second return value returns whether or not the key exists within the store.
 	Get(key string) (TimedKey, bool)
@@ -91,8 +91,8 @@ func NewTimedKeyStore() TimedKeyStore {
 	}
 }
 
-func (t *timedKeyStore) Add(key string) {
-	_ = t.Remove(key)
+func (t *timedKeyStore) Put(key string) {
+	_ = t.Delete(key)
 	timedKey := TimedKey{
 		Key:  key,
 		Time: time.Now(),
@@ -107,7 +107,7 @@ func (t *timedKeyStore) Add(key string) {
 	t.nodeByKey[key] = node
 }
 
-func (t *timedKeyStore) Remove(key string) bool {
+func (t *timedKeyStore) Delete(key string) bool {
 	node, exists := t.nodeByKey[key]
 	if !exists {
 		return false

--- a/status/health/window/timed_key_store.go
+++ b/status/health/window/timed_key_store.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"time"
+)
+
+// TimedKey is a pair of a key and a timestamp.
+type TimedKey struct {
+	Key  string
+	Time time.Time
+}
+
+// TimedKeys is a list of TimedKey objects.
+type TimedKeys []TimedKey
+
+// Keys converts the list of TimedKey objects into a list of keys preserving the order.
+func (t TimedKeys) Keys() []string {
+	var keys []string
+	for _, timedKey := range t {
+		keys = append(keys, timedKey.Key)
+	}
+	return keys
+}
+
+// TimedKeyStore is a list of keys ordered by the time they were added or updated.
+// Each key is unique within the store. Adding an already present key will cause the time of the key to be updated to
+// the current time. The position within the list will be updated accordingly.
+type TimedKeyStore interface {
+	// Add adds a new TimedKey to the end of the list with the timestamp set to the current time.
+	// Adding an already present key will cause the current TimedKey to be updated to the current and to be sent to the end of the list.
+	Add(key string)
+	// Remove removes a TimedKey from the list. If the key doesn't exist, it is a no op.
+	// The second return value returns whether or not the key existed within the store.
+	Remove(key string) bool
+	// Get returns the TimedKey associated with the provided key if it exists. Returns empty struct otherwise.
+	// The second return value returns whether or not the key exists within the store.
+	Get(key string) (TimedKey, bool)
+	// Get returns a list of all stored TimedKeys in increasing order of timestamps.
+	List() TimedKeys
+	// Oldest returns the stored TimedKey with the oldest timestamp if it exists. Returns empty struct otherwise.
+	// The second return value returns whether or not such element exist.
+	Oldest() (TimedKey, bool)
+	// Newest returns the stored TimedKey with the newest timestamp if it exists. Returns empty struct otherwise.
+	// The second return value returns whether or not such element exist.
+	Newest() (TimedKey, bool)
+}
+
+// keyNode is a node in double linked list that holds a TimedKey.
+type keyNode struct {
+	prev     *keyNode
+	next     *keyNode
+	timedKey TimedKey
+}
+
+// timedKeyStore is an implementation of a TimedKeyStore using a map and a double linked list.
+// begin and end are extra nodes that are before the first element and after the last one, respectively.
+// They point to each other when the list is empty.
+type timedKeyStore struct {
+	begin     *keyNode
+	end       *keyNode
+	nodeByKey map[string]*keyNode
+}
+
+// NewTimedKeyStore creates a TimedKeyStore that executes all operations in O(1) time except
+// for List, which is O(n), where n is the number of stored keys.
+// Memory consumption is O(n), where n is the number of stored keys.
+// This struct is not thread safe.
+func NewTimedKeyStore() TimedKeyStore {
+	begin := &keyNode{}
+	end := &keyNode{}
+	begin.next = end
+	end.prev = begin
+	return &timedKeyStore{
+		begin:     begin,
+		end:       end,
+		nodeByKey: make(map[string]*keyNode),
+	}
+}
+
+func (t *timedKeyStore) Add(key string) {
+	_ = t.Remove(key)
+	timedKey := TimedKey{
+		Key:  key,
+		Time: time.Now(),
+	}
+	node := &keyNode{
+		prev:     t.end.prev,
+		next:     t.end,
+		timedKey: timedKey,
+	}
+	node.prev.next = node
+	node.next.prev = node
+	t.nodeByKey[key] = node
+}
+
+func (t *timedKeyStore) Remove(key string) bool {
+	node, exists := t.nodeByKey[key]
+	if !exists {
+		return false
+	}
+	delete(t.nodeByKey, key)
+	node.prev.next = node.next
+	node.next.prev = node.prev
+	return true
+}
+
+func (t *timedKeyStore) Get(key string) (TimedKey, bool) {
+	node, exists := t.nodeByKey[key]
+	if !exists {
+		return TimedKey{}, false
+	}
+	return node.timedKey, true
+}
+
+func (t *timedKeyStore) List() TimedKeys {
+	var timedKeys TimedKeys
+	for node := t.begin.next; node != t.end; node = node.next {
+		timedKeys = append(timedKeys, node.timedKey)
+	}
+	return timedKeys
+}
+
+func (t *timedKeyStore) Oldest() (TimedKey, bool) {
+	if t.begin.next == t.end {
+		return TimedKey{}, false
+	}
+	return t.begin.next.timedKey, true
+}
+
+func (t *timedKeyStore) Newest() (TimedKey, bool) {
+	if t.end.prev == t.begin {
+		return TimedKey{}, false
+	}
+	return t.end.prev.timedKey, true
+}

--- a/status/health/window/timed_key_store_test.go
+++ b/status/health/window/timed_key_store_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2019 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package window
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func assertStoreContent(t *testing.T, store TimedKeyStore, list []string, subtestName string) {
+	t.Run(subtestName, func(t *testing.T) {
+		if len(list) > 0 {
+			assert.Equal(t, list, store.List().Keys())
+		} else {
+			assert.Nil(t, store.List())
+		}
+
+		oldest, nonEmpty := store.Oldest()
+		if len(list) > 0 {
+			assert.Equal(t, list[0], oldest.Key)
+			assert.True(t, nonEmpty)
+		} else {
+			assert.False(t, nonEmpty)
+		}
+
+		newest, nonEmpty := store.Newest()
+		if len(list) > 0 {
+			assert.Equal(t, list[len(list)-1], newest.Key)
+			assert.True(t, nonEmpty)
+		} else {
+			assert.False(t, nonEmpty)
+		}
+
+		var lastTime time.Time
+		for _, key := range list {
+			timedKey, exists := store.Get(key)
+			assert.True(t, exists)
+			assert.Equal(t, key, timedKey.Key)
+			assert.True(t, lastTime.Before(timedKey.Time))
+			lastTime = timedKey.Time
+		}
+	})
+}
+
+func TestTimedKeyStore(t *testing.T) {
+	store := NewTimedKeyStore()
+	assertStoreContent(t, store, []string{}, "store initially empty")
+
+	store.Remove("a")
+	assertStoreContent(t, store, []string{}, "removed unexisting key from empty store")
+
+	store.Add("a")
+	assertStoreContent(t, store, []string{"a"}, "added a single key a")
+
+	store.Remove("a")
+	assertStoreContent(t, store, []string{}, "removed a single key a")
+
+	store.Add("b")
+	assertStoreContent(t, store, []string{"b"}, "added a single key b")
+
+	store.Add("c")
+	assertStoreContent(t, store, []string{"b", "c"}, "added a second key c")
+
+	store.Add("b")
+	assertStoreContent(t, store, []string{"c", "b"}, "updated key b")
+
+	store.Remove("d")
+	assertStoreContent(t, store, []string{"c", "b"}, "removed unexisting key from non empty store")
+
+	store.Add("e")
+	assertStoreContent(t, store, []string{"c", "b", "e"}, "added a third key e")
+
+	store.Remove("b")
+	assertStoreContent(t, store, []string{"c", "e"}, "removed key b from the middle of the list")
+
+	store.Add("d")
+	assertStoreContent(t, store, []string{"c", "e", "d"}, "added a new key d")
+
+	store.Remove("d")
+	assertStoreContent(t, store, []string{"c", "e"}, "removed newest key d")
+
+	store.Remove("c")
+	assertStoreContent(t, store, []string{"e"}, "removed oldest key c")
+
+	store.Remove("e")
+	assertStoreContent(t, store, []string{}, "removed the last key e")
+}

--- a/status/health/window/timed_key_store_test.go
+++ b/status/health/window/timed_key_store_test.go
@@ -60,42 +60,42 @@ func TestTimedKeyStore(t *testing.T) {
 	store := NewTimedKeyStore()
 	assertStoreContent(t, store, []string{}, "store initially empty")
 
-	store.Remove("a")
+	store.Delete("a")
 	assertStoreContent(t, store, []string{}, "removed unexisting key from empty store")
 
-	store.Add("a")
+	store.Put("a")
 	assertStoreContent(t, store, []string{"a"}, "added a single key a")
 
-	store.Remove("a")
+	store.Delete("a")
 	assertStoreContent(t, store, []string{}, "removed a single key a")
 
-	store.Add("b")
+	store.Put("b")
 	assertStoreContent(t, store, []string{"b"}, "added a single key b")
 
-	store.Add("c")
+	store.Put("c")
 	assertStoreContent(t, store, []string{"b", "c"}, "added a second key c")
 
-	store.Add("b")
+	store.Put("b")
 	assertStoreContent(t, store, []string{"c", "b"}, "updated key b")
 
-	store.Remove("d")
+	store.Delete("d")
 	assertStoreContent(t, store, []string{"c", "b"}, "removed unexisting key from non empty store")
 
-	store.Add("e")
+	store.Put("e")
 	assertStoreContent(t, store, []string{"c", "b", "e"}, "added a third key e")
 
-	store.Remove("b")
+	store.Delete("b")
 	assertStoreContent(t, store, []string{"c", "e"}, "removed key b from the middle of the list")
 
-	store.Add("d")
+	store.Put("d")
 	assertStoreContent(t, store, []string{"c", "e", "d"}, "added a new key d")
 
-	store.Remove("d")
+	store.Delete("d")
 	assertStoreContent(t, store, []string{"c", "e"}, "removed newest key d")
 
-	store.Remove("c")
+	store.Delete("c")
 	assertStoreContent(t, store, []string{"e"}, "removed oldest key c")
 
-	store.Remove("e")
+	store.Delete("e")
 	assertStoreContent(t, store, []string{}, "removed the last key e")
 }


### PR DESCRIPTION
## Before this PR
The "Healthy if not all errors" and "Unhealthy if at least one error" and its multi key versions health checks have a memory consumption of `O(number of events in the window)`. Although this is required for the generic BaseWindowHealthCheckSource, it is not required for these ones.

## After this PR
Optimized the mentioned health sources to work in `O(1)` memory for the single key versions and `O(min(number of events in the window, number of keys))` memory for the multi key versions.
Changed the "Unhealthy if at least one error" health checks sources to forward calls to "Healthy if not all errors" sources. This greatly simplifies the code.
Added a TimedKeyStore helper that can be used on custom implementations.
Changed the error message shown to be the last in the window instead of the first.
==COMMIT_MSG==
Optimize window based health check source memory consumption. Error message shown is now the last in the window and not the first.
==COMMIT_MSG==

## Possible downsides?
Higher overhead (complexity multiplicative constant) due to the double linked list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/141)
<!-- Reviewable:end -->
