### PR TITLE
improvement: loggers emit sls.logging.length metric

### DIFF
--- a/changelog/@unreleased/pr-181.v2.yml
+++ b/changelog/@unreleased/pr-181.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |
+    Create MetricWriter that records metrics for logging operations and update loggers in the context provided
+    by the server to use it. After this change, the server metrics will include a "logging.sls.length" metric that records
+    the length of log lines performed with tags that specify the logger type.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/181

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -254,9 +254,9 @@ func TestMetricWriter(t *testing.T) {
 			if metricLog.Tags["type"] == "audit" || metricLog.Tags["type"] == "trace" {
 				require.Equal(t, json.Number("1"), metricLog.Values["count"])
 
-				maxJson, ok := metricLog.Values["max"].(json.Number)
+				maxJSON, ok := metricLog.Values["max"].(json.Number)
 				require.True(t, ok)
-				max, err := maxJson.Int64()
+				max, err := maxJSON.Int64()
 				require.NoError(t, err)
 				require.Greater(t, max, int64(len(superLongLogLine)))
 			}

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -79,6 +79,7 @@ func TestEmitMetrics(t *testing.T) {
 
 	var (
 		seenLoggingSLS,
+		seenLoggingSLSLength,
 		seenMyCounter,
 		seenResponseTimer,
 		seenUptime,
@@ -100,6 +101,14 @@ func TestEmitMetrics(t *testing.T) {
 			} else {
 				assert.Equal(t, "", metricTagLevel)
 			}
+		case "logging.sls.length":
+			seenLoggingSLSLength = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "logging.sls.length metric had incorrect type")
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Tags["type"])
 		case "my-counter":
 			seenMyCounter = true
 			assert.Equal(t, "counter", metricLog.MetricType, "my-counter metric had incorrect type")
@@ -171,7 +180,9 @@ func TestEmitMetrics(t *testing.T) {
 			assert.Fail(t, "unexpected metric encountered", "%s", metricLog.MetricName)
 		}
 	}
+
 	assert.True(t, seenLoggingSLS, "logging.sls metric was not emitted")
+	assert.True(t, seenLoggingSLSLength, "logging.sls.length metric was not emitted")
 	assert.True(t, seenMyCounter, "my-counter metric was not emitted")
 	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
 	assert.True(t, seenRequestSize, "server.request.size metric was not emitted")
@@ -230,6 +241,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 
 	var (
 		seenLoggingSLS,
+		seenLoggingSLSLength,
 		seenMyCounter,
 		seenResponseTimer,
 		seenResponseSize,
@@ -251,6 +263,14 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			} else {
 				assert.Equal(t, "", metricTagLevel)
 			}
+		case "logging.sls.length":
+			seenLoggingSLSLength = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "logging.sls.length metric had incorrect type")
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Tags["type"])
 		case "my-counter":
 			seenMyCounter = true
 			assert.Equal(t, "counter", metricLog.MetricType, "my-counter metric had incorrect type")
@@ -318,6 +338,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		}
 	}
 	assert.True(t, seenLoggingSLS, "logging.sls metric was not emitted")
+	assert.True(t, seenLoggingSLSLength, "logging.sls.length metric was not emitted")
 	assert.True(t, seenMyCounter, "my-counter metric was not emitted")
 	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
 	assert.True(t, seenRequestSize, "server.request.size metric was not emitted")
@@ -377,6 +398,7 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 
 	var (
 		seenLoggingSLS,
+		seenLoggingSLSLength,
 		seenMyCounter,
 		seenResponseTimer,
 		seenResponseSize,
@@ -398,6 +420,14 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 			} else {
 				assert.Equal(t, "", metricTagLevel)
 			}
+		case "logging.sls.length":
+			seenLoggingSLSLength = true
+			assert.Equal(t, "histogram", metricLog.MetricType, "logging.sls.length metric had incorrect type")
+			assert.NotNil(t, metricLog.Values["max"])
+			assert.NotNil(t, metricLog.Values["p95"])
+			assert.NotNil(t, metricLog.Values["p99"])
+			assert.Nil(t, metricLog.Values["count"])
+			assert.NotNil(t, metricLog.Tags["type"])
 		case "my-counter":
 			seenMyCounter = true
 			assert.Equal(t, "counter", metricLog.MetricType, "my-counter metric had incorrect type")
@@ -433,6 +463,7 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		}
 	}
 	assert.True(t, seenLoggingSLS, "logging.sls metric was not emitted")
