### PR TITLE
Convert all errors during a set grace period into REPAIRING

### DIFF
--- a/changelog/@unreleased/pr-174.v2.yml
+++ b/changelog/@unreleased/pr-174.v2.yml
@@ -1,7 +1,7 @@
 type: improvement
 improvement:
   description: |
-    Add an option to convert all errors during a set grace period into REPAIRING.
+    Convert all errors during a set grace period into REPAIRING.
   links:
     - https://github.com/palantir/witchcraft-go-server/pull/174
 

--- a/changelog/@unreleased/pr-174.v2.yml
+++ b/changelog/@unreleased/pr-174.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Add an option to convert all errors during a set grace period into REPAIRING.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/174
+

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -243,7 +243,7 @@ func TestPeriodicHealthSource(t *testing.T) {
 		},
 		"ERROR_CHECK": {
 			Type:    "ERROR_CHECK",
-			State:   health.HealthStateError,
+			State:   health.HealthStateRepairing,
 			Message: stringPtr("No successful checks during 1m0s grace period: something went wrong"),
 			Params:  map[string]interface{}{"foo": "bar"},
 		},

--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -14,6 +14,10 @@
 
 package periodic
 
+import (
+	"time"
+)
+
 type Option interface {
 	apply(source *healthCheckSource)
 }
@@ -29,5 +33,13 @@ func (fn optionFn) apply(source *healthCheckSource) {
 func WithInitialPoll() Option {
 	return optionFn(func(source *healthCheckSource) {
 		source.initialPoll = true
+	})
+}
+
+// WithStartupGracePeriod configures the health check source to transform all ERROR results into REPAIRING results
+// for the first startupGracePeriod time window.
+func WithStartupGracePeriod(startupGracePeriod time.Duration) Option {
+	return optionFn(func(source *healthCheckSource) {
+		source.startupGracePeriod = startupGracePeriod
 	})
 }

--- a/status/health/periodic/option.go
+++ b/status/health/periodic/option.go
@@ -38,6 +38,7 @@ func WithInitialPoll() Option {
 
 // WithStartupGracePeriod configures the health check source to transform all ERROR results into REPAIRING results
 // for the first startupGracePeriod time window.
+// The default value of the startup grace period is the window grace period.
 func WithStartupGracePeriod(startupGracePeriod time.Duration) Option {
 	return optionFn(func(source *healthCheckSource) {
 		source.startupGracePeriod = startupGracePeriod

--- a/status/health/periodic/options_test.go
+++ b/status/health/periodic/options_test.go
@@ -28,8 +28,10 @@ func TestWithInitialPoll(t *testing.T) {
 	var pollAlwaysErr = func() error {
 		return fmt.Errorf("error")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	periodicCheckWithInitialPoll := NewHealthCheckSource(
-		context.Background(),
+		ctx,
 		time.Minute,
 		time.Second,
 		"CHECK_TYPE",
@@ -46,14 +48,16 @@ func TestWithStartupGracePeriod(t *testing.T) {
 	var pollAlwaysErr = func() error {
 		return fmt.Errorf("error")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	periodicCheckWithInitialPoll := NewHealthCheckSource(
-		context.Background(),
+		ctx,
 		time.Minute,
 		time.Second,
 		"CHECK_TYPE",
 		pollAlwaysErr,
 		WithInitialPoll(),
-		WithStartupGracePeriod(2*time.Second))
+		WithStartupGracePeriod(3*time.Second/2))
 	<-time.After(time.Second)
 	healthStatus := periodicCheckWithInitialPoll.HealthStatus(context.Background())
 	check, ok := healthStatus.Checks["CHECK_TYPE"]

--- a/status/health/periodic/options_test.go
+++ b/status/health/periodic/options_test.go
@@ -36,7 +36,8 @@ func TestWithInitialPoll(t *testing.T) {
 		time.Second,
 		"CHECK_TYPE",
 		pollAlwaysErr,
-		WithInitialPoll())
+		WithInitialPoll(),
+		WithStartupGracePeriod(0))
 	<-time.After(time.Second)
 	healthStatus := periodicCheckWithInitialPoll.HealthStatus(context.Background())
 	check, ok := healthStatus.Checks["CHECK_TYPE"]

--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -66,11 +66,12 @@ func NewHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryI
 // of error.
 func FromHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retryInterval time.Duration, source Source, options ...Option) status.HealthCheckSource {
 	checker := &healthCheckSource{
-		source:        source,
-		gracePeriod:   gracePeriod,
-		retryInterval: retryInterval,
-		checkStates:   map[health.CheckType]*checkState{},
-		startupTime:   time.Now(),
+		source:             source,
+		gracePeriod:        gracePeriod,
+		retryInterval:      retryInterval,
+		checkStates:        map[health.CheckType]*checkState{},
+		startupTime:        time.Now(),
+		startupGracePeriod: gracePeriod,
 	}
 	for _, option := range options {
 		option.apply(checker)

--- a/status/health/periodic/source.go
+++ b/status/health/periodic/source.go
@@ -44,7 +44,7 @@ type healthCheckSource struct {
 	gracePeriod        time.Duration
 	retryInterval      time.Duration
 	initialPoll        bool
-	startupTIme        time.Time
+	startupTime        time.Time
 	startupGracePeriod time.Duration
 
 	// mutable
@@ -70,7 +70,7 @@ func FromHealthCheckSource(ctx context.Context, gracePeriod time.Duration, retry
 		gracePeriod:   gracePeriod,
 		retryInterval: retryInterval,
 		checkStates:   map[health.CheckType]*checkState{},
-		startupTIme:   time.Now(),
+		startupTime:   time.Now(),
 	}
 	for _, option := range options {
 		option.apply(checker)
@@ -109,7 +109,7 @@ func (h *healthCheckSource) HealthStatus(ctx context.Context) health.HealthStatu
 				result.State = health.HealthStateRepairing
 			}
 		}
-		if time.Since(h.startupTIme) < h.startupGracePeriod && result.State == health.HealthStateError {
+		if time.Since(h.startupTime) < h.startupGracePeriod && result.State == health.HealthStateError {
 			result.State = health.HealthStateRepairing
 		}
 		results = append(results, result)


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
If the first runs of the periodic check return an error, the health check will become unhealthy. This PR converts all errors during a set grace period into REPAIRING. The default grace period is the check grace period but there is an option to change it.

## After this PR
==COMMIT_MSG==
Convert all errors during a set grace period into REPAIRING.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
The change is optional, current workflows are unaffected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/174)
<!-- Reviewable:end -->
