### PR TITLE
Return repairing for errors inside anchored window

### DIFF
--- a/changelog/@unreleased/pr-175.v2.yml
+++ b/changelog/@unreleased/pr-175.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Return repairing for errors inside anchored window
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/174
+

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -37,7 +37,7 @@ type ErrorHealthCheckSource interface {
 }
 
 // unhealthyIfAtLeastOneErrorSource is a HealthCheckSource that polls a TimeWindowedStore.
-// It returns the first non-nil error as an unhealthy check.
+// It returns the latest non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
 type unhealthyIfAtLeastOneErrorSource struct {
 	// unhealthyIfAtLeastOneErrorSource is a healthyIfNotAllErrorsSource that drops all successes.
@@ -58,7 +58,7 @@ func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowS
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
 func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	underlyingSource, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, false, newOrdinaryTimeProvider())
+	underlyingSource, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, 0, false, newOrdinaryTimeProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -82,25 +82,24 @@ func (u *unhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) hea
 }
 
 // healthyIfNotAllErrorsSource is a HealthCheckSource that polls a TimeWindowedStore.
-// It returns, if there are only non-nil errors, the first non-nil error as an unhealthy check.
+// It returns, if there are only non-nil errors, the latest non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
 type healthyIfNotAllErrorsSource struct {
-	timeProvider           timeProvider
-	useAnchoredWindows     bool
-	windowSize             time.Duration
-	lastErrorTime          time.Time
-	lastError              error
-	lastSuccessTime        time.Time
-	sourceMutex            sync.RWMutex
-	checkType              health.CheckType
-	requireFirstFullWindow bool
-	startTime              time.Time
+	timeProvider         timeProvider
+	windowSize           time.Duration
+	lastErrorTime        time.Time
+	lastError            error
+	lastSuccessTime      time.Time
+	sourceMutex          sync.RWMutex
+	checkType            health.CheckType
+	repairingGracePeriod time.Duration
+	repairingDeadline    time.Time
 }
 
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, newOrdinaryTimeProvider())
+	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, 0, true, newOrdinaryTimeProvider())
 	if err != nil {
 		panic(err)
 	}
@@ -110,17 +109,18 @@ func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize t
 // NewHealthyIfNotAllErrorsSource creates an healthyIfNotAllErrorsSource
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
+// Errors submitted in the first time window cause the health check to go to REPAIRING instead of ERROR.
 func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	return newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, newOrdinaryTimeProvider())
+	return newHealthyIfNotAllErrorsSource(checkType, windowSize, 0, true, newOrdinaryTimeProvider())
 }
 
 // MustNewAnchoredHealthyIfNotAllErrorsSource returns the result of calling
 // NewAnchoredHealthyIfNotAllErrorsSource but panics if that call returns an error
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 // Care should be taken in considering health submission rate and window size when using anchored
-// windows. Windows too close to service emission frequency may cause errors to not surface
+// windows. Windows too close to service emission frequency may cause errors to not surface.
 func MustNewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, newOrdinaryTimeProvider())
+	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, windowSize, true, newOrdinaryTimeProvider())
 	if err != nil {
 		panic(err)
 	}
@@ -129,35 +129,38 @@ func MustNewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, wind
 
 // NewAnchoredHealthyIfNotAllErrorsSource creates an healthyIfNotAllErrorsSource
 // with supplied checkType, using sliding window of size windowSize, which will
-// anchor (force the window to be at least the grace period) by inserting a healthy
-// check at the beginning of new the initial window or after gaps greater than windowSize
-// windowSize must be a positive value, otherwise returns error. Care should be taken in
-// considering health submission rate and window size when using anchored windows.
-// Windows too close to service emission frequency may cause errors to not surface
+// anchor (force the window to be at least the grace period) by defining a repairing deadline
+// at the end of the initial window or one window size after the end of a gap.
+// If all errors happen before the repairing deadline, the health check returns REPAIRING instead of ERROR.
+// windowSize must be a positive value, otherwise returns error.
+// Care should be taken in considering health submission rate and window size when using anchored
+// windows. Windows too close to service emission frequency may cause errors to not surface.
 func NewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	return newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, newOrdinaryTimeProvider())
+	return newHealthyIfNotAllErrorsSource(checkType, windowSize, windowSize, true, newOrdinaryTimeProvider())
 }
 
-func newHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration, useAnchoredWindows bool, requireFirstFullWindow bool, timeProvider timeProvider) (ErrorHealthCheckSource, error) {
+func newHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize, repairingGracePeriod time.Duration, requireFirstFullWindow bool, timeProvider timeProvider) (ErrorHealthCheckSource, error) {
 	if windowSize <= 0 {
-		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
+		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize.String()))
+	}
+	if repairingGracePeriod < 0 {
+		return nil, werror.Error("repairingGracePeriod must be non negative", werror.SafeParam("repairingGracePeriod", repairingGracePeriod.String()))
 	}
 