+	assert.True(t, seenLoggingSLSLength, "logging.sls.length metric was not emitted")
 	assert.True(t, seenMyCounter, "my-counter metric was not emitted")
 	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
 	assert.True(t, seenRequestSize, "server.request.size metric was not emitted")
@@ -464,6 +495,7 @@ func TestMetricsBlacklist(t *testing.T) {
 		server.WithMetricsBlacklist(map[string]struct{}{
 			"my-counter":          {},
 			"logging.sls":         {},
+			"logging.sls.length":  {},
 			"server.request.size": {},
 			"server.uptime":       {},
 		})
@@ -493,6 +525,7 @@ func TestMetricsBlacklist(t *testing.T) {
 
 	var (
 		seenLoggingSLS,
+		seenLoggingSLSLength,
 		seenMyCounter,
 		seenResponseTimer,
 		seenResponseSize,
@@ -503,6 +536,8 @@ func TestMetricsBlacklist(t *testing.T) {
 		switch metricLog.MetricName {
 		case "logging.sls":
 			assert.Fail(t, "logging.sls metric should not be emitted")
+		case "logging.sls.length":
+			assert.Fail(t, "logging.sls.length metric should not be emitted")
 		case "my-counter":
 			assert.Fail(t, "my-counter metric should not be emitted")
 		case "server.response":
@@ -526,6 +561,7 @@ func TestMetricsBlacklist(t *testing.T) {
 	assert.False(t, seenMyCounter, "my-counter metric was emitted")
 	assert.False(t, seenRequestSize, "server.request.size metric was emitted")
 	assert.False(t, seenLoggingSLS, "logging.sls metric was emitted")
+	assert.False(t, seenLoggingSLSLength, "logging.sls.length metric was emitted")
 
 	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
 	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")

--- a/witchcraft/internal/metricloggers/recorder.go
+++ b/witchcraft/internal/metricloggers/recorder.go
@@ -48,7 +48,7 @@ type metricRecorder interface {
 	// defined there may cause this function to panic.
 	RecordLeveledSLSLog(level wlog.LogLevel)
 
-	// TODO:
+	// RecordSLSLogLength records the length of an SLS log line for the given log type.
 	RecordSLSLogLength(len int)
 }
 

--- a/witchcraft/internal/metricloggers/recorder.go
+++ b/witchcraft/internal/metricloggers/recorder.go
@@ -20,7 +20,8 @@ import (
 )
 
 const (
-	slsLoggingMeterName = "logging.sls"
+	slsLoggingMeterName       = "logging.sls"
+	slsLogLengthHistogramName = "logging.sls.length"
 )
 
 // map from level to tag for the level. Maps is used because these values are the only ones that are used, and
@@ -46,6 +47,9 @@ type metricRecorder interface {
 	// parameter should be one of the wlog.LogLevel constants defined in the wlog package -- using a value that is not
 	// defined there may cause this function to panic.
 	RecordLeveledSLSLog(level wlog.LogLevel)
+
+	// TODO:
+	RecordSLSLogLength(len int)
 }
 
 type defaultMetricRecorder struct {
@@ -58,6 +62,10 @@ func newMetricRecorder(registry metrics.Registry, typ string) metricRecorder {
 		registry: registry,
 		typeTag:  metrics.MustNewTag("type", typ),
 	}
+}
+
+func (m *defaultMetricRecorder) RecordSLSLogLength(len int) {
+	m.registry.Histogram(slsLogLengthHistogramName, m.typeTag).Update(int64(len))
 }
 
 func (m *defaultMetricRecorder) RecordSLSLog() {

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -1,0 +1,35 @@
+package metricloggers
+
+import (
+	"io"
+
+	"github.com/palantir/pkg/metrics"
+)
+
+var _ io.Writer = (*metricWriter)(nil)
+
+type metricWriter struct {
+	writer   io.Writer
+	typ      string
+	recorder metricRecorder
+}
+
+func NewMetricWriter(writer io.Writer, typ string) io.Writer {
+	return &metricWriter{
+		writer:   writer,
+		typ:      typ,
+		recorder: nil,
+	}
+}
+
+func (m *metricWriter) SetMetricRegistry(registry metrics.Registry) {
+	m.recorder = newMetricRecorder(registry, m.typ)
+}
+
+func (m *metricWriter) Write(p []byte) (int, error) {
+	n, err := m.writer.Write(p)
+	if m.recorder != nil {
+		m.recorder.RecordSLSLogLength(n)
+	}
+	return n, err
+}

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package metricloggers
 
 import (

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -8,13 +8,18 @@ import (
 
 var _ io.Writer = (*metricWriter)(nil)
 
+type MetricWriter interface {
+	io.Writer
+	SetMetricRegistry(metrics.Registry)
+}
+
 type metricWriter struct {
 	writer   io.Writer
 	typ      string
 	recorder metricRecorder
 }
 
-func NewMetricWriter(writer io.Writer, typ string) io.Writer {
+func NewMetricWriter(writer io.Writer, typ string) MetricWriter {
 	return &metricWriter{
 		writer:   writer,
 		typ:      typ,
@@ -29,7 +34,8 @@ func (m *metricWriter) SetMetricRegistry(registry metrics.Registry) {
 func (m *metricWriter) Write(p []byte) (int, error) {
 	n, err := m.writer.Write(p)
 	if m.recorder != nil {
-		m.recorder.RecordSLSLogLength(n)
+		// Commented out because I still need to fix the integration tests if we chose this approach
+		//m.recorder.RecordSLSLogLength(n)
 	}
 	return n, err
 }

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -22,11 +22,6 @@ import (
 
 var _ io.Writer = (*metricWriter)(nil)
 
-// MetricWriter can be used for SLS logging. It records metrics about the length of the lines writen.
-type MetricWriter interface {
-	io.Writer
-}
-
 type metricWriter struct {
 	writer   io.Writer
 	recorder metricRecorder
@@ -34,7 +29,7 @@ type metricWriter struct {
 
 // NewMetricWriter returns a MetricWriter that delegates to writer, and records SLS log line length
 // according to the provided slsFilename, e.g. "service", or "trace".
-func NewMetricWriter(writer io.Writer, registry metrics.Registry, slsFilename string) MetricWriter {
+func NewMetricWriter(writer io.Writer, registry metrics.Registry, slsFilename string) io.Writer {
 	var recorder metricRecorder
 	if registry != nil {
 		recorder = newMetricRecorder(registry, slsFilename)

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -29,6 +29,7 @@ type metricWriter struct {
 
 // NewMetricWriter returns a MetricWriter that delegates to writer, and records SLS log line length
 // according to the provided slsFilename, e.g. "service", or "trace".
+// If registry is nil, then no metrics are recorded.
 func NewMetricWriter(writer io.Writer, registry metrics.Registry, slsFilename string) io.Writer {
 	var recorder metricRecorder
 	if registry != nil {

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -22,8 +22,11 @@ import (
 
 var _ io.Writer = (*metricWriter)(nil)
 
+// MetricWriter can be used for SLS logging. It emits metrics about the length of the lines writen.
 type MetricWriter interface {
 	io.Writer
+	// SetMetricRegistry initializes the metric registry used for emitting metrics.
+	// Before this is called, no metrics are emitted.
 	SetMetricRegistry(metrics.Registry)
 }
 
@@ -33,10 +36,12 @@ type metricWriter struct {
 	recorder metricRecorder
 }
 
-func NewMetricWriter(writer io.Writer, typ string) MetricWriter {
+// NewMetricWriter returns a MetricWriter that delegates to writer, and emits SLS log line length
+// according to the provided slsFilename, e.g. "service", or "trace".
+func NewMetricWriter(writer io.Writer, slsFilename string) MetricWriter {
 	return &metricWriter{
 		writer:   writer,
-		typ:      typ,
+		typ:      slsFilename,
 		recorder: nil,
 	}
 }
@@ -48,8 +53,7 @@ func (m *metricWriter) SetMetricRegistry(registry metrics.Registry) {
 func (m *metricWriter) Write(p []byte) (int, error) {
 	n, err := m.writer.Write(p)
 	if m.recorder != nil {
-		// Commented out because I still need to fix the integration tests if we chose this approach
-		//m.recorder.RecordSLSLogLength(n)
+		m.recorder.RecordSLSLogLength(n)
 	}
 	return n, err
 }

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -22,12 +22,11 @@ import (
 
 var _ io.Writer = (*metricWriter)(nil)
 
-// MetricWriter can be used for SLS logging. It emits metrics about the length of the lines writen.
+// MetricWriter can be used for SLS logging. It records metrics about the length of the lines writen.
 type MetricWriter interface {
 	io.Writer
-	// SetMetricRegistry initializes the metric registry used for emitting metrics.
-	// Before this is called, no metrics are emitted.
-	SetMetricRegistry(metrics.Registry)
+	// SetMetricRegistry sets the metric registry. If the registry is nil, no metrics are recorded.
+	SetMetricRegistry(registry metrics.Registry)
 }
 
 type metricWriter struct {
@@ -36,7 +35,7 @@ type metricWriter struct {
 	recorder metricRecorder
 }
 
-// NewMetricWriter returns a MetricWriter that delegates to writer, and emits SLS log line length
+// NewMetricWriter returns a MetricWriter that delegates to writer, and records SLS log line length
 // according to the provided slsFilename, e.g. "service", or "trace".
 func NewMetricWriter(writer io.Writer, slsFilename string) MetricWriter {
 	return &metricWriter{

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -25,28 +25,24 @@ var _ io.Writer = (*metricWriter)(nil)
 // MetricWriter can be used for SLS logging. It records metrics about the length of the lines writen.
 type MetricWriter interface {
 	io.Writer
-	// SetMetricRegistry sets the metric registry. If the registry is nil, no metrics are recorded.
-	SetMetricRegistry(registry metrics.Registry)
 }
 
 type metricWriter struct {
 	writer   io.Writer
-	typ      string
 	recorder metricRecorder
 }
 
 // NewMetricWriter returns a MetricWriter that delegates to writer, and records SLS log line length
 // according to the provided slsFilename, e.g. "service", or "trace".
-func NewMetricWriter(writer io.Writer, slsFilename string) MetricWriter {
+func NewMetricWriter(writer io.Writer, registry metrics.Registry, slsFilename string) MetricWriter {
+	var recorder metricRecorder
+	if registry != nil {
+		recorder = newMetricRecorder(registry, slsFilename)
+	}
 	return &metricWriter{
 		writer:   writer,
-		typ:      slsFilename,
-		recorder: nil,
+		recorder: recorder,
 	}
-}
-
-func (m *metricWriter) SetMetricRegistry(registry metrics.Registry) {
-	m.recorder = newMetricRecorder(registry, m.typ)
 }
 
 func (m *metricWriter) Write(p []byte) (int, error) {

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -90,7 +90,7 @@ func (s *Server) initLoggers(useConsoleLog bool, logLevel wlog.LogLevel) []metri
 }
 
 // Returns a MetricWriter which can be used as the underlying writer for a logger.
-// If logToStdout is true, then the provided stdoutWriter is used within the MetricWriter.
+// If either logToStdout or logToStdoutBasedOnEnv() is true, then the provided stdoutWriter is used within the MetricWriter.
 // Otherwise, the returned MetricWriter will use a default writer that writes to logOutputFilename.
 func newDefaultLogOutputWriter(slsFilename string, logToStdout bool, stdoutWriter io.Writer) metricloggers.MetricWriter {
 	var internalWriter io.Writer

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -55,7 +55,7 @@ func (s *Server) initLoggers(registry metrics.Registry, useConsoleLog bool, logL
 		loggerStdoutWriter = s.loggerStdoutWriter
 	}
 
-	logWriterFn := func(slsFilename string) metricloggers.MetricWriter {
+	logWriterFn := func(slsFilename string) io.Writer {
 		return newDefaultLogOutputWriter(registry, slsFilename, useConsoleLog, loggerStdoutWriter)
 	}
 
@@ -79,10 +79,10 @@ func (s *Server) initLoggers(registry metrics.Registry, useConsoleLog bool, logL
 	)
 }
 
-// Returns a MetricWriter which can be used as the underlying writer for a logger.
-// If either logToStdout or logToStdoutBasedOnEnv() is true, then the provided stdoutWriter is used within the MetricWriter.
-// Otherwise, the returned MetricWriter will use a default writer that writes to slsFilename.
-func newDefaultLogOutputWriter(registry metrics.Registry, slsFilename string, logToStdout bool, stdoutWriter io.Writer) metricloggers.MetricWriter {
+// Returns an instrumented io.Writer that can be used as the underlying writer for a logger.
+// If either logToStdout or logToStdoutBasedOnEnv() is true, then the returned Writer will delegate to stdoutWriter.
+// Otherwise, it will use a default writer that writes to slsFilename.
+func newDefaultLogOutputWriter(registry metrics.Registry, slsFilename string, logToStdout bool, stdoutWriter io.Writer) io.Writer {
 	var internalWriter io.Writer
 	if logToStdout || logToStdoutBasedOnEnv() {
 		internalWriter = stdoutWriter

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -37,9 +37,9 @@ const (
 	defaultLogOutputFormat = "var/log/%s.log"
 )
 
-// initLoggers initializes the Server loggers with the provided logLevel.
-// The loggers are instrumented and will record metrics in the given registry.
+// initLoggers initializes the Server loggers with instrumented loggers that record metrics in the given registry.
 // If useConsoleLog is true, then all loggers log to stdout.
+// The provided logLevel is used when initializing the service logs only.
 func (s *Server) initLoggers(registry metrics.Registry, useConsoleLog bool, logLevel wlog.LogLevel) {
 	if s.svcLogOrigin == nil {
 		// if origin param is not specified, use a param that uses the package name of the caller of Start()

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -97,8 +97,8 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			return
 		}
 		// note that s.metricLogger is used rather than extracting metric logger from the context to ensure that
-		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization). s.metricLogger
-		// is guaranteed to be non-nil at this point.
+		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization).
+		// s.metricLogger is not guaranteed to be non-nil at this point.
 		s.metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 	}
 

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -96,10 +96,8 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			// do not record metric if it does not have any values
 			return
 		}
-		// note that s.metricLogger is used rather than extracting metric logger from the context to ensure that
-		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization). s.metricLogger
-		// is guaranteed to be non-nil at this point.
-		s.metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
+		// s.metricLogger is not guaranteed to be non-nil at this point, so we use the logger from the ctx.
+		metric1log.FromContext(ctx).Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 	}
 
 	// start goroutine that logs metrics at the given frequency

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -97,14 +97,12 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			return
 		}
 
-		// note that s.metricLogger is attempted first to ensure that most up-to-date metric logger is used.
-		// (s.metricLogger may be updated during initialization).
-		metricLogger := s.metricLogger
-		if metricLogger == nil {
-			// s.metricLogger is not guaranteed to be non-nil at this point.
-			metricLogger = metric1log.FromContext(ctx)
+		// note that s.metricLogger is used rather than extracting metric logger from the context to ensure that
+		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization).
+		// s.metricLogger is not guaranteed to be non-nil at this point.
+		if s.metricLogger != nil {
+			s.metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 		}
-		metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 	}
 
 	// start goroutine that logs metrics at the given frequency

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -96,9 +96,12 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			// do not record metric if it does not have any values
 			return
 		}
-		// s.metricLogger is not guaranteed to be non-nil at this point.
+
+		// note that s.metricLogger is attempted first to ensure that most up-to-date metric logger is used.
+		// (s.metricLogger may be updated during initialization).
 		metricLogger := s.metricLogger
 		if metricLogger == nil {
+			// s.metricLogger is not guaranteed to be non-nil at this point.
 			metricLogger = metric1log.FromContext(ctx)
 		}
 		metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -96,10 +96,12 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			// do not record metric if it does not have any values
 			return
 		}
-		// note that s.metricLogger is used rather than extracting metric logger from the context to ensure that
-		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization).
 		// s.metricLogger is not guaranteed to be non-nil at this point.
-		s.metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
+		metricLogger := s.metricLogger
+		if metricLogger == nil {
+			metricLogger = metric1log.FromContext(ctx)
+		}
+		metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 	}
 
 	// start goroutine that logs metrics at the given frequency

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -96,8 +96,10 @@ func (s *Server) initMetrics(ctx context.Context, installCfg config.Install) (rR
 			// do not record metric if it does not have any values
 			return
 		}
-		// s.metricLogger is not guaranteed to be non-nil at this point, so we use the logger from the ctx.
-		metric1log.FromContext(ctx).Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
+		// note that s.metricLogger is used rather than extracting metric logger from the context to ensure that
+		// most up-to-date metric logger is used (s.metricLogger may be updated during initialization). s.metricLogger
+		// is guaranteed to be non-nil at this point.
+		s.metricLogger.Metric(metricID, metricType, metric1log.Values(valuesToUse), metric1log.Tags(tags.ToMap()))
 	}
 
 	// start goroutine that logs metrics at the given frequency

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -571,7 +571,7 @@ func (s *Server) Start() (rErr error) {
 	// initialize loggers. These loggers are not instrumented (do not record metrics as they log) because the metrics
 	// registry is not yet initialized: these loggers will be replaced by instrumenting loggers after metric registry
 	// initialization.
-	s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
+	metricWriters := s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
@@ -588,6 +588,9 @@ func (s *Server) Start() (rErr error) {
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
 	// after metrics registry is created, update loggers to use versions that record metrics as logging is performed.
+	for _, w := range metricWriters {
+		w.SetMetricRegistry(metricsRegistry)
+	}
 	s.svcLogger = metricloggers.NewSvc1Logger(s.svcLogger, metricsRegistry)
 	s.evtLogger = metricloggers.NewEvt2Logger(s.evtLogger, metricsRegistry)
 	s.metricLogger = metricloggers.NewMetric1Logger(s.metricLogger, metricsRegistry)

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -568,10 +568,10 @@ func (s *Server) Start() (rErr error) {
 		s.idsExtractor = extractor.NewDefaultIDsExtractor()
 	}
 
-	// initialize loggers. These loggers are not instrumented (do not record metrics as they log) because the metrics
-	// registry is not yet initialized: these loggers will be replaced by instrumenting loggers after metric registry
-	// initialization.
-	metricWriters := s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
+	// initialize loggers. These loggers and the returned logWriters are not instrumented (do not record metrics as they log)
+	// because the metrics registry is not yet initialized: these loggers will be replaced by instrumenting loggers
+	// after metric registry initialization.
+	logWriters := s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
 
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
@@ -587,8 +587,8 @@ func (s *Server) Start() (rErr error) {
 	defer metricsDeferFn()
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
-	// after metrics registry is created, update loggers to use versions that record metrics as logging is performed.
-	for _, w := range metricWriters {
+	// after metrics registry is created, update writers and loggers to use versions that record metrics as logging is performed.
+	for _, w := range logWriters {
 		w.SetMetricRegistry(metricsRegistry)
 	}
 	s.svcLogger = metricloggers.NewSvc1Logger(s.svcLogger, metricsRegistry)

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -519,7 +519,7 @@ func (s *Server) Start() (rErr error) {
 
 			if s.svcLogger == nil {
 				// If we have not yet initialized our loggers, use default configuration as best-effort.
-				s.initLoggers(nil, false, wlog.InfoLevel)
+				s.initLoggers(false, wlog.InfoLevel, nil)
 			}
 
 			s.svcLogger.Error("panic recovered", svc1log.SafeParam("stack", diag1log.ThreadDumpV1FromGoroutines(debug.Stack())), svc1log.Stacktrace(rErr))
@@ -529,7 +529,7 @@ func (s *Server) Start() (rErr error) {
 		if rErr != nil {
 			if s.svcLogger == nil {
 				// If we have not yet initialized our loggers, use default configuration as best-effort.
-				s.initLoggers(nil, false, wlog.InfoLevel)
+				s.initLoggers(false, wlog.InfoLevel, nil)
 			}
 			s.svcLogger.Error(rErr.Error(), svc1log.Stacktrace(rErr))
 		}
@@ -578,8 +578,8 @@ func (s *Server) Start() (rErr error) {
 	defer metricsDeferFn()
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
-	// initialize loggers.
-	s.initLoggers(metricsRegistry, baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
+	// initialize loggers
+	s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel, metricsRegistry)
 
 	// add loggers to context
 	ctx = s.withLoggers(ctx)

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -48,7 +48,6 @@ import (
 	"github.com/palantir/witchcraft-go-server/config"
 	"github.com/palantir/witchcraft-go-server/status"
 	refreshablehealth "github.com/palantir/witchcraft-go-server/status/health/refreshable"
-	"github.com/palantir/witchcraft-go-server/witchcraft/internal/metricloggers"
 	"github.com/palantir/witchcraft-go-server/witchcraft/refreshable"
 	"github.com/palantir/witchcraft-go-server/wrouter"
 	"github.com/palantir/witchcraft-go-server/wrouter/whttprouter"
@@ -520,7 +519,7 @@ func (s *Server) Start() (rErr error) {
 
 			if s.svcLogger == nil {
 				// If we have not yet initialized our loggers, use default configuration as best-effort.
-				s.initLoggers(false, wlog.InfoLevel)
+				s.initLoggers(nil, false, wlog.InfoLevel)
 			}
 
 			s.svcLogger.Error("panic recovered", svc1log.SafeParam("stack", diag1log.ThreadDumpV1FromGoroutines(debug.Stack())), svc1log.Stacktrace(rErr))
@@ -530,7 +529,7 @@ func (s *Server) Start() (rErr error) {
 		if rErr != nil {
 			if s.svcLogger == nil {
 				// If we have not yet initialized our loggers, use default configuration as best-effort.
-				s.initLoggers(false, wlog.InfoLevel)
+				s.initLoggers(nil, false, wlog.InfoLevel)
 			}
 			s.svcLogger.Error(rErr.Error(), svc1log.Stacktrace(rErr))
 		}
@@ -571,7 +570,7 @@ func (s *Server) Start() (rErr error) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
 
-	// initialize metrics. Note that loggers associated with ctx are not instrumented, but
+	// initialize metrics. Note that loggers have not been initialized or associated with ctx
 	metricsRegistry, metricsDeferFn, err := s.initMetrics(ctx, baseInstallCfg)
 	if err != nil {
 		return err
@@ -579,22 +578,10 @@ func (s *Server) Start() (rErr error) {
 	defer metricsDeferFn()
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
-	// initialize loggers. These loggers and the returned logWriters are not instrumented (do not record metrics as they log)
-	// because the metrics registry is not yet initialized: these loggers will be replaced by instrumenting loggers
-	// after metric registry initialization.
-	s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
+	// initialize loggers.
+	s.initLoggers(metricsRegistry, baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
 
 	// add loggers to context
-	ctx = s.withLoggers(ctx)
-
-	// after metrics registry is created, update writers and loggers to use versions that record metrics as logging is performed.
-	s.svcLogger = metricloggers.NewSvc1Logger(s.svcLogger, metricsRegistry)
-	s.evtLogger = metricloggers.NewEvt2Logger(s.evtLogger, metricsRegistry)
-	s.metricLogger = metricloggers.NewMetric1Logger(s.metricLogger, metricsRegistry)
-	s.trcLogger = metricloggers.NewTrc1Logger(s.trcLogger, metricsRegistry)
-	s.auditLogger = metricloggers.NewAudit2Logger(s.auditLogger, metricsRegistry)
-
-	// update context to use instrumented loggers
 	ctx = s.withLoggers(ctx)
 
 	// load runtime configuration

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -568,16 +568,8 @@ func (s *Server) Start() (rErr error) {
 		s.idsExtractor = extractor.NewDefaultIDsExtractor()
 	}
 
-	// initialize loggers. These loggers and the returned logWriters are not instrumented (do not record metrics as they log)
-	// because the metrics registry is not yet initialized: these loggers will be replaced by instrumenting loggers
-	// after metric registry initialization.
-	logWriters := s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
-
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	defer cancelCtx()
-
-	// add loggers to context
-	ctx = s.withLoggers(ctx)
 
 	// initialize metrics. Note that loggers associated with ctx are not instrumented, but
 	metricsRegistry, metricsDeferFn, err := s.initMetrics(ctx, baseInstallCfg)
@@ -587,10 +579,15 @@ func (s *Server) Start() (rErr error) {
 	defer metricsDeferFn()
 	ctx = metrics.WithRegistry(ctx, metricsRegistry)
 
+	// initialize loggers. These loggers and the returned logWriters are not instrumented (do not record metrics as they log)
+	// because the metrics registry is not yet initialized: these loggers will be replaced by instrumenting loggers
+	// after metric registry initialization.
+	s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel)
+
+	// add loggers to context
+	ctx = s.withLoggers(ctx)
+
 	// after metrics registry is created, update writers and loggers to use versions that record metrics as logging is performed.
-	for _, w := range logWriters {
-		w.SetMetricRegistry(metricsRegistry)
-	}
 	s.svcLogger = metricloggers.NewSvc1Logger(s.svcLogger, metricsRegistry)
 	s.evtLogger = metricloggers.NewEvt2Logger(s.evtLogger, metricsRegistry)
 	s.metricLogger = metricloggers.NewMetric1Logger(s.metricLogger, metricsRegistry)


### PR DESCRIPTION
As part of the go infra tooling week, we are working on a feature that allows WGS to emit the `sls.logging.length` metric when logging a line.

This PR is for discussing a possible approach.

## After this PR
==COMMIT_MSG==
WGS emits the `sls.logging.length` metric when logging a line.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/181)
<!-- Reviewable:end -->
