### PR TITLE
Add `store.KeyedErrorHealthCheckSource` interface and default implementation.

### DIFF
--- a/changelog/@unreleased/pr-160.v2.yml
+++ b/changelog/@unreleased/pr-160.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Add `store.KeyedErrorHealthCheckSource` interface and default implementation.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/160
+

--- a/status/health/store/keyed_error_source.go
+++ b/status/health/store/keyed_error_source.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"sync"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status"
+)
+
+// KeyedErrorSubmitter is a separate interface to allow method signatures to only accept the Submit functionality of
+// a KeyedErrorHealthCheckSource
+type KeyedErrorSubmitter interface {
+	Submit(key string, err error)
+}
+
+// KeyedErrorHealthCheckSource tracks errors by key to compute health status
+type KeyedErrorHealthCheckSource interface {
+	KeyedErrorSubmitter
+	status.HealthCheckSource
+}
+
+type keyedErrorHealthCheckSource struct {
+	lock         sync.Mutex
+	keyedErrors  map[string]error
+	checkType    health.CheckType
+	checkMessage string
+}
+
+// NewKeyedErrorHealthCheckSource creates a health messenger that tracks errors by keys to compute health status
+func NewKeyedErrorHealthCheckSource(checkType health.CheckType, checkMessage string) KeyedErrorHealthCheckSource {
+	return &keyedErrorHealthCheckSource{
+		checkType:    checkType,
+		checkMessage: checkMessage,
+		keyedErrors:  make(map[string]error),
+	}
+}
+
+func (k *keyedErrorHealthCheckSource) Submit(key string, err error) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	if err == nil {
+		delete(k.keyedErrors, key)
+	} else {
+		k.keyedErrors[key] = err
+	}
+}
+
+func (k *keyedErrorHealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	if len(k.keyedErrors) == 0 {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				k.checkType: {
+					Message: &k.checkMessage,
+					Type:    k.checkType,
+					State:   health.HealthStateHealthy,
+				},
+			},
+		}
+	}
+	params := make(map[string]interface{}, len(k.keyedErrors))
+	for key, err := range k.keyedErrors {
+		params[key] = err.Error()
+	}
+	return health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			k.checkType: {
+				Message: &k.checkMessage,
+				Params:  params,
+				Type:    k.checkType,
+				State:   health.HealthStateError,
+			},
+		},
+	}
+}

--- a/status/health/store/keyed_error_source.go
+++ b/status/health/store/keyed_error_source.go
@@ -22,13 +22,19 @@ import (
 	"github.com/palantir/witchcraft-go-server/status"
 )
 
-// KeyedErrorSubmitter is a separate interface to allow method signatures to only accept the Submit functionality of
-// a KeyedErrorHealthCheckSource
+// KeyedErrorSubmitter is not intended to be implemented separately - it simply
+// provides consumers the ability to scope a method argument, such as a constructor, to provide
+// only the Submit functionality of the KeyedErrorHealthCheckSource.
 type KeyedErrorSubmitter interface {
+	// Submit stores non-nil errors by the provided key in a map; keys of submitted nil errors are
+	// deleted from the map.
 	Submit(key string, err error)
 }
 
-// KeyedErrorHealthCheckSource tracks errors by key to compute health status
+// KeyedErrorHealthCheckSource tracks errors by key to compute health status. Only entries with non-nil
+// errors are stored. When computing health status, the KeyedErrorHealthCheckSource will return a
+// health status with state HealthStateHealthy if it has no error entries. If it has any error entries, it will return
+// a health status with the state HealthStateError.
 type KeyedErrorHealthCheckSource interface {
 	KeyedErrorSubmitter
 	status.HealthCheckSource
@@ -41,7 +47,7 @@ type keyedErrorHealthCheckSource struct {
 	checkMessage string
 }
 
-// NewKeyedErrorHealthCheckSource creates a health messenger that tracks errors by keys to compute health status
+// NewKeyedErrorHealthCheckSource creates a health messenger that tracks errors by keys to compute health status.
 func NewKeyedErrorHealthCheckSource(checkType health.CheckType, checkMessage string) KeyedErrorHealthCheckSource {
 	return &keyedErrorHealthCheckSource{
 		checkType:    checkType,

--- a/status/health/store/keyed_error_source.go
+++ b/status/health/store/keyed_error_source.go
@@ -34,7 +34,7 @@ type KeyedErrorSubmitter interface {
 // KeyedErrorHealthCheckSource tracks errors by key to compute health status. Only entries with non-nil
 // errors are stored. When computing health status, the KeyedErrorHealthCheckSource will return a
 // health status with state HealthStateHealthy if it has no error entries. If it has any error entries, it will return
-// a health status with the state HealthStateError.
+// a health status with the state set to HealthStateError and params including all errors by their keys.
 type KeyedErrorHealthCheckSource interface {
 	KeyedErrorSubmitter
 	status.HealthCheckSource

--- a/status/health/store/keyed_error_source_test.go
+++ b/status/health/store/keyed_error_source_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testMessage = "test message"
+)
+
+func TestKeyedMessengerHealthStateError(t *testing.T) {
+	keyedErrorSource := NewKeyedErrorHealthCheckSource("TEST", testMessage)
+	keyedErrorSource.Submit("1", fmt.Errorf("error message 1"))
+	keyedErrorSource.Submit("2", fmt.Errorf("error message 2"))
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"TEST": {
+				Message: &testMessage,
+				Params: map[string]interface{}{
+					"1": "error message 1",
+					"2": "error message 2",
+				},
+				State: health.HealthStateError,
+				Type:  "TEST",
+			},
+		},
+	}, keyedErrorSource.HealthStatus(context.Background()))
+}
+
+func TestKeyedMessengerHealthStateHealthy(t *testing.T) {
+	keyedErrorSource := NewKeyedErrorHealthCheckSource("TEST", testMessage)
+	keyedErrorSource.Submit("1", fmt.Errorf("error message 1"))
+	keyedErrorSource.Submit("1", nil)
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"TEST": {
+				Message: &testMessage,
+				State:   health.HealthStateHealthy,
+				Type:    "TEST",
+			},
+		},
+	}, keyedErrorSource.HealthStatus(context.Background()))
+}


### PR DESCRIPTION
## Before this PR
The existing `window` package has some limitations around computing health described [here](https://github.com/palantir/witchcraft-go-server/pull/159).

## After this PR
==COMMIT_MSG==
The `store.KeyedErrorHealthCheckSource` provides a way to compute health based on keyed errors, where key+error entries are deleted if a nil error is submitted.
==COMMIT_MSG==

## Possible downsides?
Potentially confusing package structure given that `window` has keyed store implementations in it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/160)
<!-- Reviewable:end -->
