### PR TITLE
Add health check source tree.

### DIFF
--- a/changelog/@unreleased/pr-178.v2.yml
+++ b/changelog/@unreleased/pr-178.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    It is typical for some of our services to implement a health check ensuring connectivity/ability to authenticate with another service while also implementing health checks for more specific interactions with that service. This PR introduces a health check source tree that enables consumers to determine when the tree should traverse to health check sources further down in the tree based on the health check result at the current tree node.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/178
+

--- a/status/health/tree/tree.go
+++ b/status/health/tree/tree.go
@@ -22,6 +22,9 @@ import (
 )
 
 type (
+	// TraverseForHealthStatus accepts the health status result of the current health check source node
+	// and returns whether the current health check source tree node should traverse to child health check
+	// source nodes or not.
 	TraverseForHealthStatus func(status health.HealthStatus) bool
 )
 
@@ -50,8 +53,8 @@ func WithTraverseForHealthStatus(fn TraverseForHealthStatus) CheckSourceTreePara
 }
 
 // NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own health check
-// to determine if it should invoke the provided child health checks. the default behavior is to only traverse to child
-// checks is if the most severe health state of the current node's health status is health.HealthStateHealthy.
+// to determine if it should invoke the provided child health checks. The default behavior is to only traverse to child
+// checks if the most severe health state of the current node's health status is health.HealthStateHealthy.
 func NewHealthCheckSourceTree(
 	ownHealthCheckSource status.HealthCheckSource,
 	childrenHealthCheckSources []status.HealthCheckSource,
@@ -74,10 +77,10 @@ func (n *healthCheckSourceTreeNode) HealthStatus(ctx context.Context) health.Hea
 		return ownHealthStatus
 	}
 	healthStatusFromChildSources := n.combinedChildrenHealthCheckSource.HealthStatus(ctx)
