### PR TITLE
Feature: add configuration to set unmarshal mode to strict

### DIFF
--- a/changelog/@unreleased/pr-142.v2.yml
+++ b/changelog/@unreleased/pr-142.v2.yml
@@ -1,0 +1,9 @@
+type: feature
+feature:
+  description: |-
+    Add configuration to set unmarshal mode to strict
+
+    When configuration is set to true, configuration unmarshal is
+    done in "strict" mode, which treats unknown keys as errors.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/142

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -461,7 +461,7 @@ invalid-key: invalid-value
 		return createTestServer(t, initFn, installCfg, logOutputBuffer).
 			WithRuntimeConfigProvider(runtimeConfigRefreshable).
 			WithDisableGoRuntimeMetrics().
-			WithStrictUnmarshalConfig(true)
+			WithStrictUnmarshalConfig()
 	})
 
 	defer func() {

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -356,8 +356,9 @@ func TestHealthSharedSecret(t *testing.T) {
 	}
 }
 
-// TestRuntimeConfigReloadHealth verifies that an invalid runtime config produces an error health check.
-func TestRuntimeConfigReloadHealth(t *testing.T) {
+// TestRuntimeConfigReloadHealth verifies that runtime configuration that is invalid when strict unmarshal mode is true
+// does not produces an error health check if strict unmarshal mode is not specified (since default value is false).
+func TestRuntimeConfigReloadHealthWithStrictUnmarshalFalse(t *testing.T) {
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
 
@@ -372,6 +373,95 @@ invalid-key: invalid-value
 		return createTestServer(t, initFn, installCfg, logOutputBuffer).
 			WithRuntimeConfigProvider(runtimeConfigRefreshable).
 			WithDisableGoRuntimeMetrics()
+	})
+
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	client := testServerClient()
+	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.HealthEndpoint), nil)
+	require.NoError(t, err)
+	resp, err := client.Do(request)
+	require.NoError(t, err)
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var healthResults health.HealthStatus
+	err = json.Unmarshal(bytes, &healthResults)
+	require.NoError(t, err)
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			health.CheckType("CONFIG_RELOAD"): {
+				Type:   health.CheckType("CONFIG_RELOAD"),
+				State:  health.HealthStateHealthy,
+				Params: make(map[string]interface{}),
+			},
+			health.CheckType("SERVER_STATUS"): {
+				Type:   health.CheckType("SERVER_STATUS"),
+				State:  reporter.HealthyState,
+				Params: make(map[string]interface{}),
+			},
+		},
+	}, healthResults)
+
+	// write invalid runtime config and observe health check go unhealthy
+	err = runtimeConfigRefreshable.Update([]byte(invalidCfgYML))
+	require.NoError(t, err)
+	time.Sleep(500 * time.Millisecond)
+
+	request, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.HealthEndpoint), nil)
+	require.NoError(t, err)
+	resp, err = client.Do(request)
+	require.NoError(t, err)
+
+	bytes, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	err = json.Unmarshal(bytes, &healthResults)
+	require.NoError(t, err)
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			health.CheckType("CONFIG_RELOAD"): {
+				Type:   health.CheckType("CONFIG_RELOAD"),
+				State:  health.HealthStateHealthy,
+				Params: make(map[string]interface{}),
+			},
+			health.CheckType("SERVER_STATUS"): {
+				Type:   health.CheckType("SERVER_STATUS"),
+				State:  reporter.HealthyState,
+				Params: make(map[string]interface{}),
+			},
+		},
+	}, healthResults)
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestRuntimeConfigReloadHealth verifies that runtime configuration that is invalid when strict unmarshal mode is true
+// produces an error health check.
+func TestRuntimeConfigReloadHealthWithStrictUnmarshalTrue(t *testing.T) {
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+
+	validCfgYML := `logging:
+  level: info
+`
+	invalidCfgYML := `
+invalid-key: invalid-value
+`
+	runtimeConfigRefreshable := refreshable.NewDefaultRefreshable([]byte(validCfgYML))
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, nil, ioutil.Discard, func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).
+			WithRuntimeConfigProvider(runtimeConfigRefreshable).
+			WithDisableGoRuntimeMetrics().
+			WithStrictUnmarshalConfig(true)
 	})
 
 	defer func() {

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -456,7 +456,7 @@ exclamations: 4
 			info.RuntimeConfig.Subscribe(setCfg)
 			return nil, nil
 		}).
-		WithStrictUnmarshalConfig(true)
+		WithStrictUnmarshalConfig()
 
 	serverChan := make(chan error)
 	go func() {

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -241,9 +241,9 @@ func TestRuntimeReloadWithNilLoggerConfig(t *testing.T) {
 	}
 }
 