-	retVal := &healthyIfNotAllErrorsSource{
-		timeProvider:           timeProvider,
-		useAnchoredWindows:     useAnchoredWindows,
-		windowSize:             windowSize,
-		checkType:              checkType,
-		startTime:              timeProvider.Now(),
-		requireFirstFullWindow: requireFirstFullWindow,
+	source := &healthyIfNotAllErrorsSource{
+		timeProvider:         timeProvider,
+		windowSize:           windowSize,
+		checkType:            checkType,
+		repairingGracePeriod: repairingGracePeriod,
+		repairingDeadline:    timeProvider.Now(),
 	}
 
-	// When anchored treat first initial window as anchored
-	if useAnchoredWindows {
-		retVal.lastSuccessTime = retVal.timeProvider.Now()
+	// If requireFirstFullWindow, extend the repairing deadline to one windowSize from now.
+	if requireFirstFullWindow {
+		source.repairingDeadline = timeProvider.Now().Add(windowSize)
 	}
 
-	return retVal, nil
+	return source, nil
 }
 
 // Submit submits an error.
@@ -166,12 +169,12 @@ func (h *healthyIfNotAllErrorsSource) Submit(err error) {
 	defer h.sourceMutex.Unlock()
 
 	// If using anchored windows when last submit is greater than the window
-	// it will re-anchor the next window with a new healthy point.
-	if h.useAnchoredWindows && h.timeProvider.Now().Sub(h.lastSuccessTime) > h.windowSize &&
-		(h.lastErrorTime.IsZero() || h.timeProvider.Now().Sub(h.lastErrorTime) > h.windowSize) {
-		// This check source treats no data as healthy so implicitly
-		// are already reporting healthy when doing the re-anchor
-		h.lastSuccessTime = h.timeProvider.Now()
+	// it will re-anchor the next window with a new repairing deadline.
+	if !h.hasSuccessInWindow() && !h.hasErrorInWindow() {
+		newRepairingDeadline := h.timeProvider.Now().Add(h.repairingGracePeriod)
+		if newRepairingDeadline.After(h.repairingDeadline) {
+			h.repairingDeadline = newRepairingDeadline
+		}
 	}
 
 	if err != nil {
@@ -188,12 +191,10 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 	defer h.sourceMutex.RUnlock()
 
 	var healthCheckResult health.HealthCheckResult
-	curTime := h.timeProvider.Now()
-	if !h.lastSuccessTime.IsZero() && curTime.Sub(h.lastSuccessTime) < h.windowSize {
+	if h.hasSuccessInWindow() {
 		healthCheckResult = whealth.HealthyHealthCheckResult(h.checkType)
-	} else if !h.lastErrorTime.IsZero() && curTime.Sub(h.lastErrorTime) < h.windowSize {
-
-		if h.requireFirstFullWindow && curTime.Sub(h.startTime) < h.windowSize {
+	} else if h.hasErrorInWindow() {
+		if h.lastErrorTime.Before(h.repairingDeadline) {
 			healthCheckResult = whealth.RepairingHealthCheckResult(h.checkType, h.lastError.Error())
 		} else {
 			healthCheckResult = whealth.UnhealthyHealthCheckResult(h.checkType, h.lastError.Error())
@@ -207,4 +208,12 @@ func (h *healthyIfNotAllErrorsSource) HealthStatus(ctx context.Context) health.H
 			h.checkType: healthCheckResult,
 		},
 	}
+}
+
+func (h *healthyIfNotAllErrorsSource) hasSuccessInWindow() bool {
+	return !h.lastSuccessTime.IsZero() && h.timeProvider.Now().Sub(h.lastSuccessTime) <= h.windowSize
+}
+
+func (h *healthyIfNotAllErrorsSource) hasErrorInWindow() bool {
+	return !h.lastErrorTime.IsZero() && h.timeProvider.Now().Sub(h.lastErrorTime) <= h.windowSize
 }

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -99,7 +99,7 @@ type healthyIfNotAllErrorsSource struct {
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, 0, true, newOrdinaryTimeProvider())
+	source, err := NewHealthyIfNotAllErrorsSource(checkType, windowSize)
 	if err != nil {
 		panic(err)
 	}
@@ -120,7 +120,7 @@ func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.
 // Care should be taken in considering health submission rate and window size when using anchored
 // windows. Windows too close to service emission frequency may cause errors to not surface.
 func MustNewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, windowSize, true, newOrdinaryTimeProvider())
+	source, err := NewAnchoredHealthyIfNotAllErrorsSource(checkType, windowSize)
 	if err != nil {
 		panic(err)
 	}

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -186,7 +186,7 @@ func TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairing(t *testing.T) {
 }
 
 // TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenError validates that in a constant stream of errors, the health
-// check initially reports repairing and then reports error after the etime window.
+// check initially reports repairing and then reports error after the time window.
 func TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenError(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, true, timeProvider)

--- a/status/health/window/error_source_test.go
+++ b/status/health/window/error_source_test.go
@@ -140,9 +140,9 @@ func TestHealthyIfNotAllErrorsSource(t *testing.T) {
 	}
 }
 
-// TestErrorInInitialWindow validates that error in the first window
+// TestHealthyIfNotAllErrorsSource_ErrorInInitialWindowWhenFirstFullWindowRequired validates that error in the first window
 // causes the check to report as repairing when first window is required.
-func TestErrorInInitialWindowWhenFirstFullWindowRequired(t *testing.T) {
+func TestHealthyIfNotAllErrorsSource_ErrorInInitialWindowWhenFirstFullWindowRequired(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, 0, true, timeProvider)
 	assert.NoError(t, err)
@@ -154,9 +154,9 @@ func TestErrorInInitialWindowWhenFirstFullWindowRequired(t *testing.T) {
 	assert.Equal(t, health.HealthStateRepairing, checkResult.State)
 }
 
-// TestErrorInInitialWindow validates that error in the first window
+// TestAnchoredHealthyIfNotAllErrorsSource_ErrorInInitialAnchoredWindow validates that error in the first window
 // does not cause the health status to become unhealthy when anchored as well.
-func TestErrorInInitialAnchoredWindow(t *testing.T) {
+func TestAnchoredHealthyIfNotAllErrorsSource_ErrorInInitialAnchoredWindow(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, false, timeProvider)
 	assert.NoError(t, err)
@@ -168,9 +168,9 @@ func TestErrorInInitialAnchoredWindow(t *testing.T) {
 	assert.Equal(t, health.HealthStateRepairing, checkResult.State)
 }
 
-// TestErrorInInitialWindow validates that error in the first window
+// TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairing validates that error in the first window
 // does not cause the health status to become unhealthy when anchored as well.
-func TestGapThenRepairing(t *testing.T) {
+func TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairing(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, true, timeProvider)
 	assert.NoError(t, err)
@@ -185,9 +185,9 @@ func TestGapThenRepairing(t *testing.T) {
 	assert.Equal(t, health.HealthStateRepairing, checkResult.State)
 }
 
-// TestRepairingThenError validates that in a constant stream of errors, the health
+// TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenError validates that in a constant stream of errors, the health
 // check initially reports repairing and then reports error after the etime window.
-func TestGapThenRepairingThenError(t *testing.T) {
+func TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenError(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, true, timeProvider)
 	assert.NoError(t, err)
@@ -211,9 +211,9 @@ func TestGapThenRepairingThenError(t *testing.T) {
 	assert.Equal(t, health.HealthStateError, checkResult.State)
 }
 
-// TestRepairingThenError validates that if a success is submitted during repairing phase,
+// TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenHealthy validates that if a success is submitted during repairing phase,
 // the health check recovers.
-func TestGapThenRepairingThenHealthy(t *testing.T) {
+func TestAnchoredHealthyIfNotAllErrorsSource_GapThenRepairingThenHealthy(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, true, timeProvider)
 	assert.NoError(t, err)
@@ -237,9 +237,9 @@ func TestGapThenRepairingThenHealthy(t *testing.T) {
 	assert.Equal(t, health.HealthStateHealthy, checkResult.State)
 }
 
-// TestRepairingThenGap validates if no more errors happen beyond the repairing phase,
+// TestAnchoredHealthyIfNotAllErrorsSource_RepairingThenGap validates if no more errors happen beyond the repairing phase,
 // the health check recovers.
-func TestRepairingThenGap(t *testing.T) {
+func TestAnchoredHealthyIfNotAllErrorsSource_RepairingThenGap(t *testing.T) {
 	timeProvider := &offsetTimeProvider{}
 	anchoredWindow, err := newHealthyIfNotAllErrorsSource(testCheckType, windowSize, windowSize, true, timeProvider)
 	assert.NoError(t, err)


### PR DESCRIPTION
## Before this PR
Currently the health check simply swallows all errors for all errors than happen after a long period of inactivity for up to one time window. Instead it should return repairing and expose the error message.
Also there is a bug where if a small (less than a time window) stream of error happens, the health check reports unhealthy for a period of the stream one widow after the start of the stream. 

## After this PR
Now errors that happen immediately after long periods of inactivity are not ignored and cause the health check to report repairing.
The mentioned bug is now fixed: the health check will report repairing for the whole time.
==COMMIT_MSG==
Return repairing for errors inside anchored window
==COMMIT_MSG==

## Possible downsides?
No that I'm aware of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/175)
<!-- Reviewable:end -->
