### PR TITLE
Add configHealthCheckSource after the init function

### DIFF
--- a/changelog/@unreleased/pr-151.v2.yml
+++ b/changelog/@unreleased/pr-151.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+feature:
+  fix: Add configHealthCheckSource after the init function
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/151

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -41,7 +41,7 @@ func (s *Server) initRouters(installCfg config.Install) (rRouter wrouter.Router,
 	return routerWithContextPath, mgmtRouterWithContextPath
 }
 
-func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg refreshableBaseRuntimeConfig) error {
+func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg refreshableBaseRuntimeConfig, configHealthCheckSource status.HealthCheckSource) error {
 	// add debugging endpoint to management router
 	if err := addDebuggingRoutes(mgmtRouterWithContextPath); err != nil {
 		return werror.Wrap(err, "failed to register debugging routes")
@@ -50,7 +50,7 @@ func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg 
 	statusResource := wresource.New("status", mgmtRouterWithContextPath)
 
 	// add health endpoints
-	if err := routes.AddHealthRoutes(statusResource, status.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
+	if err := routes.AddHealthRoutes(statusResource, status.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager, configHealthCheckSource)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
 		return in.(config.Runtime).HealthChecks.SharedSecret
 	}))); err != nil {
 		return werror.Wrap(err, "failed to register health routes")

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -660,8 +660,8 @@ func (s *Server) Start() (rErr error) {
 	}
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any
-	// health/liveness/readiness configuration updated by initFn is applied.
-	// this includes the configReloadHealthCheckSource which is always appended to health checks added by the initFn
+	// health/liveness/readiness configuration updated by initFn is applied. Includes the
+	// configReloadHealthCheckSource, which is always appended to s.healthCheckSources.
 	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg, configReloadHealthCheckSource); err != nil {
 		return err
 	}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -103,7 +103,7 @@ type Server struct {
 	// the server's status is used.
 	readinessSource status.Source
 
-	// specifies the source used to provide the liveneswitchcraft/server_routess information for the server. If nil, a default value that uses
+	// specifies the source used to provide the liveness information for the server. If nil, a default value that uses
 	// the server's status is used.
 	livenessSource status.Source
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -103,7 +103,7 @@ type Server struct {
 	// the server's status is used.
 	readinessSource status.Source
 
-	// specifies the source used to provide the liveness information for the server. If nil, a default value that uses
+	// specifies the source used to provide the liveneswitchcraft/server_routess information for the server. If nil, a default value that uses
 	// the server's status is used.
 	livenessSource status.Source
 
@@ -582,7 +582,6 @@ func (s *Server) Start() (rErr error) {
 	if err != nil {
 		return err
 	}
-	s.healthCheckSources = append(s.healthCheckSources, configReloadHealthCheckSource)
 
 	if loggerCfg := baseRefreshableRuntimeCfg.CurrentBaseRuntimeConfig().LoggerConfig; loggerCfg != nil {
 		s.svcLogger.SetLevel(loggerCfg.Level)
@@ -662,7 +661,8 @@ func (s *Server) Start() (rErr error) {
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any
 	// health/liveness/readiness configuration updated by initFn is applied.
-	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg); err != nil {
+	// this includes the configReloadHealthCheckSource which is always appended to health checks added by the initFn
+	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg, configReloadHealthCheckSource); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- We added the configHealthCheckSource before the init function. This caused it to get overridden by user health checks

## After this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- We add configHealthCheckSource after the init function like the SERVER_STATUS health check. This preserves it. 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/151)
<!-- Reviewable:end -->

==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/151)
<!-- Reviewable:end -->
