### PR TITLE
[DO NOT MERGE] Add broken test demonstrating health check source behavior.

### DIFF
--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -16,6 +16,7 @@ package window
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -91,6 +92,15 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 					"3": "Error #1 for key 3",
 				},
 			},
+		},
+		{
+			name: "new nil error for key results in healthy",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1", err: fmt.Errorf("error #1 for key 1")},
+				{key: "2", err: nil},
+				{key: "1", err: nil},
+			},
+			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds a test demonstrating the behavior of the `multiKeyUnhealthyIfAtLeastOneErrorSource` health check source when a key `k` is submitted first with a non-nil error and then with a nil error. I want to verify with @splucs that this behavior is intended. I used this health check for the following use case:
- a processor pulls of elements from a queue. These queue elements happen to just be strings that are effectively keys for retrieving objects from a cache.
- the processor succeeds or fails to process queue elements. It submits the queue element as the key and the possibly nil error to the health check source.
- the processor re-enqueues elements it fails to process.
- the processor sometimes successfully processes these elements soon after the initial failure. In this case, the processor submits the same key, now with a nil error, to the health check source.

Ideally (at least in this use case), submitting the same key with a nil error upon a successful retry would cause the reported health status to be healthy. This is not the current behavior. I'm happy to make the code change if we want to change the current behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/159)
<!-- Reviewable:end -->