-	for ownCheckType, ownCheckResult := range ownHealthStatus.Checks {
-		healthStatusFromChildSources.Checks[ownCheckType] = ownCheckResult
+	for checkType, checkResult := range healthStatusFromChildSources.Checks {
+		ownHealthStatus.Checks[checkType] = checkResult
 	}
-	return healthStatusFromChildSources
+	return ownHealthStatus
 }
 
 func healthStateFromChecks(checks map[health.CheckType]health.HealthCheckResult) health.HealthState {

--- a/status/health/tree/tree.go
+++ b/status/health/tree/tree.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree
+
+import (
+	"context"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status"
+)
+
+type (
+	TraverseForHealthStatus func(status health.HealthStatus) bool
+)
+
+type healthCheckSourceTreeNode struct {
+	healthCheckSource                 status.HealthCheckSource
+	combinedChildrenHealthCheckSource status.HealthCheckSource
+	traverseForHealthState            TraverseForHealthStatus
+}
+
+type CheckSourceTreeParam interface {
+	apply(*healthCheckSourceTreeNode)
+}
+
+type healthCheckSourceTreeParamFn func(*healthCheckSourceTreeNode)
+
+func (fn healthCheckSourceTreeParamFn) apply(node *healthCheckSourceTreeNode) {
+	fn(node)
+}
+
+// WithTraverseForHealthStatus allows consumer-provided logic to determine when the child health checks of the node
+// should be invoked based on the current node's returned health status.
+func WithTraverseForHealthStatus(fn TraverseForHealthStatus) CheckSourceTreeParam {
+	return healthCheckSourceTreeParamFn(func(node *healthCheckSourceTreeNode) {
+		node.traverseForHealthState = fn
+	})
+}
+
+// NewHealthCheckSourceTree returns a new health check source tree node that uses the result of its own health check
+// to determine if it should invoke the provided child health checks. the default behavior is to only traverse to child
+// checks is if the most severe health state of the current node's health status is health.HealthStateHealthy.
+func NewHealthCheckSourceTree(
+	ownHealthCheckSource status.HealthCheckSource,
+	childrenHealthCheckSources []status.HealthCheckSource,
+	params ...CheckSourceTreeParam,
+) status.HealthCheckSource {
+	n := &healthCheckSourceTreeNode{
+		healthCheckSource:                 ownHealthCheckSource,
+		combinedChildrenHealthCheckSource: status.NewCombinedHealthCheckSource(childrenHealthCheckSources...),
+		traverseForHealthState:            defaultTraverseForHealthStatus,
+	}
+	for _, param := range params {
+		param.apply(n)
+	}
+	return n
+}
+
+func (n *healthCheckSourceTreeNode) HealthStatus(ctx context.Context) health.HealthStatus {
+	ownHealthStatus := n.healthCheckSource.HealthStatus(ctx)
+	if !n.traverseForHealthState(ownHealthStatus) {
+		return ownHealthStatus
+	}
+	healthStatusFromChildSources := n.combinedChildrenHealthCheckSource.HealthStatus(ctx)
+	for ownCheckType, ownCheckResult := range ownHealthStatus.Checks {
+		healthStatusFromChildSources.Checks[ownCheckType] = ownCheckResult
+	}
+	return healthStatusFromChildSources
+}
+
+func healthStateFromChecks(checks map[health.CheckType]health.HealthCheckResult) health.HealthState {
+	healthState := health.HealthStateHealthy
+	for _, checkResult := range checks {
+		if status.HealthStateStatusCodes[checkResult.State] > status.HealthStateStatusCodes[healthState] {
+			healthState = checkResult.State
+		}
+	}
+	return healthState
+}
+
+func defaultTraverseForHealthStatus(healthStatus health.HealthStatus) bool {
+	return healthStateFromChecks(healthStatus.Checks) == health.HealthStateHealthy
+}

--- a/status/health/tree/tree_test.go
+++ b/status/health/tree/tree_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tree_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/status"
+	"github.com/palantir/witchcraft-go-server/status/health/tree"
+	"github.com/stretchr/testify/assert"
+)
+
+type healthStatusFn func(ctx context.Context) health.HealthStatus
+
+func (fn healthStatusFn) HealthStatus(ctx context.Context) health.HealthStatus {
+	return fn(ctx)
+}
+
+func TestHealthCheckSourceTree(t *testing.T) {
+	someChildCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"CHILD": {},
+			},
+		}
+	})
+	alwaysErrParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"PARENT": {
+					State: health.HealthStateError,
+				},
+			},
+		}
+	})
+	treeSource := tree.NewHealthCheckSourceTree(alwaysErrParentCheck, []status.HealthCheckSource{someChildCheck})
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"PARENT": {
+				State: health.HealthStateError,
+			},
+		},
+	}, treeSource.HealthStatus(context.Background()))
+
+	healthyParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"PARENT": {
+					State: health.HealthStateHealthy,
+				},
+			},
+		}
+	})
+	treeSource = tree.NewHealthCheckSourceTree(healthyParentCheck, []status.HealthCheckSource{someChildCheck})
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"PARENT": {
+				State: health.HealthStateHealthy,
+			},
+			"CHILD": {},
+		},
+	}, treeSource.HealthStatus(context.Background()))
+}
+
+func TestHealthCheckSourceTreeWithTraverseForHealthState(t *testing.T) {
+	dummyChildCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"CHILD_CHECK": {
+					State: health.HealthStateRepairing,
+				},
+			},
+		}
+	})
+	unhealthyParentCheck := healthStatusFn(func(ctx context.Context) health.HealthStatus {
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				"TEST_CHECK": {
+					State: health.HealthStateRepairing,
+				},
+			},
+		}
+	})
+	healthCheckSourceTree := tree.NewHealthCheckSourceTree(unhealthyParentCheck, []status.HealthCheckSource{
+		dummyChildCheck,
+	}, tree.WithTraverseForHealthStatus(func(healthStatus health.HealthStatus) bool {
+		return true
+	}))
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"TEST_CHECK": {
+				State: health.HealthStateRepairing,
+			},
+			"CHILD_CHECK": {
+				State: health.HealthStateRepairing,
+			},
+		},
+	}, healthCheckSourceTree.HealthStatus(context.Background()))
+
+	healthCheckSourceTree = tree.NewHealthCheckSourceTree(unhealthyParentCheck, []status.HealthCheckSource{
+		dummyChildCheck,
+	}, tree.WithTraverseForHealthStatus(func(healthStatus health.HealthStatus) bool {
+		return false
+	}))
+
+	assert.Equal(t, health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			"TEST_CHECK": {
+				State: health.HealthStateRepairing,
+			},
+		},
+	}, healthCheckSourceTree.HealthStatus(context.Background()))
+}


### PR DESCRIPTION
## Before this PR
It is typical for some of our services to implement a health check ensuring connectivity/ability to authenticate with another service while also implementing health checks for more specific interactions with that service. A common pattern in our kubernetes controllers, for example is to have two different checks:
1. Can the controller authenticate with the kubernetes API server?
2. Is the controller successfully processing whatever resource events it is receiving from the API server?

Note here that if (1) fails, (2) necessarily fails, as processing resource events is predicated on being able to authenticate with the API server. If (1) is failing, we do not care about debugging (2). In this case, we really just care about the health check result for (1).

This PR introduces a health check source tree that enables consumers to determine when the tree should traverse to health check sources further down in the tree based on the health check result at the current tree node.

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/178)
<!-- Reviewable:end -->