-// TestRuntimeReloadWithInvalidConfig verifies that reloading runtime configuration with invalid config produces an
-// unhealthy health check and uses the last known valid config.
-func TestRuntimeReloadWithInvalidConfig(t *testing.T) {
+// TestRuntimeReloadWithConfigWithExtraKeyDefaultUnmarshal verifies that reloading runtime configuration with an unknown
+// key succeeds when server is in its default mode.
+func TestRuntimeReloadWithConfigWithUnknownKeyDefaultUnmarshal(t *testing.T) {
 	testDir, cleanup, err := dirs.TempDir("", "")
 	require.NoError(t, err)
 	defer cleanup()
@@ -353,9 +353,141 @@ exclamations: 4
 	// Assert our configuration was set to the initial values
 	assert.Equal(t, validCfg1, currCfg)
 
+	// Assert that, in default mode, configuration with extra key is considered valid: extra value should be ignored,
+	// and "missing" values should be default values
+	invalidRuntimeConfig := testRuntimeConfig{
+		Runtime:        config.Runtime{},
+		SecretGreeting: "",
+		Exclamations:   0,
+	}
+
+	err = ioutil.WriteFile(runtimeYML, []byte("invalid-key: \"invalid-value\""), 0644)
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, invalidRuntimeConfig, currCfg)
+
+	// Update config to different config and assert that our subscription overwrites the value
+	err = ioutil.WriteFile(runtimeYML, []byte(validCfg2YML), 0644)
+	require.NoError(t, err)
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, validCfg2, currCfg)
+}
+
+// TestRuntimeReloadWithConfigWithExtraKeyStrictUnmarshal verifies that reloading runtime configuration with an unknown
+// key fails and uses last known valid config when server is in strict unmarshal mode.
+func TestRuntimeReloadWithConfigWithExtraKeyStrictUnmarshal(t *testing.T) {
+	testDir, cleanup, err := dirs.TempDir("", "")
+	require.NoError(t, err)
+	defer cleanup()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() {
+		err := os.Chdir(wd)
+		require.NoError(t, err)
+	}()
+
+	err = os.Chdir(testDir)
+	require.NoError(t, err)
+
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+
+	err = os.MkdirAll("var/conf", 0755)
+	require.NoError(t, err)
+
+	const validCfg1YML = `
+logging:
+  level: debug
+exclamations: 3
+`
+	validCfg1 := testRuntimeConfig{
+		Runtime: config.Runtime{
+			LoggerConfig: &config.LoggerConfig{
+				Level: wlog.DebugLevel,
+			},
+		},
+		Exclamations: 3,
+	}
+	const invalidYML = `
+invalid-key: invalid-value
+`
+	const validCfg2YML = `
+logging:
+  level: info
+exclamations: 4
+`
+	validCfg2 := testRuntimeConfig{
+		Runtime: config.Runtime{
+			LoggerConfig: &config.LoggerConfig{
+				Level: wlog.InfoLevel,
+			},
+		},
+		Exclamations: 4,
+	}
+
+	err = ioutil.WriteFile(runtimeYML, []byte(validCfg1YML), 0644)
+	require.NoError(t, err)
+
+	var currCfg testRuntimeConfig
+
+	server := witchcraft.NewServer().
+		WithRuntimeConfigType(testRuntimeConfig{}).
+		WithInstallConfig(config.Install{
+			ProductName:   productName,
+			UseConsoleLog: true,
+			Server: config.Server{
+				Address:     "localhost",
+				Port:        port,
+				ContextPath: basePath,
+			},
+		}).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate().
+		WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo) (cleanupFn func(), rErr error) {
+			setCfg := func(cfgI interface{}) {
+				cfg, ok := cfgI.(testRuntimeConfig)
+				if !ok {
+					panic(fmt.Errorf("unable to cast runtime config of type %T to testRuntimeConfig", cfgI))
+				}
+				currCfg = cfg
+			}
+			setCfg(info.RuntimeConfig.Current())
+			info.RuntimeConfig.Subscribe(setCfg)
+			return nil, nil
+		}).
+		WithStrictUnmarshalConfig(true)
+
+	serverChan := make(chan error)
+	go func() {
+		serverChan <- server.Start()
+	}()
+
+	select {
+	case err := <-serverChan:
+		require.NoError(t, err)
+	default:
+	}
+
+	ready := <-waitForTestServerReady(port, path.Join(basePath, status.LivenessEndpoint), 5*time.Second)
+	if !ready {
+		errMsg := "timed out waiting for server to start"
+		select {
+		case err := <-serverChan:
+			errMsg = fmt.Sprintf("%s: %+v", errMsg, err)
+		}
+		require.Fail(t, errMsg)
+	}
+
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+
+	// Assert our configuration was set to the initial values
+	assert.Equal(t, validCfg1, currCfg)
+
 	// Assert that introducing invalid config does not change the stored config
