### PR TITLE
Fix: Add default status code for rest error when none is provided.

### DIFF
--- a/changelog/@unreleased/pr-155.v2.yml
+++ b/changelog/@unreleased/pr-155.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Add default status code for rest error when none is provided.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/155
+

--- a/changelog/@unreleased/pr-155.v2.yml
+++ b/changelog/@unreleased/pr-155.v2.yml
@@ -3,4 +3,3 @@ fix:
   description: Add default status code for rest error when none is provided.
   links:
     - https://github.com/palantir/witchcraft-go-server/pull/155
-

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -37,7 +37,9 @@ func (f errorParamFunc) apply(err *errorMetadata) {
 }
 
 func NewError(err error, params ...ErrorParam) error {
-	e := errorMetadata{}
+	e := errorMetadata{
+		statusCode: StatusCodeMapper(err),
+	}
 	for _, param := range params {
 		param.apply(&e)
 	}

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -16,6 +16,7 @@ package rest
 
 import (
 	werror "github.com/palantir/witchcraft-go-error"
+	"net/http"
 )
 
 const (
@@ -37,7 +38,9 @@ func (f errorParamFunc) apply(err *errorMetadata) {
 }
 
 func NewError(err error, params ...ErrorParam) error {
-	e := errorMetadata{}
+	e := errorMetadata{
+		statusCode: http.StatusInternalServerError,
+	}
 	for _, param := range params {
 		param.apply(&e)
 	}

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -16,7 +16,6 @@ package rest
 
 import (
 	werror "github.com/palantir/witchcraft-go-error"
-	"net/http"
 )
 
 const (
@@ -38,9 +37,7 @@ func (f errorParamFunc) apply(err *errorMetadata) {
 }
 
 func NewError(err error, params ...ErrorParam) error {
-	e := errorMetadata{
-		statusCode: http.StatusInternalServerError,
-	}
+	e := errorMetadata{}
 	for _, param := range params {
 		param.apply(&e)
 	}

--- a/rest/handlers.go
+++ b/rest/handlers.go
@@ -85,10 +85,7 @@ func StatusCodeMapper(err error) int {
 		return http.StatusInternalServerError
 	}
 	statusCodeInt, ok := statusCode.(int)
-	if !ok {
-		return http.StatusInternalServerError
-	}
-	if statusCodeInt == 0 {
+	if !ok || statusCodeInt == 0 {
 		return http.StatusInternalServerError
 	}
 	return statusCodeInt

--- a/rest/handlers.go
+++ b/rest/handlers.go
@@ -88,6 +88,9 @@ func StatusCodeMapper(err error) int {
 	if !ok {
 		return http.StatusInternalServerError
 	}
+	if statusCodeInt == 0 {
+		return http.StatusInternalServerError
+	}
 	return statusCodeInt
 }
 

--- a/rest/handlers.go
+++ b/rest/handlers.go
@@ -88,9 +88,6 @@ func StatusCodeMapper(err error) int {
 	if !ok {
 		return http.StatusInternalServerError
 	}
-	if statusCodeInt == 0 {
-		return http.StatusInternalServerError
-	}
 	return statusCodeInt
 }
 

--- a/rest/handlers.go
+++ b/rest/handlers.go
@@ -76,7 +76,7 @@ func (h handler) handleError(ctx context.Context, statusCode int, err error) {
 	}
 }
 
-// StatusCodeMapper maps a provided error to an HTTP status code. If the provided error contains a status code added
+// StatusCodeMapper maps a provided error to an HTTP status code. If the provided error contains a non-zero status code added
 // using the StatusCode ErrorParam, returns that status code; otherwise, returns http.StatusInternalServerError.
 func StatusCodeMapper(err error) int {
 	safe, _ := werror.ParamsFromError(err)
@@ -86,6 +86,9 @@ func StatusCodeMapper(err error) int {
 	}
 	statusCodeInt, ok := statusCode.(int)
 	if !ok {
+		return http.StatusInternalServerError
+	}
+	if statusCodeInt == 0 {
 		return http.StatusInternalServerError
 	}
 	return statusCodeInt


### PR DESCRIPTION
## Before this PR
It is possible for the httpStatusCode safe param to have a value of 0 when logged by [this line](https://github.com/palantir/witchcraft-go-server/blob/develop/rest/handlers.go#L105). This is because rest error creation ([here](https://github.com/palantir/witchcraft-go-server/blob/develop/rest/errors.go#L39)) can be called without a `StatusCode()` error parameter. The implementation of `rest.NewError` is such that the HTTP status code is the zero value (0) in this case. We always attach the httpStatusCode safe param in `rest.NewError`.

## After this PR
==COMMIT_MSG==
Add a default value of `500` for the `httpStatusCode` safe parameter. This aligns with the logic we have in the `rest.StatusCodeMapper` method [here](https://github.com/palantir/witchcraft-go-server/blob/develop/rest/handlers.go#L81). Perhaps we want to move this change to be there instead of in `rest.NewError`.
==COMMIT_MSG==

## Possible downsides?
This change only fixes a misleading log line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/155)
<!-- Reviewable:end -->
