### PR TITLE
Reduce default trace sample rate from 100% -> 1%

### DIFF
--- a/changelog/@unreleased/pr-170.v2.yml
+++ b/changelog/@unreleased/pr-170.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Reduce default trace sample rate from 100% -> 1%
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/170
+

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -238,6 +238,8 @@ type ConfigurableRouter interface {
 	WithLiveness(liveness status.Source) *Server
 }
 
+const defaultSampleRate = 0.01
+
 // NewServer returns a new uninitialized server.
 func NewServer() *Server {
 	return &Server{}
@@ -903,7 +905,7 @@ func stopServer(s *Server, stopper func(s *http.Server) error) error {
 }
 
 func (s *Server) getApplicationTracingOptions(install config.Install) []wtracing.TracerOption {
-	return getTracingOptions(s.applicationTraceSampler, install, alwaysSample, install.Server.Port, install.TraceSampleRate)
+	return getTracingOptions(s.applicationTraceSampler, install, traceSamplerFromSampleRate(defaultSampleRate), install.Server.Port, install.TraceSampleRate)
 }
 
 func (s *Server) getManagementTracingOptions(install config.Install) []wtracing.TracerOption {


### PR DESCRIPTION
## Before this PR
Fixes https://github.com/palantir/witchcraft-go-server/issues/169

## After this PR
==COMMIT_MSG==
Reduce default trace sample rate from 100% -> 1%
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/170)
<!-- Reviewable:end -->
