### PR TITLE
Enforce full initial elapses window before HealthyIfNotAllErrorsSource reports unhealthy

### DIFF
--- a/changelog/@unreleased/pr-165.v2.yml
+++ b/changelog/@unreleased/pr-165.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    HealthyIfNotAllErrorsSources require the window period elapse after startup before becoming unhealthy whether anchored or not.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/165
+

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -126,6 +126,8 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			timeProvider := &offsetTimeProvider{}
 			source, err := newHealthyIfNotAllErrorsSource(testCheckType, time.Hour, false, timeProvider)
+
+			// Make sure test is applied outside of startup window
 			timeProvider.RestlessSleep(time.Hour)
 
 			require.NoError(t, err)
@@ -143,9 +145,23 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 	}
 }
 
-// TestErrorInInitialWindow validates that the anchor prevents a single error
-// in the first window from causing the health status to become unhealthy
+// TestErrorInInitialWindow validates that error in the first window
+// does not cause the health status to become unhealthy
 func TestErrorInInitialWindow(t *testing.T) {
+	timeProvider := &offsetTimeProvider{}
+	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, false, timeProvider)
+	assert.NoError(t, err)
+
+	anchoredWindow.Submit(werror.ErrorWithContextParams(context.Background(), "an error"))
+	healthStatus := anchoredWindow.HealthStatus(context.Background())
+	checkResult, ok := healthStatus.Checks[testCheckType]
+	assert.True(t, ok)
+	assert.Equal(t, health.HealthStateHealthy, checkResult.State)
+}
+
+// TestErrorInInitialWindow validates that error in the first window
+// does not cause the health status to become unhealthy when anchored as well
+func TestErrorInInitialAnchoredWindow(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, true, timeProvider)
 	assert.NoError(t, err)

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -68,6 +68,7 @@ func TestUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			source, err := NewUnhealthyIfAtLeastOneErrorSource(testCheckType, time.Hour)
 			require.NoError(t, err)
+
 			for _, err := range testCase.errors {
 				source.Submit(err)
 			}
@@ -123,7 +124,10 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			source, err := NewHealthyIfNotAllErrorsSource(testCheckType, time.Hour)
+			timeProvider := &offsetTimeProvider{}
+			source, err := newHealthyIfNotAllErrorsSource(testCheckType, time.Hour, false, timeProvider)
+			timeProvider.RestlessSleep(time.Hour)
+
 			require.NoError(t, err)
 			for _, err := range testCase.errors {
 				source.Submit(err)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The default behavior for all HealthyIfNotAllErrorsSource should intuitively be to require the first initial window to elapse before it can become unhealthy, regardless if it is anchored or not. Anchoring should only be required if desired in post startup windows 

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
HealthyIfNotAllErrorsSources require the window period elapse after startup before becoming unhealthy whether anchored or not.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Breaking change in existing behavior for those who count on initial window to become unhealthy on single error, but in truth such uses should likely have been using NewUnhealthyIfAtLeastOneErrorSource actually anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/165)
<!-- Reviewable:end -->
