### PR TITLE
Return repairing for errors inside multi key anchored window

### DIFF
--- a/changelog/@unreleased/pr-176.v2.yml
+++ b/changelog/@unreleased/pr-176.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Return repairing for errors inside multi key anchored window
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/176
+

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -58,7 +58,7 @@ func MustNewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowS
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
 func NewUnhealthyIfAtLeastOneErrorSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	underlyingSource, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, false, newOrdinaryTimeProvider())
+	underlyingSource, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, false, NewOrdinaryTimeProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (u *unhealthyIfAtLeastOneErrorSource) HealthStatus(ctx context.Context) hea
 // It returns, if there are only non-nil errors, the first non-nil error as an unhealthy check.
 // If there are no items, returns healthy.
 type healthyIfNotAllErrorsSource struct {
-	timeProvider           timeProvider
+	timeProvider           TimeProvider
 	useAnchoredWindows     bool
 	windowSize             time.Duration
 	lastErrorTime          time.Time
@@ -100,7 +100,7 @@ type healthyIfNotAllErrorsSource struct {
 // MustNewHealthyIfNotAllErrorsSource returns the result of calling NewHealthyIfNotAllErrorsSource, but panics if it returns an error.
 // Should only be used in instances where the inputs are statically defined and known to be valid.
 func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, newOrdinaryTimeProvider())
+	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, NewOrdinaryTimeProvider())
 	if err != nil {
 		panic(err)
 	}
@@ -111,7 +111,7 @@ func MustNewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize t
 // with a sliding window of size windowSize and uses the checkType.
 // windowSize must be a positive value, otherwise returns error.
 func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	return newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, newOrdinaryTimeProvider())
+	return newHealthyIfNotAllErrorsSource(checkType, windowSize, false, true, NewOrdinaryTimeProvider())
 }
 
 // MustNewAnchoredHealthyIfNotAllErrorsSource returns the result of calling
@@ -120,7 +120,7 @@ func NewHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.
 // Care should be taken in considering health submission rate and window size when using anchored
 // windows. Windows too close to service emission frequency may cause errors to not surface
 func MustNewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) ErrorHealthCheckSource {
-	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, newOrdinaryTimeProvider())
+	source, err := newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, NewOrdinaryTimeProvider())
 	if err != nil {
 		panic(err)
 	}
@@ -135,10 +135,10 @@ func MustNewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, wind
 // considering health submission rate and window size when using anchored windows.
 // Windows too close to service emission frequency may cause errors to not surface
 func NewAnchoredHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration) (ErrorHealthCheckSource, error) {
-	return newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, newOrdinaryTimeProvider())
+	return newHealthyIfNotAllErrorsSource(checkType, windowSize, true, true, NewOrdinaryTimeProvider())
 }
 
-func newHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration, useAnchoredWindows bool, requireFirstFullWindow bool, timeProvider timeProvider) (ErrorHealthCheckSource, error) {
+func newHealthyIfNotAllErrorsSource(checkType health.CheckType, windowSize time.Duration, useAnchoredWindows bool, requireFirstFullWindow bool, timeProvider TimeProvider) (ErrorHealthCheckSource, error) {
 	if windowSize <= 0 {
 		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize))
 	}

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -110,7 +110,7 @@ func TestMultiKeyUnhealthyIfAtLeastOneErrorSource(t *testing.T) {
 	}
 }
 