-	invalidRuntimeConfig := "invalid-key: \"invalid-value\""
-	err = ioutil.WriteFile(runtimeYML, []byte(invalidRuntimeConfig), 0644)
+	err = ioutil.WriteFile(runtimeYML, []byte("invalid-key: \"invalid-value\""), 0644)
 	require.NoError(t, err)
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, validCfg1, currCfg)

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -167,9 +167,9 @@ type Server struct {
 	// disableKeepAlives disables keep-alives.
 	disableKeepAlives bool
 
-	// if true, strict YAML unmarshaling is used when unmarshaling install and runtime configuration. This means that
-	// unknown keys will be treated as errors rather than being ignored.
-	strictUnmarshalConfig bool
+	// configYAMLUnmarshalFn is the function used to unmarshal YAML configuration. By default, this is yaml.Unmarshal.
+	// If WithStrictUnmarshalConfig is called, this is set to yaml.UnmarshalStrict.
+	configYAMLUnmarshalFn func(in []byte, out interface{}) (err error)
 
 	// request logger configuration
 
@@ -445,8 +445,8 @@ func (s *Server) WithDisableKeepAlives() *Server {
 }
 
 // WithStrictUnmarshalConfig configures the server to use the provided strict unmarshal configuration.
-func (s *Server) WithStrictUnmarshalConfig(strictUnmarshalConfig bool) *Server {
-	s.strictUnmarshalConfig = strictUnmarshalConfig
+func (s *Server) WithStrictUnmarshalConfig() *Server {
+	s.configYAMLUnmarshalFn = yaml.UnmarshalStrict
 	return s
 }
 
@@ -548,6 +548,11 @@ func (s *Server) Start() (rErr error) {
 	// set provider for ECV key
 	if s.ecvKeyProvider == nil {
 		s.ecvKeyProvider = ECVKeyFromFile(ecvKeyPath)
+	}
+
+	// if config unmarshal function is not set, default to yaml.Unmarshal
+	if s.configYAMLUnmarshalFn == nil {
+		s.configYAMLUnmarshalFn = yaml.Unmarshal
 	}
 
 	// load install configuration
@@ -729,11 +734,7 @@ func (s *Server) initInstallConfig() (config.Install, interface{}, error) {
 	}
 	specificInstallCfg := reflect.New(reflect.TypeOf(installConfigStruct)).Interface()
 
-	unmarshalYAMLFn := yaml.Unmarshal
-	if s.strictUnmarshalConfig {
-		unmarshalYAMLFn = yaml.UnmarshalStrict
-	}
-	if err := unmarshalYAMLFn(cfgBytes, *&specificInstallCfg); err != nil {
+	if err := s.configYAMLUnmarshalFn(cfgBytes, *&specificInstallCfg); err != nil {
 		return config.Install{}, nil, werror.Wrap(err, "Failed to unmarshal install specific configuration YAML")
 	}
 	return baseInstallCfg, reflect.Indirect(reflect.ValueOf(specificInstallCfg)).Interface(), nil
@@ -760,11 +761,6 @@ func (s *Server) initRuntimeConfig(ctx context.Context) (rBaseCfg refreshableBas
 		return cfgBytes
 	})
 
-	unmarshalYAMLFn := yaml.Unmarshal
-	if s.strictUnmarshalConfig {
-		unmarshalYAMLFn = yaml.UnmarshalStrict
-	}
-
 	validatedRuntimeConfig, err := refreshable.NewValidatingRefreshable(
 		runtimeConfigProvider,
 		func(cfgBytesVal interface{}) error {
@@ -773,7 +769,7 @@ func (s *Server) initRuntimeConfig(ctx context.Context) (rBaseCfg refreshableBas
 				runtimeConfigStruct = config.Runtime{}
 			}
 			runtimeCfg := reflect.New(reflect.TypeOf(runtimeConfigStruct)).Interface()
-			return unmarshalYAMLFn(cfgBytesVal.([]byte), *&runtimeCfg)
+			return s.configYAMLUnmarshalFn(cfgBytesVal.([]byte), *&runtimeCfg)
 		})
 	if err != nil {
 		return nil, nil, nil, err
@@ -785,7 +781,7 @@ func (s *Server) initRuntimeConfig(ctx context.Context) (rBaseCfg refreshableBas
 
 	baseRuntimeConfig := newRefreshableBaseRuntimeConfig(validatedRuntimeConfig.Map(func(cfgBytesVal interface{}) interface{} {
 		var runtimeCfg config.Runtime
-		if err := yaml.Unmarshal(cfgBytesVal.([]byte), &runtimeCfg); err != nil {
+		if err := s.configYAMLUnmarshalFn(cfgBytesVal.([]byte), &runtimeCfg); err != nil {
 			s.svcLogger.Error("Failed to unmarshal runtime configuration", svc1log.Stacktrace(err))
 		}
 		return runtimeCfg
@@ -797,7 +793,7 @@ func (s *Server) initRuntimeConfig(ctx context.Context) (rBaseCfg refreshableBas
 			runtimeConfigStruct = config.Runtime{}
 		}
 		runtimeCfg := reflect.New(reflect.TypeOf(runtimeConfigStruct)).Interface()
-		if err := unmarshalYAMLFn(cfgBytesVal.([]byte), *&runtimeCfg); err != nil {
+		if err := s.configYAMLUnmarshalFn(cfgBytesVal.([]byte), *&runtimeCfg); err != nil {
 			// this should not happen unless there is a bug in Witchcraft because configuration has already been
 			// processed by unmarshalYAMLFn without issue at this stage
 			panic("Failed to unmarshal runtime configuration")


### PR DESCRIPTION
When configuration is set to true, configuration unmarshal is
done in "strict" mode, which treats unknown keys as errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/142)
<!-- Reviewable:end -->
