### PR TITLE
Bump werror to 1.3.0 and move over Error/Wrap functions 

### DIFF
--- a/app_example/main.go
+++ b/app_example/main.go
@@ -50,7 +50,7 @@ func main() {
 			}
 
 			// register endpoint that uses runtime configuration
-			myNumRefreshable := refreshable.NewInt(info.RuntimeConfig.Map(func(in interface{}) interface{} {
+			myNumRefreshable := refreshable.NewInt(info.RuntimeConfig.Map(ctx, func(in interface{}) interface{} {
 				return in.(AppRuntimeConfig).MyNum
 			}))
 			if err := registerRuntimeNumEndpoint(info.Router, myNumRefreshable); err != nil {

--- a/changelog/@unreleased/pr-158.v2.yml
+++ b/changelog/@unreleased/pr-158.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Bump werror to 1.3.0 and move over Error/Wrap functions
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/158

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/palantir/pkg/safeyaml v1.0.0
 	github.com/palantir/pkg/signals v1.0.0
 	github.com/palantir/pkg/tlsconfig v1.0.0
-	github.com/palantir/witchcraft-go-error v1.2.0
+	github.com/palantir/witchcraft-go-error v1.3.0
 	github.com/palantir/witchcraft-go-logging v1.5.0
 	github.com/palantir/witchcraft-go-params v1.1.0
 	github.com/palantir/witchcraft-go-tracing v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/palantir/pkg/transform v1.0.0 h1:21MzkUg9fQgIdadTYMM1Z1qrml2MVdpNY5ai
 github.com/palantir/pkg/transform v1.0.0/go.mod h1:YH2PQUzswoDayk4rTvKt6B+NcnUJgZRNr9MEqfAMCo0=
 github.com/palantir/witchcraft-go-error v1.2.0 h1:YFoZ8VC0ZLCGuhqM9iqdflUrTHGQmc3DC4GXGDZkhfY=
 github.com/palantir/witchcraft-go-error v1.2.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
+github.com/palantir/witchcraft-go-error v1.3.0 h1:1FUvIv+jS22t81uPI0Q5JEwzBDigClqGJJkLTuE8sZI=
+github.com/palantir/witchcraft-go-error v1.3.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
 github.com/palantir/witchcraft-go-logging v1.5.0 h1:LxmZ6XuhitMKmNrUQZ3UBU92q6PKPsawV94FlLVUui4=
 github.com/palantir/witchcraft-go-logging v1.5.0/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
 github.com/palantir/witchcraft-go-params v1.1.0 h1:siRqQv9TuJ0qY2JK5Svd3/rGQQCWvNnjI2OGAftm8gc=

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -128,7 +128,7 @@ func TestEncryptedConfig(t *testing.T) {
 
 			logOutputBuffer := &bytes.Buffer{}
 			server := witchcraft.NewServer().
-				WithECVKeyFromFile(ecvKeyFile).
+				WithECVKeyFromFile(context.Background(), ecvKeyFile).
 				WithInstallConfigFromFile(installFile).
 				WithInstallConfigType(&messageInstall{}).
 				WithRuntimeConfigFromFile(runtimeFile).

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -121,7 +121,7 @@ func TestHealthReporter(t *testing.T) {
 	for _, n := range healthyComponents {
 		go func(healthReporter reporter.HealthReporter, name string) {
 			defer wg.Done()
-			component, err := healthReporter.InitializeHealthComponent(name)
+			component, err := healthReporter.InitializeHealthComponent(context.Background(), name)
 			if err != nil {
 				panic(fmt.Errorf("failed to initialize %s health reporter: %v", name, err))
 			}
@@ -137,7 +137,7 @@ func TestHealthReporter(t *testing.T) {
 	for _, n := range unhealthyComponents {
 		go func(healthReporter reporter.HealthReporter, name string) {
 			defer wg.Done()
-			component, err := healthReporter.InitializeHealthComponent(name)
+			component, err := healthReporter.InitializeHealthComponent(context.Background(), name)
 			if err != nil {
 				panic(fmt.Errorf("failed to initialize %s health reporter: %v", name, err))
 			}
@@ -408,7 +408,7 @@ invalid-key: invalid-value
 	}, healthResults)
 
 	// write invalid runtime config and observe health check go unhealthy
-	err = runtimeConfigRefreshable.Update([]byte(invalidCfgYML))
+	err = runtimeConfigRefreshable.Update(context.Background(), []byte(invalidCfgYML))
 	require.NoError(t, err)
 	time.Sleep(500 * time.Millisecond)
 
@@ -497,7 +497,7 @@ invalid-key: invalid-value
 	}, healthResults)
 
 	// write invalid runtime config and observe health check go unhealthy
-	err = runtimeConfigRefreshable.Update([]byte(invalidCfgYML))
+	err = runtimeConfigRefreshable.Update(context.Background(), []byte(invalidCfgYML))
 	require.NoError(t, err)
 	time.Sleep(500 * time.Millisecond)
 

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestNewInflightLimitMiddleware(t *testing.T) {
 	healthReporter := reporter.NewHealthReporter()
-	healthComponent, err := healthReporter.InitializeHealthComponent("INFLIGHT_MUTATING_REQUESTS")
+	healthComponent, err := healthReporter.InitializeHealthComponent(context.Background(), "INFLIGHT_MUTATING_REQUESTS")
 	require.NoError(t, err)
 	requireHealthy := func(msg string) {
 		require.Equal(t, string(health.HealthStateHealthy), string(healthComponent.Status()), msg)
@@ -159,7 +159,7 @@ func waitForRequests(reqChan <-chan struct{}, expected int, timeout time.Duratio
 				return nil
 			}
 		case <-t:
-			return werror.ErrorWithContextParams("timed out waiting for expected number of requests",
+			return werror.ErrorWithContextParams(context.Background(), "timed out waiting for expected number of requests",
 				werror.SafeParam("current", current),
 				werror.SafeParam("expected", expected))
 		}

--- a/integration/ratelimit_test.go
+++ b/integration/ratelimit_test.go
@@ -159,7 +159,7 @@ func waitForRequests(reqChan <-chan struct{}, expected int, timeout time.Duratio
 				return nil
 			}
 		case <-t:
-			return werror.Error("timed out waiting for expected number of requests",
+			return werror.ErrorWithContextParams("timed out waiting for expected number of requests",
 				werror.SafeParam("current", current),
 				werror.SafeParam("expected", expected))
 		}

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -16,6 +16,7 @@ package rest
 
 import (
 	"context"
+
 	werror "github.com/palantir/witchcraft-go-error"
 )
 

--- a/rest/errors.go
+++ b/rest/errors.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"context"
 	werror "github.com/palantir/witchcraft-go-error"
 )
 
@@ -36,14 +37,14 @@ func (f errorParamFunc) apply(err *errorMetadata) {
 	f(err)
 }
 
-func NewError(err error, params ...ErrorParam) error {
+func NewError(ctx context.Context, err error, params ...ErrorParam) error {
 	e := errorMetadata{
 		statusCode: StatusCodeMapper(err),
 	}
 	for _, param := range params {
 		param.apply(&e)
 	}
-	return werror.Wrap(err, "witchcraft-server rest error", werror.SafeParam(httpStatusCodeParamKey, e.statusCode))
+	return werror.WrapWithContextParams(ctx, err, "witchcraft-server rest error", werror.SafeParam(httpStatusCodeParamKey, e.statusCode))
 }
 
 func StatusCode(code int) ErrorParam {

--- a/rest/errors_test.go
+++ b/rest/errors_test.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -24,10 +25,10 @@ import (
 )
 
 func TestNewErrorOneWrap(t *testing.T) {
-	werr := werror.Error("Test error", werror.SafeParam("param1", "val1"),
+	werr := werror.ErrorWithContextParams(context.Background(), "Test error", werror.SafeParam("param1", "val1"),
 		werror.UnsafeParam("param2", "val2"))
 
-	restErr := NewError(werr, StatusCode(400))
+	restErr := NewError(context.Background(), werr, StatusCode(400))
 	errString := fmt.Sprintf("%+v", restErr)
 	assert.Contains(t, errString, "Test error")
 	assert.Equal(t, map[string]interface{}{
@@ -38,9 +39,9 @@ func TestNewErrorOneWrap(t *testing.T) {
 }
 
 func TestNewErrorTwoWrap(t *testing.T) {
-	werr1 := werror.Error("werr1", werror.SafeParam("param1", "val1"))
-	werr2 := werror.Wrap(werr1, "werr2", werror.SafeParam("param2", "val2"))
-	restErr := NewError(werr2, StatusCode(http.StatusBadRequest))
+	werr1 := werror.ErrorWithContextParams(context.Background(), "werr1", werror.SafeParam("param1", "val1"))
+	werr2 := werror.WrapWithContextParams(context.Background(), werr1, "werr2", werror.SafeParam("param2", "val2"))
+	restErr := NewError(context.Background(), werr2, StatusCode(http.StatusBadRequest))
 	errString := fmt.Sprintf("%+v", restErr)
 	assert.Contains(t, errString, "werr1")
 	assert.Contains(t, errString, "werr2")

--- a/rest/handlers_test.go
+++ b/rest/handlers_test.go
@@ -31,12 +31,12 @@ func TestStatusCodeMapper(t *testing.T) {
 	}{
 		{
 			name:         "not found rest error",
-			err:          NewError(werror.Error("Test error"), StatusCode(http.StatusNotFound)),
+			err:          NewError(context.Background(), werror.ErrorWithContextParams(context.Background(), "Test error"), StatusCode(http.StatusNotFound)),
 			expectedCode: http.StatusNotFound,
 		},
 		{
 			name:         "werror wrapping not found error",
-			err:          werror.WrapWithContextParams(context.Background(), NewError(werror.Error("inner"), StatusCode(http.StatusNotFound)), "outer"),
+			err:          werror.WrapWithContextParams(context.Background(), NewError(context.Background(), werror.ErrorWithContextParams(context.Background(), "inner"), StatusCode(http.StatusNotFound)), "outer"),
 			expectedCode: http.StatusNotFound,
 		},
 		{

--- a/rest/handlers_test.go
+++ b/rest/handlers_test.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -35,12 +36,12 @@ func TestStatusCodeMapper(t *testing.T) {
 		},
 		{
 			name:         "werror wrapping not found error",
-			err:          werror.Wrap(NewError(werror.Error("inner"), StatusCode(http.StatusNotFound)), "outer"),
+			err:          werror.WrapWithContextParams(context.Background(), NewError(werror.Error("inner"), StatusCode(http.StatusNotFound)), "outer"),
 			expectedCode: http.StatusNotFound,
 		},
 		{
 			name:         "no rest error",
-			err:          werror.Error("werror"),
+			err:          werror.ErrorWithContextParams(context.Background(), "werror"),
 			expectedCode: http.StatusInternalServerError,
 		},
 	} {

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -42,11 +42,11 @@ func WriteJSONResponse(w http.ResponseWriter, obj interface{}, status int) {
 func ParseBearerTokenHeader(req *http.Request) (string, error) {
 	authHeader := req.Header.Get("Authorization")
 	if authHeader == "" {
-		return "", werror.Error("Authorization header not found")
+		return "", werror.ErrorWithContextParams("Authorization header not found")
 	}
 	headerSplit := strings.Split(authHeader, " ")
 	if len(headerSplit) != 2 || strings.ToLower(headerSplit[0]) != "bearer" {
-		return "", werror.Error("Illegal authorization header, expected Bearer")
+		return "", werror.ErrorWithContextParams("Illegal authorization header, expected Bearer")
 	}
 	return headerSplit[1], nil
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"context"
 	"net/http"
 	"strings"
 
@@ -39,14 +40,14 @@ func WriteJSONResponse(w http.ResponseWriter, obj interface{}, status int) {
 // ParseBearerTokenHeader parses a bearer token value out of the Authorization header. It expects a header with a key
 // of 'Authorization' and a value of 'bearer {token}'. ParseBearerTokenHeader will return the token value, or an error
 // if the Authorization header is missing, an empty string, or is not in the format expected.
-func ParseBearerTokenHeader(req *http.Request) (string, error) {
+func ParseBearerTokenHeader(ctx context.Context, req *http.Request) (string, error) {
 	authHeader := req.Header.Get("Authorization")
 	if authHeader == "" {
-		return "", werror.ErrorWithContextParams("Authorization header not found")
+		return "", werror.ErrorWithContextParams(ctx, "Authorization header not found")
 	}
 	headerSplit := strings.Split(authHeader, " ")
 	if len(headerSplit) != 2 || strings.ToLower(headerSplit[0]) != "bearer" {
-		return "", werror.ErrorWithContextParams("Illegal authorization header, expected Bearer")
+		return "", werror.ErrorWithContextParams(ctx, "Illegal authorization header, expected Bearer")
 	}
 	return headerSplit[1], nil
 }

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -41,7 +41,7 @@ func TestWriteJSONResponse_Error(t *testing.T) {
 		},
 		{
 			Name:         "rest.Error with code",
-			Err:          rest.NewError(context.Background(),  werror.ErrorWithContextParams(context.Background(), "bad things happened"), rest.StatusCode(400)),
+			Err:          rest.NewError(context.Background(), werror.ErrorWithContextParams(context.Background(), "bad things happened"), rest.StatusCode(400)),
 			ExpectedCode: 400,
 			ExpectedJSON: "\"witchcraft-server rest error: bad things happened\"\n",
 		},

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -15,6 +15,7 @@
 package rest_test
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -34,13 +35,13 @@ func TestWriteJSONResponse_Error(t *testing.T) {
 	}{
 		{
 			Name:         "standard werror",
-			Err:          werror.Error("bad things happened"),
+			Err:          werror.ErrorWithContextParams(context.Background(), "bad things happened"),
 			ExpectedCode: 500,
 			ExpectedJSON: "\"bad things happened\"\n",
 		},
 		{
 			Name:         "rest.Error with code",
-			Err:          rest.NewError(werror.Error("bad things happened"), rest.StatusCode(400)),
+			Err:          rest.NewError(context.Background(),  werror.ErrorWithContextParams(context.Background(), "bad things happened"), rest.StatusCode(400)),
 			ExpectedCode: 400,
 			ExpectedJSON: "\"witchcraft-server rest error: bad things happened\"\n",
 		},

--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -47,8 +47,8 @@ var _ status.HealthCheckSource = &HealthCheckSource{}
 // heartbeatTimeout and startupTimeout. The returning HealthCheckResult is of type checkType.
 // Panics if heartbeatTimeout is non-positive or if startupTimeout is negative.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) *HealthCheckSource {
-	healthCheckSource, err := NewHealthCheckSourceWithStartupGracePeriod(checkType, heartbeatTimeout, startupTimeout)
+func MustNewHealthCheckSourceWithStartupGracePeriod(ctx context.Context,checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) *HealthCheckSource {
+	healthCheckSource, err := NewHealthCheckSourceWithStartupGracePeriod(ctx, checkType, heartbeatTimeout, startupTimeout)
 	if err != nil {
 		panic(err)
 	}
@@ -58,12 +58,12 @@ func MustNewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, 
 // NewHealthCheckSourceWithStartupGracePeriod creates a HealthCheckSource with the specified
 // heartbeatTimeout and startupTimeout. The returning HealthCheckResult is of type checkType.
 // Returns an error if heartbeatTimeout is non-positive or if startupTimeout is negative.
-func NewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) (*HealthCheckSource, error) {
+func NewHealthCheckSourceWithStartupGracePeriod(ctx context.Context, checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) (*HealthCheckSource, error) {
 	if heartbeatTimeout <= 0 {
-		return nil, werror.ErrorWithContextParams("heartbeatTimeout must be positive")
+		return nil, werror.ErrorWithContextParams(ctx, "heartbeatTimeout must be positive")
 	}
 	if startupTimeout < 0 {
-		return nil, werror.ErrorWithContextParams("startupTimeout cannot be negative")
+		return nil, werror.ErrorWithContextParams(ctx, "startupTimeout cannot be negative")
 	}
 	return &HealthCheckSource{
 		heartbeatTimeout:  heartbeatTimeout,
@@ -77,8 +77,8 @@ func NewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, hear
 // heartbeatTimeout and zero as startupTimeout. The returning HealthCheckResult is of type checkType.
 // Panics if heartbeatTimeout is non-positive.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Duration) *HealthCheckSource {
-	healthCheckSource, err := NewHealthCheckSource(checkType, heartbeatTimeout)
+func MustNewHealthCheckSource(ctx context.Context, checkType health.CheckType, heartbeatTimeout time.Duration) *HealthCheckSource {
+	healthCheckSource, err := NewHealthCheckSource(ctx, checkType, heartbeatTimeout)
 	if err != nil {
 		panic(err)
 	}
@@ -88,8 +88,8 @@ func MustNewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.
 // NewHealthCheckSource creates a HealthCheckSource with the specified
 // heartbeatTimeout and zero as startupTimeout. The returning HealthCheckResult is of type checkType.
 // Returns an error if heartbeatTimeout is non-positive.
-func NewHealthCheckSource(checkType health.CheckType, heartbeatTimeout time.Duration) (*HealthCheckSource, error) {
-	return NewHealthCheckSourceWithStartupGracePeriod(checkType, heartbeatTimeout, 0)
+func NewHealthCheckSource(ctx context.Context, checkType health.CheckType, heartbeatTimeout time.Duration) (*HealthCheckSource, error) {
+	return NewHealthCheckSourceWithStartupGracePeriod(ctx, checkType, heartbeatTimeout, 0)
 }
 
 // HealthStatus constructs a HealthStatus object based on the submitted heartbeats.

--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -60,10 +60,10 @@ func MustNewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, 
 // Returns an error if heartbeatTimeout is non-positive or if startupTimeout is negative.
 func NewHealthCheckSourceWithStartupGracePeriod(checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) (*HealthCheckSource, error) {
 	if heartbeatTimeout <= 0 {
-		return nil, werror.Error("heartbeatTimeout must be positive")
+		return nil, werror.ErrorWithContextParams("heartbeatTimeout must be positive")
 	}
 	if startupTimeout < 0 {
-		return nil, werror.Error("startupTimeout cannot be negative")
+		return nil, werror.ErrorWithContextParams("startupTimeout cannot be negative")
 	}
 	return &HealthCheckSource{
 		heartbeatTimeout:  heartbeatTimeout,

--- a/status/health/heartbeat/source.go
+++ b/status/health/heartbeat/source.go
@@ -47,7 +47,7 @@ var _ status.HealthCheckSource = &HealthCheckSource{}
 // heartbeatTimeout and startupTimeout. The returning HealthCheckResult is of type checkType.
 // Panics if heartbeatTimeout is non-positive or if startupTimeout is negative.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewHealthCheckSourceWithStartupGracePeriod(ctx context.Context,checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) *HealthCheckSource {
+func MustNewHealthCheckSourceWithStartupGracePeriod(ctx context.Context, checkType health.CheckType, heartbeatTimeout, startupTimeout time.Duration) *HealthCheckSource {
 	healthCheckSource, err := NewHealthCheckSourceWithStartupGracePeriod(ctx, checkType, heartbeatTimeout, startupTimeout)
 	if err != nil {
 		panic(err)

--- a/status/health/heartbeat/source_test.go
+++ b/status/health/heartbeat/source_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 func TestHealthCheckSource_NoHeartbeats_Repairing(t *testing.T) {
-	source, err := NewHealthCheckSourceWithStartupGracePeriod(testCheckType, 25*time.Millisecond, 25*time.Millisecond)
+	source, err := NewHealthCheckSourceWithStartupGracePeriod(context.Background(), testCheckType, 25*time.Millisecond, 25*time.Millisecond)
 	require.NoError(t, err)
 	status := source.HealthStatus(context.Background())
 	require.Equal(t, 1, len(status.Checks))
@@ -39,7 +39,7 @@ func TestHealthCheckSource_NoHeartbeats_Repairing(t *testing.T) {
 }
 
 func TestHealthCheckSource_NoHeartbeats_Error(t *testing.T) {
-	source, err := NewHealthCheckSourceWithStartupGracePeriod(testCheckType, 25*time.Millisecond, 25*time.Millisecond)
+	source, err := NewHealthCheckSourceWithStartupGracePeriod(context.Background(), testCheckType, 25*time.Millisecond, 25*time.Millisecond)
 	require.NoError(t, err)
 	<-time.After(50 * time.Millisecond)
 	status := source.HealthStatus(context.Background())
@@ -50,7 +50,7 @@ func TestHealthCheckSource_NoHeartbeats_Error(t *testing.T) {
 }
 
 func TestHealthCheckSource_WithHeartbeats_Healthy(t *testing.T) {
-	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	source, err := NewHealthCheckSource(context.Background(), testCheckType, 25*time.Millisecond)
 	require.NoError(t, err)
 	source.Heartbeat()
 	status := source.HealthStatus(context.Background())
@@ -61,7 +61,7 @@ func TestHealthCheckSource_WithHeartbeats_Healthy(t *testing.T) {
 }
 
 func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
-	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	source, err := NewHealthCheckSource(context.Background(), testCheckType, 25*time.Millisecond)
 	require.NoError(t, err)
 	source.Heartbeat()
 	<-time.After(50 * time.Millisecond)
@@ -73,7 +73,7 @@ func TestHealthCheckSource_WithHeartbeats_Error(t *testing.T) {
 }
 
 func TestHealthCheckSource_WithHeartbeats_HealthyThenErrorThenHealthy(t *testing.T) {
-	source, err := NewHealthCheckSource(testCheckType, 25*time.Millisecond)
+	source, err := NewHealthCheckSource(context.Background(), testCheckType, 25*time.Millisecond)
 	require.NoError(t, err)
 	source.Heartbeat()
 	status := source.HealthStatus(context.Background())

--- a/status/health/refreshable/source_test.go
+++ b/status/health/refreshable/source_test.go
@@ -49,7 +49,7 @@ func TestNewValidatingRefreshableHealthCheckSource_HealthStatus(t *testing.T) {
 	}))
 
 	// change underyling refreshable to value that fails validation
-	err = testRefreshable.Update("validation-failing-value")
+	err = testRefreshable.Update(context.Background(), "validation-failing-value")
 	require.NoError(t, err)
 	errorMsg := "Refreshable validation failed, please look at service logs for more information."
 	assert.True(t, reflect.DeepEqual(healthCheckSource.HealthStatus(context.Background()), health.HealthStatus{
@@ -63,7 +63,7 @@ func TestNewValidatingRefreshableHealthCheckSource_HealthStatus(t *testing.T) {
 	}))
 
 	// change underyling refreshable to value that passes validation
-	err = testRefreshable.Update("other-value")
+	err = testRefreshable.Update(context.Background(), "other-value")
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(healthCheckSource.HealthStatus(context.Background()), health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{

--- a/status/health/refreshable/source_test.go
+++ b/status/health/refreshable/source_test.go
@@ -29,9 +29,9 @@ import (
 func TestNewValidatingRefreshableHealthCheckSource_HealthStatus(t *testing.T) {
 	testHealthCheckType := health.CheckType("TEST_HEALTH_CHECK")
 	testRefreshable := refreshable.NewDefaultRefreshable("initial-value")
-	validatingRefreshable, err := refreshable.NewValidatingRefreshable(testRefreshable, func(i interface{}) error {
+	validatingRefreshable, err := refreshable.NewValidatingRefreshable(context.Background(), testRefreshable, func(i interface{}) error {
 		if i.(string) == "validation-failing-value" {
-			return werror.Error("fail validation")
+			return werror.ErrorWithContextParams(context.Background(), "fail validation")
 		}
 		return nil
 	})

--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -46,8 +46,8 @@ type baseHealthCheckSource struct {
 
 // MustNewBaseHealthCheckSource returns the result of calling NewBaseHealthCheckSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {
-	source, err := NewBaseHealthCheckSource(windowSize, itemsToCheckFn)
+func MustNewBaseHealthCheckSource(ctx context.Context,windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {
+	source, err := NewBaseHealthCheckSource(ctx, windowSize, itemsToCheckFn)
 	if err != nil {
 		panic(err)
 	}
@@ -57,13 +57,13 @@ func MustNewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn Items
 // NewBaseHealthCheckSource creates a baseHealthCheckSource
 // with a sliding window of size windowSize and uses the itemsToCheckFn.
 // windowSize must be a positive value and itemsToCheckFn must not be nil, otherwise returns error.
-func NewBaseHealthCheckSource(windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) (BaseHealthCheckSource, error) {
-	timeWindowedStore, err := NewTimeWindowedStore(windowSize)
+func NewBaseHealthCheckSource(ctx context.Context, windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) (BaseHealthCheckSource, error) {
+	timeWindowedStore, err := NewTimeWindowedStore(ctx, windowSize)
 	if err != nil {
 		return nil, err
 	}
 	if itemsToCheckFn == nil {
-		return nil, werror.Error("itemsToCheckFn cannot be nil")
+		return nil, werror.ErrorWithContextParams(ctx, "itemsToCheckFn cannot be nil")
 	}
 	return &baseHealthCheckSource{
 		timeWindowedStore: timeWindowedStore,

--- a/status/health/window/base_source.go
+++ b/status/health/window/base_source.go
@@ -46,7 +46,7 @@ type baseHealthCheckSource struct {
 
 // MustNewBaseHealthCheckSource returns the result of calling NewBaseHealthCheckSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewBaseHealthCheckSource(ctx context.Context,windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {
+func MustNewBaseHealthCheckSource(ctx context.Context, windowSize time.Duration, itemsToCheckFn ItemsToCheckFn) BaseHealthCheckSource {
 	source, err := NewBaseHealthCheckSource(ctx, windowSize, itemsToCheckFn)
 	if err != nil {
 		panic(err)

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -46,8 +46,8 @@ type unhealthyIfAtLeastOneErrorSource struct {
 
 // MustNewUnhealthyIfAtLeastOneErrorSource returns the result of calling NewUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := NewUnhealthyIfAtLeastOneErrorSource(checkType, windowSize)
+func MustNewUnhealthyIfAtLeastOneErrorSource(ctx context.Context, checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
+	source, err := NewUnhealthyIfAtLeastOneErrorSource(ctx, checkType, windowSize)
 	if err != nil {
 		panic(err)
 	}
@@ -57,8 +57,8 @@ func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowS
 // NewUnhealthyIfAtLeastOneErrorSource creates an unhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
-func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
+func NewUnhealthyIfAtLeastOneErrorSource(ctx context.Context, checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
+	source, err := NewHealthyIfNotAllErrorsSource(ctx, checkType, windowSize)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +94,8 @@ type healthyIfNotAllErrorsSource struct {
 
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
+func MustNewHealthyIfNotAllErrorsSource(ctx context.Context, checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
+	source, err := NewHealthyIfNotAllErrorsSource(ctx, checkType, windowSize)
 	if err != nil {
 		panic(err)
 	}
@@ -105,9 +105,9 @@ func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize t
 // NewHealthyIfNotAllErrorsSource creates an healthyIfNotAllErrorsSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
-func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
+func NewHealthyIfNotAllErrorsSource(ctx context.Context, checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
 	if windowSize <= 0 {
-		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
+		return nil, werror.ErrorWithContextParams(ctx, "windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &healthyIfNotAllErrorsSource{
 		windowSize: windowSize,

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -54,9 +54,9 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 			name: "unhealthy when there is at least one err",
 			errors: []error{
 				nil,
-				werror.ErrorWithContextParams(context.Background(),"Error #1"),
+				werror.ErrorWithContextParams(context.Background(), "Error #1"),
 				nil,
-				werror.ErrorWithContextParams(context.Background(),"Error #2"),
+				werror.ErrorWithContextParams(context.Background(), "Error #2"),
 				nil,
 			},
 			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
@@ -103,9 +103,9 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 			name: "healthy when there is at least one non nil err",
 			errors: []error{
 				nil,
-				werror.ErrorWithContextParams(context.Background(),"Error #1"),
+				werror.ErrorWithContextParams(context.Background(), "Error #1"),
 				nil,
-				werror.ErrorWithContextParams(context.Background(),"Error #2"),
+				werror.ErrorWithContextParams(context.Background(), "Error #2"),
 				nil,
 			},
 			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
@@ -113,8 +113,8 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 		{
 			name: "unhealthy when there are only non nil items",
 			errors: []error{
-				werror.ErrorWithContextParams(context.Background(),"Error #1"),
-				werror.ErrorWithContextParams(context.Background(),"Error #2"),
+				werror.ErrorWithContextParams(context.Background(), "Error #1"),
+				werror.ErrorWithContextParams(context.Background(), "Error #2"),
 			},
 			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
 		},

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -54,16 +54,16 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 			name: "unhealthy when there is at least one err",
 			errors: []error{
 				nil,
-				werror.Error("Error #1"),
+				werror.ErrorWithContextParams(context.Background(),"Error #1"),
 				nil,
-				werror.Error("Error #2"),
+				werror.ErrorWithContextParams(context.Background(),"Error #2"),
 				nil,
 			},
 			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			source, err := NewUnhealthyIfAtLeastOneErrorSource(testCheckType, time.Hour)
+			source, err := NewUnhealthyIfAtLeastOneErrorSource(context.Background(), testCheckType, time.Hour)
 			require.NoError(t, err)
 			for _, err := range testCase.errors {
 				source.Submit(err)
@@ -103,9 +103,9 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 			name: "healthy when there is at least one non nil err",
 			errors: []error{
 				nil,
-				werror.Error("Error #1"),
+				werror.ErrorWithContextParams(context.Background(),"Error #1"),
 				nil,
-				werror.Error("Error #2"),
+				werror.ErrorWithContextParams(context.Background(),"Error #2"),
 				nil,
 			},
 			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
@@ -113,14 +113,14 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 		{
 			name: "unhealthy when there are only non nil items",
 			errors: []error{
-				werror.Error("Error #1"),
-				werror.Error("Error #2"),
+				werror.ErrorWithContextParams(context.Background(),"Error #1"),
+				werror.ErrorWithContextParams(context.Background(),"Error #2"),
 			},
 			expectedCheck: whealth.UnhealthyHealthCheckResult(testCheckType, "Error #2"),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			source, err := NewHealthyIfNotAllErrorsSource(testCheckType, time.Hour)
+			source, err := NewHealthyIfNotAllErrorsSource(context.Background(), testCheckType, time.Hour)
 			require.NoError(t, err)
 			for _, err := range testCase.errors {
 				source.Submit(err)

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -114,7 +114,7 @@ func MustNewMultiKeyHealthyIfNotAllErrorsSource(ctx context.Context, checkType h
 // windowSize must be a positive value, otherwise returns error.
 func NewMultiKeyHealthyIfNotAllErrorsSource(ctx context.Context, checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
 	if windowSize <= 0 {
-		return nil, werror.ErrorWithContextParams(ctx,"windowSize must be positive", werror.SafeParam("windowSize", windowSize))
+		return nil, werror.ErrorWithContextParams(ctx, "windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &multiKeyHealthyIfNotAllErrorsSource{
 		windowSize:           windowSize,

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -48,8 +48,8 @@ type multiKeyUnhealthyIfAtLeastOneErrorSource struct {
 
 // MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource returns the result of calling NewMultiKeyUnhealthyIfAtLeastOneErrorSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
-	source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType, messageInCaseOfError, windowSize)
+func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(ctx context.Context, checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
+	source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(ctx, checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		panic(err)
 	}
@@ -59,8 +59,8 @@ func MustNewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType,
 // NewMultiKeyUnhealthyIfAtLeastOneErrorSource creates an multiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
-func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
-	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(checkType, messageInCaseOfError, windowSize)
+func NewMultiKeyUnhealthyIfAtLeastOneErrorSource(ctx context.Context, checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
+	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(ctx, checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		return nil, err
 	}
@@ -101,8 +101,8 @@ var _ status.HealthCheckSource = &multiKeyHealthyIfNotAllErrorsSource{}
 
 // MustNewMultiKeyHealthyIfNotAllErrorsSource returns the result of calling NewMultiKeyHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
-func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
-	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(checkType, messageInCaseOfError, windowSize)
+func MustNewMultiKeyHealthyIfNotAllErrorsSource(ctx context.Context, checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) KeyedErrorHealthCheckSource {
+	source, err := NewMultiKeyHealthyIfNotAllErrorsSource(ctx, checkType, messageInCaseOfError, windowSize)
 	if err != nil {
 		panic(err)
 	}
@@ -112,9 +112,9 @@ func MustNewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, mess
 // NewMultiKeyHealthyIfNotAllErrorsSource creates an multiKeyUnhealthyIfAtLeastOneErrorSource
 // with a sliding window of size windowSize and uses the checkType and a message in case of errors.
 // windowSize must be a positive value, otherwise returns error.
-func NewMultiKeyHealthyIfNotAllErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
+func NewMultiKeyHealthyIfNotAllErrorsSource(ctx context.Context, checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration) (KeyedErrorHealthCheckSource, error) {
 	if windowSize <= 0 {
-		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
+		return nil, werror.ErrorWithContextParams(ctx,"windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &multiKeyHealthyIfNotAllErrorsSource{
 		windowSize:           windowSize,

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -57,9 +57,9 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 			name: "unhealthy when some keys are partially healthy",
 			keyErrorPairs: []keyErrorPair{
 				{key: "1"},
-				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
 				{key: "1"},
-				{key: "2", err: werror.Error("Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
 				{key: "2"},
 				{key: "3"},
 			},
@@ -76,10 +76,10 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 		{
 			name: "unhealthy when all keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.Error("Error #1 for key 1")},
-				{key: "2", err: werror.Error("Error #1 for key 2")},
-				{key: "2", err: werror.Error("Error #2 for key 2")},
-				{key: "3", err: werror.Error("Error #1 for key 3")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,
@@ -94,7 +94,7 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(testCheckType, messageInCaseOfError, time.Hour)
+			source, err := NewMultiKeyUnhealthyIfAtLeastOneErrorSource(context.Background(), testCheckType, messageInCaseOfError, time.Hour)
 			require.NoError(t, err)
 			for _, keyErrorPair := range testCase.keyErrorPairs {
 				source.Submit(keyErrorPair.key, keyErrorPair.err)
@@ -136,24 +136,24 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 			name: "healthy when all keys are partially healthy",
 			keyErrorPairs: []keyErrorPair{
 				{key: "1"},
-				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
 				{key: "1"},
-				{key: "2", err: werror.Error("Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
 				{key: "2"},
 				{key: "3"},
-				{key: "3", err: werror.Error("Error #1 for key 3")},
-				{key: "3", err: werror.Error("Error #2 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 3")},
 			},
 			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
 		},
 		{
 			name: "unhealthy when some keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.Error("Error #1 for key 1")},
-				{key: "2", err: werror.Error("Error #1 for key 2")},
-				{key: "2", err: werror.Error("Error #2 for key 2")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
 				{key: "3"},
-				{key: "3", err: werror.Error("Error #1 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,
@@ -168,10 +168,10 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 		{
 			name: "unhealthy when all keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.Error("Error #1 for key 1")},
-				{key: "2", err: werror.Error("Error #1 for key 2")},
-				{key: "2", err: werror.Error("Error #2 for key 2")},
-				{key: "3", err: werror.Error("Error #1 for key 3")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,
@@ -186,7 +186,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			source, err := NewMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour)
+			source, err := NewMultiKeyHealthyIfNotAllErrorsSource(context.Background(), testCheckType, messageInCaseOfError, time.Hour)
 			require.NoError(t, err)
 			for _, keyErrorPair := range testCase.keyErrorPairs {
 				source.Submit(keyErrorPair.key, keyErrorPair.err)

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -57,9 +57,9 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 			name: "unhealthy when some keys are partially healthy",
 			keyErrorPairs: []keyErrorPair{
 				{key: "1"},
-				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 1")},
 				{key: "1"},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 2")},
 				{key: "2"},
 				{key: "3"},
 			},
@@ -76,10 +76,10 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 		{
 			name: "unhealthy when all keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
-				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #2 for key 2")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,
@@ -136,24 +136,24 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 			name: "healthy when all keys are partially healthy",
 			keyErrorPairs: []keyErrorPair{
 				{key: "1"},
-				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 1")},
 				{key: "1"},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 2")},
 				{key: "2"},
 				{key: "3"},
-				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
-				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(), "Error #2 for key 3")},
 			},
 			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
 		},
 		{
 			name: "unhealthy when some keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #2 for key 2")},
 				{key: "3"},
-				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,
@@ -168,10 +168,10 @@ func TestMultiKeyHealthyIfNotAllErrorsSource(t *testing.T) {
 		{
 			name: "unhealthy when all keys are completely unhealthy",
 			keyErrorPairs: []keyErrorPair{
-				{key: "1", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 1")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 2")},
-				{key: "2", err: werror.ErrorWithContextParams(context.Background(),"Error #2 for key 2")},
-				{key: "3", err: werror.ErrorWithContextParams(context.Background(),"Error #1 for key 3")},
+				{key: "1", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 1")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 2")},
+				{key: "2", err: werror.ErrorWithContextParams(context.Background(), "Error #2 for key 2")},
+				{key: "3", err: werror.ErrorWithContextParams(context.Background(), "Error #1 for key 3")},
 			},
 			expectedCheck: health.HealthCheckResult{
 				Type:    testCheckType,

--- a/status/health/window/time_windowed_store.go
+++ b/status/health/window/time_windowed_store.go
@@ -15,6 +15,7 @@
 package window
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -38,9 +39,9 @@ type TimeWindowedStore struct {
 
 // NewTimeWindowedStore creates a new TimeWindowedStore with the provided windowSize.
 // windowSize must be a positive value, otherwise returns error.
-func NewTimeWindowedStore(windowSize time.Duration) (*TimeWindowedStore, error) {
+func NewTimeWindowedStore(ctx context.Context, windowSize time.Duration) (*TimeWindowedStore, error) {
 	if windowSize <= 0 {
-		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
+		return nil, werror.ErrorWithContextParams(ctx, "windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}
 	return &TimeWindowedStore{
 		windowSize: windowSize,

--- a/status/health/window/time_windowed_store_test.go
+++ b/status/health/window/time_windowed_store_test.go
@@ -50,7 +50,7 @@ func TestTimeWindowedStore_AllItemsUpToDate(t *testing.T) {
 }
 
 func TestTimeWindowedStore_AllItemsOutOfDate(t *testing.T) {
-	store, err := NewTimeWindowedStore(context.Background(), 50 * time.Millisecond)
+	store, err := NewTimeWindowedStore(context.Background(), 50*time.Millisecond)
 	require.NoError(t, err)
 	store.Submit("item #1")
 	store.Submit("item #2")
@@ -61,7 +61,7 @@ func TestTimeWindowedStore_AllItemsOutOfDate(t *testing.T) {
 }
 
 func TestTimeWindowedStore_SomeItemsOutOfDate(t *testing.T) {
-	store, err := NewTimeWindowedStore(context.Background(), 50 * time.Millisecond)
+	store, err := NewTimeWindowedStore(context.Background(), 50*time.Millisecond)
 	require.NoError(t, err)
 	store.Submit("item #1")
 	store.Submit("item #2")

--- a/status/health/window/time_windowed_store_test.go
+++ b/status/health/window/time_windowed_store_test.go
@@ -15,6 +15,7 @@
 package window
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,20 +24,20 @@ import (
 )
 
 func TestTimeWindowedStore_ErrorOnCreate(t *testing.T) {
-	_, err := NewTimeWindowedStore(0)
+	_, err := NewTimeWindowedStore(context.Background(), 0)
 	// This should error as 0 is not a valid windowSize.
 	assert.Error(t, err)
 }
 
 func TestTimeWindowedStore_NoItems(t *testing.T) {
-	store, err := NewTimeWindowedStore(time.Millisecond)
+	store, err := NewTimeWindowedStore(context.Background(), time.Millisecond)
 	require.NoError(t, err)
 	items := store.ItemsInWindow()
 	assert.Nil(t, items)
 }
 
 func TestTimeWindowedStore_AllItemsUpToDate(t *testing.T) {
-	store, err := NewTimeWindowedStore(time.Second)
+	store, err := NewTimeWindowedStore(context.Background(), time.Second)
 	require.NoError(t, err)
 	store.Submit("item #1")
 	store.Submit("item #2")
@@ -49,7 +50,7 @@ func TestTimeWindowedStore_AllItemsUpToDate(t *testing.T) {
 }
 
 func TestTimeWindowedStore_AllItemsOutOfDate(t *testing.T) {
-	store, err := NewTimeWindowedStore(50 * time.Millisecond)
+	store, err := NewTimeWindowedStore(context.Background(), 50 * time.Millisecond)
 	require.NoError(t, err)
 	store.Submit("item #1")
 	store.Submit("item #2")
@@ -60,7 +61,7 @@ func TestTimeWindowedStore_AllItemsOutOfDate(t *testing.T) {
 }
 
 func TestTimeWindowedStore_SomeItemsOutOfDate(t *testing.T) {
-	store, err := NewTimeWindowedStore(50 * time.Millisecond)
+	store, err := NewTimeWindowedStore(context.Background(), 50 * time.Millisecond)
 	require.NoError(t, err)
 	store.Submit("item #1")
 	store.Submit("item #2")

--- a/status/reporter/component_test.go
+++ b/status/reporter/component_test.go
@@ -30,7 +30,7 @@ const (
 
 func setup(t *testing.T) (HealthComponent, HealthReporter) {
 	healthReporter := NewHealthReporter()
-	healthComponent, err := healthReporter.InitializeHealthComponent(context.Background(),  validComponent)
+	healthComponent, err := healthReporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.NoError(t, err)
 	return healthComponent, healthReporter
 }

--- a/status/reporter/component_test.go
+++ b/status/reporter/component_test.go
@@ -30,7 +30,7 @@ const (
 
 func setup(t *testing.T) (HealthComponent, HealthReporter) {
 	healthReporter := NewHealthReporter()
-	healthComponent, err := healthReporter.InitializeHealthComponent(validComponent)
+	healthComponent, err := healthReporter.InitializeHealthComponent(context.Background(),  validComponent)
 	assert.NoError(t, err)
 	return healthComponent, healthReporter
 }
@@ -82,7 +82,7 @@ func TestSetHealthAndGetHealthResult(t *testing.T) {
 
 func TestNonCompliantName(t *testing.T) {
 	healthReporter := NewHealthReporter()
-	_, err := healthReporter.InitializeHealthComponent(invalidComponent)
+	_, err := healthReporter.InitializeHealthComponent(context.Background(), invalidComponent)
 	assert.Error(t, err)
 }
 

--- a/status/reporter/reporter.go
+++ b/status/reporter/reporter.go
@@ -59,7 +59,7 @@ func newHealthReporter() *healthReporter {
 func (r *healthReporter) InitializeHealthComponent(name string) (HealthComponent, error) {
 	isSLSCompliant := regexp.MustCompile(slsHealthNameRegex).MatchString
 	if !isSLSCompliant(name) {
-		return nil, werror.Error("component name is not a valid SLS health component name",
+		return nil, werror.ErrorWithContextParams("component name is not a valid SLS health component name",
 			werror.SafeParam("name", name),
 			werror.SafeParam("validPattern", slsHealthNameRegex))
 	}
@@ -72,7 +72,7 @@ func (r *healthReporter) InitializeHealthComponent(name string) (HealthComponent
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if _, ok := r.healthComponents[componentName]; ok {
-		return nil, werror.Error("Health component name already exists", werror.SafeParam("name", name))
+		return nil, werror.ErrorWithContextParams("Health component name already exists", werror.SafeParam("name", name))
 	}
 
 	r.healthComponents[componentName] = healthComponent

--- a/status/reporter/reporter_test.go
+++ b/status/reporter/reporter_test.go
@@ -61,18 +61,18 @@ func TestGetNotFound(t *testing.T) {
 
 func TestInitializeCollision(t *testing.T) {
 	reporter := NewHealthReporter()
-	component, err := reporter.InitializeHealthComponent(validComponent)
+	component, err := reporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.NotNil(t, component)
 	assert.NoError(t, err)
 
-	componentCollision, err := reporter.InitializeHealthComponent(validComponent)
+	componentCollision, err := reporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.Nil(t, componentCollision)
 	assert.Error(t, err)
 }
 
 func TestInitializeThenGet(t *testing.T) {
 	reporter := NewHealthReporter()
-	component, err := reporter.InitializeHealthComponent(validComponent)
+	component, err := reporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.NotNil(t, component)
 	assert.NoError(t, err)
 
@@ -83,7 +83,7 @@ func TestInitializeThenGet(t *testing.T) {
 
 func TestUnregisterThenGet(t *testing.T) {
 	reporter := newHealthReporter()
-	component, err := reporter.InitializeHealthComponent(validComponent)
+	component, err := reporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.NotNil(t, component)
 	assert.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestUnregisterThenGet(t *testing.T) {
 
 func TestUnregisterThenGetComponentStatus(t *testing.T) {
 	reporter := newHealthReporter()
-	component, err := reporter.InitializeHealthComponent(validComponent)
+	component, err := reporter.InitializeHealthComponent(context.Background(), validComponent)
 	assert.NotNil(t, component)
 	assert.NoError(t, err)
 

--- a/status/routes/routes.go
+++ b/status/routes/routes.go
@@ -15,6 +15,7 @@
 package routes
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/palantir/witchcraft-go-server/rest"
@@ -23,16 +24,16 @@ import (
 	"github.com/palantir/witchcraft-go-server/witchcraft/wresource"
 )
 
-func AddLivenessRoutes(resource wresource.Resource, source status.Source) error {
-	return resource.Get("liveness", status.LivenessEndpoint, handler(source))
+func AddLivenessRoutes(ctx context.Context, resource wresource.Resource, source status.Source) error {
+	return resource.Get(ctx, "liveness", status.LivenessEndpoint, handler(source))
 }
 
-func AddReadinessRoutes(resource wresource.Resource, source status.Source) error {
-	return resource.Get("readiness", status.ReadinessEndpoint, handler(source))
+func AddReadinessRoutes(ctx context.Context, resource wresource.Resource, source status.Source) error {
+	return resource.Get(ctx, "readiness", status.ReadinessEndpoint, handler(source))
 }
 
-func AddHealthRoutes(resource wresource.Resource, source status.HealthCheckSource, sharedSecret refreshable.String) error {
-	return resource.Get("health", status.HealthEndpoint, status.NewHealthCheckHandler(source, sharedSecret))
+func AddHealthRoutes(ctx context.Context, resource wresource.Resource, source status.HealthCheckSource, sharedSecret refreshable.String) error {
+	return resource.Get(ctx, "health", status.HealthEndpoint, status.NewHealthCheckHandler(source, sharedSecret))
 }
 
 // handler returns an HTTP handler that writes a response based on the provided source. The status code of the response

--- a/status/routes/routes_test.go
+++ b/status/routes/routes_test.go
@@ -42,7 +42,7 @@ func TestAddStatusRoutes(t *testing.T) {
 
 	for i, tc := range []struct {
 		endpoint  string
-		routeFunc func(resource wresource.Resource, source status.Source) error
+		routeFunc func(ctx context.Context, resource wresource.Resource, source status.Source) error
 		status    int
 		metadata  testMetadata
 	}{
@@ -68,7 +68,7 @@ func TestAddStatusRoutes(t *testing.T) {
 		func() {
 			r := wrouter.New(whttprouter.New(), nil)
 			resource := wresource.New("test", r)
-			err := tc.routeFunc(resource, statusFunc(func() (int, interface{}) {
+			err := tc.routeFunc(context.Background(), resource, statusFunc(func() (int, interface{}) {
 				return tc.status, tc.metadata
 			}))
 			require.NoError(t, err, "Case %d", i)
@@ -201,7 +201,7 @@ func TestAddHealthRoute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			r := wrouter.New(whttprouter.New())
 			resource := wresource.New("test", r)
-			err := AddHealthRoutes(resource, healthCheck{value: test.metadata}, refreshable.NewString(refreshable.NewDefaultRefreshable(test.sharedSecret)))
+			err := AddHealthRoutes(context.Background(), resource, healthCheck{value: test.metadata}, refreshable.NewString(refreshable.NewDefaultRefreshable(test.sharedSecret)))
 			require.NoError(t, err)
 
 			server := httptest.NewServer(r)

--- a/status/status.go
+++ b/status/status.go
@@ -115,7 +115,7 @@ func (h *healthHandlerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 
 func (h *healthHandlerImpl) computeNewHealthStatus(req *http.Request) (health.HealthStatus, int) {
 	if sharedSecret := h.healthCheckSharedSecret.CurrentString(); sharedSecret != "" {
-		token, err := rest.ParseBearerTokenHeader(req)
+		token, err := rest.ParseBearerTokenHeader(req.Context(), req)
 		if err != nil || sharedSecret != token {
 			return health.HealthStatus{}, http.StatusUnauthorized
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -41,7 +41,7 @@ github.com/palantir/pkg/signals
 github.com/palantir/pkg/tlsconfig
 # github.com/palantir/pkg/transform v1.0.0
 github.com/palantir/pkg/transform
-# github.com/palantir/witchcraft-go-error v1.2.0
+# github.com/palantir/witchcraft-go-error v1.3.0
 github.com/palantir/witchcraft-go-error
 github.com/palantir/witchcraft-go-error/internal/errors
 # github.com/palantir/witchcraft-go-logging v1.5.0

--- a/witchcraft/ecv.go
+++ b/witchcraft/ecv.go
@@ -15,6 +15,7 @@
 package witchcraft
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 
@@ -42,18 +43,18 @@ func ECVKeyFromStatic(kwt *encryptedconfigvalue.KeyWithType) ECVKeyProvider {
 	})
 }
 
-func ECVKeyFromFile(path string) ECVKeyProvider {
+func ECVKeyFromFile(ctx context.Context, path string) ECVKeyProvider {
 	return ecvKeyProvider(func() (*encryptedconfigvalue.KeyWithType, error) {
 		keyBytes, err := ioutil.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				return nil, werror.Wrap(err, "encryption key file does not exist", werror.SafeParam("path", path))
+				return nil, werror.WrapWithContextParams(ctx, err, "encryption key file does not exist", werror.SafeParam("path", path))
 			}
-			return nil, werror.Wrap(err, "failed to read encryption key file", werror.SafeParam("path", path))
+			return nil, werror.WrapWithContextParams(ctx, err, "failed to read encryption key file", werror.SafeParam("path", path))
 		}
 		kwt, err := encryptedconfigvalue.NewKeyWithType(string(keyBytes))
 		if err != nil {
-			return nil, werror.Wrap(err, "failed to create key with type")
+			return nil, werror.WrapWithContextParams(ctx, err, "failed to create key with type")
 		}
 		return &kwt, nil
 	})

--- a/witchcraft/internal/middleware/request_test.go
+++ b/witchcraft/internal/middleware/request_test.go
@@ -16,6 +16,7 @@ package middleware_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -187,7 +188,7 @@ func TestRequestMetricHandlerWithTags(t *testing.T) {
 		)
 
 		authResource := wresource.New("AuthResource", wRouter)
-		err := authResource.Get("userAuth", "/userAuth", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		err := authResource.Get(context.Background(), "userAuth", "/userAuth", http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 			rw.WriteHeader(http.StatusInternalServerError)
 		}))
 		require.NoError(t, err)

--- a/witchcraft/refreshable/refreshable.go
+++ b/witchcraft/refreshable/refreshable.go
@@ -14,6 +14,8 @@
 
 package refreshable
 
+import "context"
+
 type Refreshable interface {
 	// Current returns the most recent value of this Refreshable.
 	Current() interface{}
@@ -23,5 +25,5 @@ type Refreshable interface {
 	Subscribe(consumer func(interface{})) (unsubscribe func())
 
 	// Map returns a new Refreshable based on the current one that handles updates based on the current Refreshable.
-	Map(func(interface{}) interface{}) Refreshable
+	Map(context.Context, func(interface{}) interface{}) Refreshable
 }

--- a/witchcraft/refreshable/refreshable.go
+++ b/witchcraft/refreshable/refreshable.go
@@ -14,7 +14,9 @@
 
 package refreshable
 
-import "context"
+import (
+	"context"
+)
 
 type Refreshable interface {
 	// Current returns the most recent value of this Refreshable.

--- a/witchcraft/refreshable/refreshable_default.go
+++ b/witchcraft/refreshable/refreshable_default.go
@@ -15,6 +15,7 @@
 package refreshable
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -40,12 +41,12 @@ func NewDefaultRefreshable(val interface{}) *DefaultRefreshable {
 	}
 }
 
-func (d *DefaultRefreshable) Update(val interface{}) error {
+func (d *DefaultRefreshable) Update(ctx context.Context, val interface{}) error {
 	d.Lock()
 	defer d.Unlock()
 
 	if valType := reflect.TypeOf(val); valType != d.typ {
-		return werror.ErrorWithContextParams("value of Refreshable must is not the correct type",
+		return werror.ErrorWithContextParams(ctx, "value of Refreshable must is not the correct type",
 			werror.SafeParam("refreshableType", d.typ),
 			werror.SafeParam("providedType", valType))
 	}
@@ -92,10 +93,10 @@ func (d *DefaultRefreshable) unsubscribe(consumerFnPtr *func(interface{})) {
 	}
 }
 
-func (d *DefaultRefreshable) Map(mapFn func(interface{}) interface{}) Refreshable {
+func (d *DefaultRefreshable) Map(ctx context.Context, mapFn func(interface{}) interface{}) Refreshable {
 	newRefreshable := NewDefaultRefreshable(mapFn(d.Current()))
 	d.Subscribe(func(updatedVal interface{}) {
-		_ = newRefreshable.Update(mapFn(updatedVal))
+		_ = newRefreshable.Update(ctx, mapFn(updatedVal))
 	})
 	return newRefreshable
 }

--- a/witchcraft/refreshable/refreshable_default.go
+++ b/witchcraft/refreshable/refreshable_default.go
@@ -45,7 +45,7 @@ func (d *DefaultRefreshable) Update(val interface{}) error {
 	defer d.Unlock()
 
 	if valType := reflect.TypeOf(val); valType != d.typ {
-		return werror.Error("value of Refreshable must is not the correct type",
+		return werror.ErrorWithContextParams("value of Refreshable must is not the correct type",
 			werror.SafeParam("refreshableType", d.typ),
 			werror.SafeParam("providedType", valType))
 	}

--- a/witchcraft/refreshable/refreshable_file.go
+++ b/witchcraft/refreshable/refreshable_file.go
@@ -90,7 +90,7 @@ func (d *fileRefreshable) watchForChanges(ctx context.Context) error {
 						svc1log.FromContext(ctx).Debug("Ignoring fsnotify event for runtime configuration file because file checksum was unchanged")
 						continue
 					}
-					if err := d.innerRefreshable.Update(fileBytes); err != nil {
+					if err := d.innerRefreshable.Update(ctx, fileBytes); err != nil {
 						svc1log.FromContext(ctx).Error("Failed to update refreshable with new file bytes", svc1log.Stacktrace(err))
 						continue
 					}
@@ -112,6 +112,6 @@ func (d *fileRefreshable) Subscribe(consumer func(interface{})) (unsubscribe fun
 	return d.innerRefreshable.Subscribe(consumer)
 }
 
-func (d *fileRefreshable) Map(mapFn func(interface{}) interface{}) Refreshable {
-	return d.innerRefreshable.Map(mapFn)
+func (d *fileRefreshable) Map(ctx context.Context, mapFn func(interface{}) interface{}) Refreshable {
+	return d.innerRefreshable.Map(ctx, mapFn)
 }

--- a/witchcraft/refreshable/refreshable_file.go
+++ b/witchcraft/refreshable/refreshable_file.go
@@ -41,7 +41,7 @@ type fileRefreshable struct {
 func NewFileRefreshable(ctx context.Context, filePath string) (r Refreshable, rErr error) {
 	initialBytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return nil, werror.Wrap(err, "failed to create file-based Refreshable because file could not be read", werror.SafeParam("filePath", filePath))
+		return nil, werror.WrapWithContextParams(ctx, err, "failed to create file-based Refreshable because file could not be read", werror.SafeParam("filePath", filePath))
 	}
 	fRefreshable := &fileRefreshable{
 		innerRefreshable: NewDefaultRefreshable(initialBytes),
@@ -57,14 +57,14 @@ func NewFileRefreshable(ctx context.Context, filePath string) (r Refreshable, rE
 func (d *fileRefreshable) watchForChanges(ctx context.Context) error {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return werror.Wrap(err, "Failed to initialize file watcher")
+		return werror.WrapWithContextParams(ctx, err, "Failed to initialize file watcher")
 	}
 	// watch the directory to handle scenarios where the file is removed and then re-added
 	fileDir := filepath.Dir(d.filePath)
 	// use the base name of the fileLocation to normalize to the relative path the watcher will return
 	relativeFilePath := filepath.Base(d.filePath)
 	if err := watcher.Add(fileDir); err != nil {
-		return werror.Wrap(err, "Failed to add file to watcher",
+		return werror.WrapWithContextParams(ctx, err, "Failed to add file to watcher",
 			werror.SafeParam("file", d.filePath),
 			werror.SafeParam("fileDir", fileDir))
 	}

--- a/witchcraft/refreshable/refreshable_validating.go
+++ b/witchcraft/refreshable/refreshable_validating.go
@@ -41,8 +41,8 @@ func (v *ValidatingRefreshable) Subscribe(consumer func(interface{})) (unsubscri
 	return v.validatedRefreshable.Subscribe(consumer)
 }
 
-func (v *ValidatingRefreshable) Map(mapFn func(interface{}) interface{}) Refreshable {
-	return v.validatedRefreshable.Map(mapFn)
+func (v *ValidatingRefreshable) Map(ctx context.Context,  mapFn func(interface{}) interface{}) Refreshable {
+	return v.validatedRefreshable.Map(ctx, mapFn)
 }
 
 func (v *ValidatingRefreshable) LastValidateErr() error {
@@ -81,7 +81,7 @@ func NewValidatingRefreshable(ctx context.Context, origRefreshable Refreshable, 
 			return
 		}
 
-		if err := validatedRefreshable.Update(i); err != nil {
+		if err := validatedRefreshable.Update(ctx, i); err != nil {
 			v.lastValidateErr.Store(errorWrapper{err})
 			return
 		}

--- a/witchcraft/refreshable/refreshable_validating.go
+++ b/witchcraft/refreshable/refreshable_validating.go
@@ -41,7 +41,7 @@ func (v *ValidatingRefreshable) Subscribe(consumer func(interface{})) (unsubscri
 	return v.validatedRefreshable.Subscribe(consumer)
 }
 
-func (v *ValidatingRefreshable) Map(ctx context.Context,  mapFn func(interface{}) interface{}) Refreshable {
+func (v *ValidatingRefreshable) Map(ctx context.Context, mapFn func(interface{}) interface{}) Refreshable {
 	return v.validatedRefreshable.Map(ctx, mapFn)
 }
 

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -69,7 +69,7 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 	// start routine that capture Go runtime metrics
 	if !s.disableGoRuntimeMetrics {
 		if ok := metrics.CaptureRuntimeMemStatsWithContext(ctx, metricsRegistry, metricsEmitFreq); !ok {
-			return nil, nil, werror.ErrorWithContextParams(ctx,"metricsRegistry does not support capturing runtime memory statistics")
+			return nil, nil, werror.ErrorWithContextParams(ctx, "metricsRegistry does not support capturing runtime memory statistics")
 		}
 	}
 

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -69,7 +69,7 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 	// start routine that capture Go runtime metrics
 	if !s.disableGoRuntimeMetrics {
 		if ok := metrics.CaptureRuntimeMemStatsWithContext(ctx, metricsRegistry, metricsEmitFreq); !ok {
-			return nil, nil, werror.Error("metricsRegistry does not support capturing runtime memory statistics")
+			return nil, nil, werror.ErrorWithContextParams("metricsRegistry does not support capturing runtime memory statistics")
 		}
 	}
 

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -69,7 +69,7 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 	// start routine that capture Go runtime metrics
 	if !s.disableGoRuntimeMetrics {
 		if ok := metrics.CaptureRuntimeMemStatsWithContext(ctx, metricsRegistry, metricsEmitFreq); !ok {
-			return nil, nil, werror.ErrorWithContextParams("metricsRegistry does not support capturing runtime memory statistics")
+			return nil, nil, werror.ErrorWithContextParams(ctx,"metricsRegistry does not support capturing runtime memory statistics")
 		}
 	}
 

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -51,7 +51,7 @@ func (s *Server) addRoutes(ctx context.Context, mgmtRouterWithContextPath wroute
 	statusResource := wresource.New("status", mgmtRouterWithContextPath)
 
 	// add health endpoints
-	if err := routes.AddHealthRoutes(ctx, statusResource, status.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager, configHealthCheckSource)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
+	if err := routes.AddHealthRoutes(ctx, statusResource, status.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager, configHealthCheckSource)...), refreshable.NewString(runtimeCfg.Map(ctx, func(in interface{}) interface{} {
 		return in.(config.Runtime).HealthChecks.SharedSecret
 	}))); err != nil {
 		return werror.WrapWithContextParams(ctx, err, "failed to register health routes")

--- a/witchcraft/server_run.go
+++ b/witchcraft/server_run.go
@@ -103,7 +103,7 @@ func newTLSConfig(ctx context.Context, serverConfig config.Server, useSelfSigned
 		} else {
 			msg = "certificate file"
 		}
-		return nil, werror.ErrorWithContextParams(ctx, msg + " for server not specified in configuration")
+		return nil, werror.ErrorWithContextParams(ctx, msg+" for server not specified in configuration")
 	}
 
 	tlsConfig, err := tlsconfig.NewServerConfig(

--- a/witchcraft/server_run.go
+++ b/witchcraft/server_run.go
@@ -67,7 +67,7 @@ func newServerStartShutdownFns(
 	svcLogger svc1log.Logger,
 	handler http.Handler,
 ) (rHTTPServer *http.Server, start func() error, shutdown func(context.Context) error, rErr error) {
-	tlsConfig, err := newTLSConfig(serverConfig, useSelfSignedServerCertificate, clientAuthType)
+	tlsConfig, err := newTLSConfig(ctx, serverConfig, useSelfSignedServerCertificate, clientAuthType)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -103,7 +103,7 @@ func newTLSConfig(ctx context.Context, serverConfig config.Server, useSelfSigned
 		} else {
 			msg = "certificate file"
 		}
-		return nil, werror.Error(msg + " for server not specified in configuration")
+		return nil, werror.ErrorWithContextParams(ctx, msg + " for server not specified in configuration")
 	}
 
 	tlsConfig, err := tlsconfig.NewServerConfig(

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -49,7 +49,7 @@ type serverStateManager struct {
 	serverRunning int32
 }
 
-func (s *serverStateManager) Start() error {
+func (s *serverStateManager) Start(ctx context.Context) error {
 	// state went from Idle to Initializing: OK
 	if atomic.CompareAndSwapInt32(&s.serverRunning, int32(ServerIdle), int32(ServerInitializing)) {
 		return nil
@@ -58,11 +58,11 @@ func (s *serverStateManager) Start() error {
 	// error if current state is not idle/failed to transition to initializing
 	switch s.State() {
 	case ServerInitializing:
-		return werror.ErrorWithContextParams("server is already initializing and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx,"server is already initializing and must be stopped before it can be started again")
 	case ServerRunning:
-		return werror.ErrorWithContextParams("server is already running and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx,"server is already running and must be stopped before it can be started again")
 	default:
-		return werror.ErrorWithContextParams("server is in an unknown state and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx,"server is in an unknown state and must be stopped before it can be started again")
 	}
 }
 

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -58,11 +58,11 @@ func (s *serverStateManager) Start() error {
 	// error if current state is not idle/failed to transition to initializing
 	switch s.State() {
 	case ServerInitializing:
-		return werror.Error("server is already initializing and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams("server is already initializing and must be stopped before it can be started again")
 	case ServerRunning:
-		return werror.Error("server is already running and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams("server is already running and must be stopped before it can be started again")
 	default:
-		return werror.Error("server is in an unknown state and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams("server is in an unknown state and must be stopped before it can be started again")
 	}
 }
 

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -58,11 +58,11 @@ func (s *serverStateManager) Start(ctx context.Context) error {
 	// error if current state is not idle/failed to transition to initializing
 	switch s.State() {
 	case ServerInitializing:
-		return werror.ErrorWithContextParams(ctx,"server is already initializing and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx, "server is already initializing and must be stopped before it can be started again")
 	case ServerRunning:
-		return werror.ErrorWithContextParams(ctx,"server is already running and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx, "server is already running and must be stopped before it can be started again")
 	default:
-		return werror.ErrorWithContextParams(ctx,"server is in an unknown state and must be stopped before it can be started again")
+		return werror.ErrorWithContextParams(ctx, "server is in an unknown state and must be stopped before it can be started again")
 	}
 }
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -556,7 +556,7 @@ func (s *Server) Start() (rErr error) {
 	}
 
 	// load install configuration
-	baseInstallCfg, fullInstallCfg, err := s.initInstallConfig(context.Background(), )
+	baseInstallCfg, fullInstallCfg, err := s.initInstallConfig(context.Background())
 	if err != nil {
 		return err
 	}

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -43,7 +43,7 @@ func TestFatalErrorLogging(t *testing.T) {
 		{
 			Name: "error returned by init function",
 			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
-				return nil, werror.Error("oops", werror.SafeParam("k", "v"))
+				return nil, werror.ErrorWithContextParams("oops", werror.SafeParam("k", "v"))
 			},
 			VerifyLog: func(t *testing.T, logOutput []byte) {
 				var log logging.ServiceLogV1
@@ -57,7 +57,7 @@ func TestFatalErrorLogging(t *testing.T) {
 		{
 			Name: "panic init function with error",
 			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
-				panic(werror.Error("oops", werror.SafeParam("k", "v")))
+				panic(werror.ErrorWithContextParams("oops", werror.SafeParam("k", "v")))
 			},
 			VerifyLog: func(t *testing.T, logOutput []byte) {
 				var log logging.ServiceLogV1

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -43,7 +43,7 @@ func TestFatalErrorLogging(t *testing.T) {
 		{
 			Name: "error returned by init function",
 			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
-				return nil, werror.ErrorWithContextParams("oops", werror.SafeParam("k", "v"))
+				return nil, werror.ErrorWithContextParams(ctx, "oops", werror.SafeParam("k", "v"))
 			},
 			VerifyLog: func(t *testing.T, logOutput []byte) {
 				var log logging.ServiceLogV1
@@ -57,7 +57,7 @@ func TestFatalErrorLogging(t *testing.T) {
 		{
 			Name: "panic init function with error",
 			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
-				panic(werror.ErrorWithContextParams("oops", werror.SafeParam("k", "v")))
+				panic(werror.ErrorWithContextParams(ctx, "oops", werror.SafeParam("k", "v")))
 			},
 			VerifyLog: func(t *testing.T, logOutput []byte) {
 				var log logging.ServiceLogV1

--- a/witchcraft/wresource/resource.go
+++ b/witchcraft/wresource/resource.go
@@ -15,6 +15,7 @@
 package wresource
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/palantir/pkg/metrics"
@@ -33,25 +34,25 @@ const (
 type Resource interface {
 	// Register performs the same operation as the Router.Register, but registers the route using the provided
 	// resourceName as the resource name that will be used as the tag in the recorded metric.
-	Register(endpointName, method, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Register(ctx context.Context, endpointName, method, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Get is a shorthand for Register(endpointName, http.MethodGet, handler, params...)
-	Get(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Get(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Head is a shorthand for Register(endpointName, http.MethodHead, handler, params...)
-	Head(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Head(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Post is a shorthand for Register(endpointName, http.MethodPost, handler, params...)
-	Post(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Post(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Put is a shorthand for Register(endpointName, http.MethodPut, handler, params...)
-	Put(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Put(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Patch is a shorthand for Register(endpointName, http.MethodPatch, handler, params...)
-	Patch(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Patch(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 
 	// Delete is a shorthand for Register(endpointName, http.MethodDelete, handler, params...)
-	Delete(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
+	Delete(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error
 }
 
 func New(resourceName string, router wrouter.Router) Resource {
@@ -67,49 +68,49 @@ type resourceImpl struct {
 	router       wrouter.Router
 }
 
-func (r *resourceImpl) Register(endpointName, method, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+func (r *resourceImpl) Register(ctx context.Context, endpointName, method, path string, handler http.Handler, params ...wrouter.RouteParam) error {
 	var tags metrics.Tags
 	resourceTag, err := metrics.NewTag(ResourceTagName, r.resourceName)
 	if err != nil {
-		return werror.Wrap(err, "failed to create metric resourceTag")
+		return werror.WrapWithContextParams(ctx, err, "failed to create metric resourceTag")
 	}
 	tags = append(tags, resourceTag)
 
 	methodTag, err := metrics.NewTag(MethodTagName, method)
 	if err != nil {
-		return werror.Wrap(err, "failed to create metric methodTag")
+		return werror.WrapWithContextParams(ctx, err, "failed to create metric methodTag")
 	}
 	tags = append(tags, methodTag)
 
 	endpointTag, err := metrics.NewTag(EndpointTagName, endpointName)
 	if err != nil {
-		return werror.Wrap(err, "failed to create metric endpointTag")
+		return werror.WrapWithContextParams(ctx, err, "failed to create metric endpointTag")
 	}
 	tags = append(tags, endpointTag)
 
 	return r.router.Register(method, path, handler, append(params, wrouter.MetricTags(tags))...)
 }
 
-func (r *resourceImpl) Get(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodGet, path, handler, params...)
+func (r *resourceImpl) Get(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodGet, path, handler, params...)
 }
 
-func (r *resourceImpl) Head(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodHead, path, handler, params...)
+func (r *resourceImpl) Head(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodHead, path, handler, params...)
 }
 
-func (r *resourceImpl) Post(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodPost, path, handler, params...)
+func (r *resourceImpl) Post(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodPost, path, handler, params...)
 }
 
-func (r *resourceImpl) Put(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodPut, path, handler, params...)
+func (r *resourceImpl) Put(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodPut, path, handler, params...)
 }
 
-func (r *resourceImpl) Patch(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodPatch, path, handler, params...)
+func (r *resourceImpl) Patch(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodPatch, path, handler, params...)
 }
 
-func (r *resourceImpl) Delete(endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
-	return r.Register(endpointName, http.MethodDelete, path, handler, params...)
+func (r *resourceImpl) Delete(ctx context.Context, endpointName, path string, handler http.Handler, params ...wrouter.RouteParam) error {
+	return r.Register(ctx, endpointName, http.MethodDelete, path, handler, params...)
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- Bump werror to 1.3.0 and move over Error/Wrap functions
- The Error/Wrap functions without a context are deprecated 
## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/158)
<!-- Reviewable:end -->
