### PR TITLE
fix: wait for requests before testing rate limit

### DIFF
--- a/changelog/@unreleased/pr-145.v2.yml
+++ b/changelog/@unreleased/pr-145.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: wait for requests before testing rate limit
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/145

--- a/changelog/@unreleased/pr-145.v2.yml
+++ b/changelog/@unreleased/pr-145.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: wait for requests before testing rate limit
+  description: Fix flaky test by waiting for requests before testing rate limit
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/145

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -49,7 +49,7 @@ func TestNewInflightLimitMiddleware(t *testing.T) {
 	wait, closeWait := context.WithCancel(context.Background())
 	defer closeWait()
 
-	totalPostRequests := 4
+	const totalPostRequests = 4
 	reqChan := make(chan struct{}, totalPostRequests)
 	initFn := func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
 		info.Router.RootRouter().AddRouteHandlerMiddleware(limiter)
@@ -79,7 +79,7 @@ func TestNewInflightLimitMiddleware(t *testing.T) {
 
 	client := testServerClient()
 
-	testTimeout := time.Minute
+	const testTimeout = time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()
 


### PR DESCRIPTION
## Before this PR
Fixes: #117 
There was a race condition on the requests being made when testing the rate limit. There was a 1 millisecond timer between making the first two requests and the expected rate limited request, but this was not long enough. The 3rd request (the one expected to be rate limited) would sometimes make it through before one of the other requests causing a deadlock since we send on the `<-ctx.Done` channel in the handler but don't actually receive from that channel until after the 3rd request has returned. Therefore we never make it past the 3rd request until the context is cancelled which then made the request nil and thus the panic when we try to access those fields.

## After this PR
==COMMIT_MSG==
wait for requests before testing rate limit
==COMMIT_MSG==

This change removes the `time.Sleep` and instead uses a channel to synchronize and waits until the first 2 requests make it through to the handler before testing the 3rd request for rate limiting.

cc: @bmoylan @nmiyake 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/145)
<!-- Reviewable:end -->