-func TestMultiKeyHealthyIfNotAllErrorsSourceOutsideStartWindow(t *testing.T) {
+func TestMultiKeyHealthyIfNotAllErrorsSource_OutsideStartWindow(t *testing.T) {
 	messageInCaseOfError := "message in case of error"
 	for _, testCase := range []struct {
 		name          string
@@ -187,7 +187,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSourceOutsideStartWindow(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			timeProvider := &offsetTimeProvider{}
-			source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, true, timeProvider)
+			source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, 0, true, timeProvider)
 			require.NoError(t, err)
 
 			// sleep puts all tests outside the required healthy start window
@@ -207,7 +207,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSourceOutsideStartWindow(t *testing.T) {
 	}
 }
 
-func TestMultiKeyHealthyIfNotAllErrorsSourceInsideStartWindow(t *testing.T) {
+func TestMultiKeyHealthyIfNotAllErrorsSource_InsideStartWindow(t *testing.T) {
 	messageInCaseOfError := "message in case of error"
 	for _, testCase := range []struct {
 		name          string
@@ -269,7 +269,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSourceInsideStartWindow(t *testing.T) {
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			timeProvider := &offsetTimeProvider{}
-			source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, true, timeProvider)
+			source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, 0, true, timeProvider)
 			require.NoError(t, err)
 
 			for _, keyErrorPair := range testCase.keyErrorPairs {
@@ -286,7 +286,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSourceInsideStartWindow(t *testing.T) {
 	}
 }
 
-func TestMultiKeyHealthyIfNotAllErrorsSourceStartOnlyErrorWithWindowTransition(t *testing.T) {
+func TestMultiKeyHealthyIfNotAllErrorsSource_StartOnlyErrorWithWindowTransition(t *testing.T) {
 	ctx := context.Background()
 	messageInCaseOfError := "message in case of error"
 
@@ -304,7 +304,7 @@ func TestMultiKeyHealthyIfNotAllErrorsSourceStartOnlyErrorWithWindowTransition(t
 	}
 
 	timeProvider := &offsetTimeProvider{}
-	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, true, timeProvider)
+	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, 0, true, timeProvider)
 	require.NoError(t, err)
 
 	// move partially into the initial health check window

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -286,11 +286,20 @@ func TestMultiKeyHealthyIfNotAllErrorsSource_InsideStartWindow(t *testing.T) {
 	}
 }
 
-func TestMultiKeyHealthyIfNotAllErrorsSource_StartOnlyErrorWithWindowTransition(t *testing.T) {
+func TestMultiKeyHealthyIfNotAllErrorsSource_InitialWindowErrorsReturnRepairing(t *testing.T) {
 	ctx := context.Background()
 	messageInCaseOfError := "message in case of error"
+	const timeWindow = time.Minute
 
-	repairStatus := health.HealthStatus{
+	timeProvider := &offsetTimeProvider{}
+	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, timeWindow, 0, true, timeProvider)
+	require.NoError(t, err)
+
+	// move partially into the initial health check window
+	timeProvider.RestlessSleep(3 * timeWindow / 4)
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+
+	assert.Equal(t, health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			testCheckType: {
 				Type:    testCheckType,
@@ -301,24 +310,228 @@ func TestMultiKeyHealthyIfNotAllErrorsSource_StartOnlyErrorWithWindowTransition(
 				},
 			},
 		},
-	}
-
-	timeProvider := &offsetTimeProvider{}
-	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, time.Hour, 0, true, timeProvider)
-	require.NoError(t, err)
-
-	// move partially into the initial health check window
-	timeProvider.RestlessSleep(20 * time.Minute)
-	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
-
-	// still inside the initial window so error should be suppressed
-	actualStatus := source.HealthStatus(context.Background())
-	assert.Equal(t, repairStatus, actualStatus)
+	}, source.HealthStatus(ctx))
 
 	// move out of the initial health check window but keep error inside sliding window
-	timeProvider.RestlessSleep(50 * time.Minute)
+	timeProvider.RestlessSleep(timeWindow / 2)
 
-	expectedPostWindow := health.HealthStatus{
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+}
+
+func TestAnchoredMultiKeyHealthyIfNotAllErrorsSource_GapThenRepairingThenHealthy(t *testing.T) {
+	ctx := context.Background()
+	messageInCaseOfError := "message in case of error"
+	const timeWindow = time.Minute
+
+	timeProvider := &offsetTimeProvider{}
+	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, timeWindow, timeWindow, true, timeProvider)
+	require.NoError(t, err)
+
+	// move out of the initial health check window
+	timeProvider.RestlessSleep(2 * timeWindow)
+
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+	timeProvider.RestlessSleep(timeWindow / 2)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("2", werror.ErrorWithContextParams(ctx, "error for key: 2"))
+	timeProvider.RestlessSleep(timeWindow / 4)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("1", nil)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("2", nil)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: whealth.HealthyHealthCheckResult(testCheckType),
+		},
+	}, source.HealthStatus(ctx))
+}
+
+func TestAnchoredMultiKeyHealthyIfNotAllErrorsSource_GapThenRepairingThenGap(t *testing.T) {
+	ctx := context.Background()
+	messageInCaseOfError := "message in case of error"
+	const timeWindow = time.Minute
+
+	timeProvider := &offsetTimeProvider{}
+	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, timeWindow, timeWindow, true, timeProvider)
+	require.NoError(t, err)
+
+	// move out of the initial health check window
+	timeProvider.RestlessSleep(2 * timeWindow)
+
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+	timeProvider.RestlessSleep(timeWindow / 2)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("2", werror.ErrorWithContextParams(ctx, "error for key: 2"))
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	timeProvider.RestlessSleep(3 * timeWindow / 4)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	timeProvider.RestlessSleep(timeWindow / 2)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: whealth.HealthyHealthCheckResult(testCheckType),
+		},
+	}, source.HealthStatus(ctx))
+}
+
+func TestAnchoredMultiKeyHealthyIfNotAllErrorsSource_GapThenRepairingThenError(t *testing.T) {
+	ctx := context.Background()
+	messageInCaseOfError := "message in case of error"
+	const timeWindow = time.Minute
+
+	timeProvider := &offsetTimeProvider{}
+	source, err := newMultiKeyHealthyIfNotAllErrorsSource(testCheckType, messageInCaseOfError, timeWindow, timeWindow, true, timeProvider)
+	require.NoError(t, err)
+
+	// move out of the initial health check window
+	timeProvider.RestlessSleep(2 * timeWindow)
+
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+	timeProvider.RestlessSleep(timeWindow / 2)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("2", werror.ErrorWithContextParams(ctx, "error for key: 2"))
+	timeProvider.RestlessSleep(timeWindow / 4)
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateRepairing,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+	timeProvider.RestlessSleep(timeWindow / 2)
+	source.Submit("1", werror.ErrorWithContextParams(ctx, "error for key: 1"))
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			testCheckType: {
+				Type:    testCheckType,
+				State:   health.HealthStateError,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "error for key: 1",
+					"2": "error for key: 2",
+				},
+			},
+		},
+	}, source.HealthStatus(ctx))
+
+	timeProvider.RestlessSleep(timeWindow / 2)
+
+	assert.Equal(t, health.HealthStatus{
 		Checks: map[health.CheckType]health.HealthCheckResult{
 			testCheckType: {
 				Type:    testCheckType,
@@ -329,9 +542,5 @@ func TestMultiKeyHealthyIfNotAllErrorsSource_StartOnlyErrorWithWindowTransition(
 				},
 			},
 		},
-	}
-
-	actualStatus = source.HealthStatus(context.Background())
-	assert.Equal(t, expectedPostWindow, actualStatus)
-
+	}, source.HealthStatus(ctx))
 }

