### PR TITLE
improvement: add benchmarking tests for server loggers

### DIFF
--- a/changelog/@unreleased/pr-180.v2.yml
+++ b/changelog/@unreleased/pr-180.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add benchmarking tests for server loggers
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/180

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -156,9 +156,8 @@ func BenchmarkServer_Loggers(b *testing.B) {
 			},
 		},
 	} {
-		for _, count := range []int{1, 10, 100} {
-			b.Run(fmt.Sprintf("%s-count=%d", test.Name, count), func(b *testing.B) {
-				numLinesToLog := 100
+		for _, numLinesToLog := range []int{1, 10, 100} {
+			b.Run(fmt.Sprintf("%s-count=%d", test.Name, numLinesToLog), func(b *testing.B) {
 				logOutputBuffer := &bytes.Buffer{}
 				err := witchcraft.NewServer().
 					WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -157,7 +157,7 @@ func BenchmarkServer_Loggers(b *testing.B) {
 		},
 	} {
 		for _, numLinesToLog := range []int{1, 10, 100} {
-			b.Run(fmt.Sprintf("%s-count=%d", test.Name, numLinesToLog), func(b *testing.B) {
+			b.Run(fmt.Sprintf("%s-numLinesToLog=%d", test.Name, numLinesToLog), func(b *testing.B) {
 				logOutputBuffer := &bytes.Buffer{}
 				err := witchcraft.NewServer().
 					WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -27,8 +27,14 @@ import (
 
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log"
+	"github.com/palantir/witchcraft-go-logging/wlog/evtlog/evt2log"
+	"github.com/palantir/witchcraft-go-logging/wlog/metriclog/metric1log"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-server/config"
 	"github.com/palantir/witchcraft-go-server/witchcraft"
+	"github.com/palantir/witchcraft-go-tracing/wtracing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -98,6 +104,87 @@ func TestFatalErrorLogging(t *testing.T) {
 
 			require.Error(t, err)
 			test.VerifyLog(t, logOutputBuffer.Bytes())
+		})
+	}
+}
+
+// BenchmarkServer_Loggers benchmarks the time for Server loggers to log 100 lines.
+func BenchmarkServer_Loggers(b *testing.B) {
+	for _, test := range []struct {
+		Name   string
+		InitFn witchcraft.InitFunc
+	}{
+		{
+			Name: "svc1log",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < 100; j++ {
+						svc1log.FromContext(ctx).Info("info!")
+					}
+				}
+				return nil, werror.ErrorWithContextParams(ctx, "must error to get Start to return!")
+			},
+		},
+		{
+			Name: "evt2log",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < 100; j++ {
+						evt2log.FromContext(ctx).Event("event!")
+					}
+				}
+				return nil, werror.ErrorWithContextParams(ctx, "must error to get Start to return!")
+			},
+		},
+		{
+			Name: "metric1log",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < 100; j++ {
+						metric1log.FromContext(ctx).Metric("metric!", metric1log.MetricTypeKey)
+					}
+				}
+				return nil, werror.ErrorWithContextParams(ctx, "must error to get Start to return!")
+			},
+		},
+		{
+			Name: "trc1log",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < 100; j++ {
+						trc1log.FromContext(ctx).Log(wtracing.SpanModel{})
+					}
+				}
+				return nil, werror.ErrorWithContextParams(ctx, "must error to get Start to return!")
+			},
+		},
+		{
+			Name: "audit2log",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
+				for i := 0; i < b.N; i++ {
+					for j := 0; j < 100; j++ {
+						audit2log.FromContext(ctx).Audit("audit!", audit2log.AuditResultSuccess)
+					}
+				}
+				return nil, werror.ErrorWithContextParams(ctx, "must error to get Start to return!")
+			},
+		},
+	} {
+		b.Run(test.Name, func(b *testing.B) {
+			logOutputBuffer := &bytes.Buffer{}
+			err := witchcraft.NewServer().
+				WithInitFunc(test.InitFn).
+				WithInstallConfig(config.Install{UseConsoleLog: true}).
+				WithRuntimeConfig(config.Runtime{}).
+				WithLoggerStdoutWriter(logOutputBuffer).
+				WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+				WithDisableGoRuntimeMetrics().
+				WithMetricsBlacklist(map[string]struct{}{"server.uptime": {}}).
+				WithSelfSignedCertificate().
+				Start()
+
+			// Requires an error so that `Start` will return
+			require.Error(b, err)
 		})
 	}
 }


### PR DESCRIPTION
## After this PR
This PR adds benchmark tests for all SLS loggers, in preparation for adding metrics about logging in https://github.com/palantir/witchcraft-go-server/pull/179.

==COMMIT_MSG==
Adds a benchmark test for sls loggers
==COMMIT_MSG==

## Possible downsides?
None that I can see.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/180)
<!-- Reviewable:end -->
