### PR TITLE
Improvement: add Go metric tags to server.uptime metric

### DIFF
--- a/changelog/@unreleased/pr-154.v2.yml
+++ b/changelog/@unreleased/pr-154.v2.yml
@@ -1,0 +1,9 @@
+type: improvement
+improvement:
+  description: |-
+    Add Go metric tags to server.uptime metric
+
+    Add tags that include Go version, Go OS and Go Arch to the
+    server.uptime metric.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/154

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -140,6 +141,11 @@ func TestEmitMetrics(t *testing.T) {
 		case "server.uptime":
 			seenUptime = true
 			assert.Equal(t, "gauge", metricLog.MetricType, "server.uptime metric had incorrect type")
+			assert.Equal(t, map[string]string{
+				"go_os":      runtime.GOOS,
+				"go_arch":    runtime.GOARCH,
+				"go_version": runtime.Version(),
+			}, metricLog.Tags)
 			assert.NotZero(t, metricLog.Values["value"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)


### PR DESCRIPTION
Add tags that include Go version, Go OS and Go Arch to the
server.uptime metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/154)
<!-- Reviewable:end -->