--- a/status/health/window/time_provider.go
+++ b/status/health/window/time_provider.go
@@ -18,9 +18,9 @@ import (
 	"time"
 )
 
-// timeProvider exists to supply a means of testing time window
+// TimeProvider exists to supply a means of testing time window
 // changes without actually taking the time to sleep
-type timeProvider interface {
+type TimeProvider interface {
 	Now() time.Time
 }
 
@@ -30,7 +30,8 @@ func (o *ordinaryTimeProvider) Now() time.Time {
 	return time.Now()
 }
 
-func newOrdinaryTimeProvider() timeProvider {
+// NewOrdinaryTimeProvider creates a new time provider that returns time.Now().
+func NewOrdinaryTimeProvider() TimeProvider {
 	return &ordinaryTimeProvider{}
 }
 

--- a/status/health/window/timed_key_store.go
+++ b/status/health/window/timed_key_store.go
@@ -74,14 +74,14 @@ type timedKeyStore struct {
 	begin        *keyNode
 	end          *keyNode
 	nodeByKey    map[string]*keyNode
-	timeProvider timeProvider
+	timeProvider TimeProvider
 }
 
 // NewTimedKeyStore creates a TimedKeyStore that executes all operations in O(1) time except
 // for List, which is O(n), where n is the number of stored keys.
 // Memory consumption is O(n), where n is the number of stored keys.
 // This struct is not thread safe.
-func NewTimedKeyStore(timeProvider timeProvider) TimedKeyStore {
+func NewTimedKeyStore(timeProvider TimeProvider) TimedKeyStore {
 	begin := &keyNode{}
 	end := &keyNode{}
 	begin.next = end

--- a/status/health/window/timed_key_store.go
+++ b/status/health/window/timed_key_store.go
@@ -71,24 +71,26 @@ type keyNode struct {
 // begin and end are extra nodes that are before the first element and after the last one, respectively.
 // They point to each other when the list is empty.
 type timedKeyStore struct {
-	begin     *keyNode
-	end       *keyNode
-	nodeByKey map[string]*keyNode
+	begin        *keyNode
+	end          *keyNode
+	nodeByKey    map[string]*keyNode
+	timeProvider timeProvider
 }
 
 // NewTimedKeyStore creates a TimedKeyStore that executes all operations in O(1) time except
 // for List, which is O(n), where n is the number of stored keys.
 // Memory consumption is O(n), where n is the number of stored keys.
 // This struct is not thread safe.
-func NewTimedKeyStore() TimedKeyStore {
+func NewTimedKeyStore(timeProvider timeProvider) TimedKeyStore {
 	begin := &keyNode{}
 	end := &keyNode{}
 	begin.next = end
 	end.prev = begin
 	return &timedKeyStore{
-		begin:     begin,
-		end:       end,
-		nodeByKey: make(map[string]*keyNode),
+		begin:        begin,
+		end:          end,
+		nodeByKey:    make(map[string]*keyNode),
+		timeProvider: timeProvider,
 	}
 }
 
@@ -96,7 +98,7 @@ func (t *timedKeyStore) Put(key string, payload interface{}) {
 	_ = t.Delete(key)
 	timedKey := TimedKey{
 		Key:     key,
-		Time:    time.Now(),
+		Time:    t.timeProvider.Now(),
 		Payload: payload,
 	}
 	node := &keyNode{

--- a/status/health/window/timed_key_store.go
+++ b/status/health/window/timed_key_store.go
@@ -20,8 +20,9 @@ import (
 
 // TimedKey is a pair of a key and a timestamp.
 type TimedKey struct {
-	Key  string
-	Time time.Time
+	Key     string
+	Time    time.Time
+	Payload interface{}
 }
 
 // TimedKeys is a list of TimedKey objects.
@@ -42,7 +43,7 @@ func (t TimedKeys) Keys() []string {
 type TimedKeyStore interface {
 	// Put adds a new TimedKey to the end of the list with the timestamp set to the current time.
 	// Adding an already present key will cause the current TimedKey to be updated to the current and to be sent to the end of the list.
-	Put(key string)
+	Put(key string, payload interface{})
 	// Delete removes a TimedKey from the list. If the key doesn't exist, it is a no op.
 	// The second return value returns whether or not the key existed within the store.
 	Delete(key string) bool
@@ -91,11 +92,12 @@ func NewTimedKeyStore() TimedKeyStore {
 	}
 }
 
-func (t *timedKeyStore) Put(key string) {
+func (t *timedKeyStore) Put(key string, payload interface{}) {
 	_ = t.Delete(key)
 	timedKey := TimedKey{
-		Key:  key,
-		Time: time.Now(),
+		Key:     key,
+		Time:    time.Now(),
+		Payload: payload,
 	}
 	node := &keyNode{
 		prev:     t.end.prev,

--- a/status/health/window/timed_key_store_test.go
+++ b/status/health/window/timed_key_store_test.go
@@ -57,7 +57,7 @@ func assertStoreContent(t *testing.T, store TimedKeyStore, list []string, subtes
 }
 
 func TestTimedKeyStore(t *testing.T) {
-	store := NewTimedKeyStore()
+	store := NewTimedKeyStore(newOrdinaryTimeProvider())
 	assertStoreContent(t, store, []string{}, "store initially empty")
 
 	store.Delete("a")

--- a/status/health/window/timed_key_store_test.go
+++ b/status/health/window/timed_key_store_test.go
@@ -57,7 +57,7 @@ func assertStoreContent(t *testing.T, store TimedKeyStore, list []string, subtes
 }
 
 func TestTimedKeyStore(t *testing.T) {
-	store := NewTimedKeyStore(newOrdinaryTimeProvider())
+	store := NewTimedKeyStore(NewOrdinaryTimeProvider())
 	assertStoreContent(t, store, []string{}, "store initially empty")
 
 	store.Delete("a")

--- a/status/health/window/timed_key_store_test.go
+++ b/status/health/window/timed_key_store_test.go
@@ -63,31 +63,31 @@ func TestTimedKeyStore(t *testing.T) {
 	store.Delete("a")
 	assertStoreContent(t, store, []string{}, "removed unexisting key from empty store")
 
-	store.Put("a")
+	store.Put("a", "")
 	assertStoreContent(t, store, []string{"a"}, "added a single key a")
 
 	store.Delete("a")
 	assertStoreContent(t, store, []string{}, "removed a single key a")
 
-	store.Put("b")
+	store.Put("b", "")
 	assertStoreContent(t, store, []string{"b"}, "added a single key b")
 
-	store.Put("c")
+	store.Put("c", "")
 	assertStoreContent(t, store, []string{"b", "c"}, "added a second key c")
 
-	store.Put("b")
+	store.Put("b", "")
 	assertStoreContent(t, store, []string{"c", "b"}, "updated key b")
 
 	store.Delete("d")
 	assertStoreContent(t, store, []string{"c", "b"}, "removed unexisting key from non empty store")
 
-	store.Put("e")
+	store.Put("e", "")
 	assertStoreContent(t, store, []string{"c", "b", "e"}, "added a third key e")
 
 	store.Delete("b")
 	assertStoreContent(t, store, []string{"c", "e"}, "removed key b from the middle of the list")
 
-	store.Put("d")
+	store.Put("d", "")
 	assertStoreContent(t, store, []string{"c", "e", "d"}, "added a new key d")
 
 	store.Delete("d")


### PR DESCRIPTION
This PR is analogous to https://github.com/palantir/witchcraft-go-server/pull/175, but for multi key window checks.

## Before this PR
Currently the health check does not support "anchoring", which leads to initial errors after long periods of inactivity to cause the health check to report ERROR. We should report REPAIRING for an initial period after idle time.

## After this PR
==COMMIT_MSG==
Return repairing for errors inside multi key anchored window
==COMMIT_MSG==

## Possible downsides?
Not that I'm aware of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/176)
<!-- Reviewable:end -->
