### PR TITLE
Improvement: record metrics for diag1 and req2 loggers

### DIFF
--- a/changelog/@unreleased/pr-182.v2.yml
+++ b/changelog/@unreleased/pr-182.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Records the "logging.sls" metric for diag1 and req2 loggers.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/182

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/palantir/pkg/signals v1.0.0
 	github.com/palantir/pkg/tlsconfig v1.0.0
 	github.com/palantir/witchcraft-go-error v1.3.0
-	github.com/palantir/witchcraft-go-logging v1.5.0
+	github.com/palantir/witchcraft-go-logging v1.5.2
 	github.com/palantir/witchcraft-go-params v1.1.0
 	github.com/palantir/witchcraft-go-tracing v1.2.0
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/palantir/witchcraft-go-error v1.2.0 h1:YFoZ8VC0ZLCGuhqM9iqdflUrTHGQmc
 github.com/palantir/witchcraft-go-error v1.2.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
 github.com/palantir/witchcraft-go-error v1.3.0 h1:1FUvIv+jS22t81uPI0Q5JEwzBDigClqGJJkLTuE8sZI=
 github.com/palantir/witchcraft-go-error v1.3.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
-github.com/palantir/witchcraft-go-logging v1.5.0 h1:LxmZ6XuhitMKmNrUQZ3UBU92q6PKPsawV94FlLVUui4=
-github.com/palantir/witchcraft-go-logging v1.5.0/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
+github.com/palantir/witchcraft-go-logging v1.5.2 h1:1xTnCqOSB5+BVlw4RkN3UWidhMxFT7nNNoRC1wA7scs=
+github.com/palantir/witchcraft-go-logging v1.5.2/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
 github.com/palantir/witchcraft-go-params v1.1.0 h1:siRqQv9TuJ0qY2JK5Svd3/rGQQCWvNnjI2OGAftm8gc=
 github.com/palantir/witchcraft-go-params v1.1.0/go.mod h1:HH+l5b0binfqBJ21qVvQVOJp6s2/I6ld0NEWnaEgWvI=
 github.com/palantir/witchcraft-go-tracing v1.2.0 h1:+7MinUHafMfF3fDdHVRuQ6fhMi8R1qxv36ECqN3cqOQ=
@@ -83,6 +83,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/zerolog v1.11.0 h1:DRuq/S+4k52uJzBQciUcofXx45GrMC6yrEbb/CoK6+M=
 github.com/rs/zerolog v1.11.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/logger_provider_jsonmarshal.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/logger_provider_jsonmarshal.go
@@ -41,37 +41,33 @@ func (l *jsonMapLogger) Log(params ...Param) {
 func (l *jsonMapLogger) Debug(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel:
-		l.logOutputWithMessage(msg, "DEBUG", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "DEBUG")))
 	}
 }
 
 func (l *jsonMapLogger) Info(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel:
-		l.logOutputWithMessage(msg, "INFO", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "INFO")))
 	}
 }
 
 func (l *jsonMapLogger) Warn(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel:
-		l.logOutputWithMessage(msg, "WARN", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "WARN")))
 	}
 }
 
 func (l *jsonMapLogger) Error(msg string, params ...Param) {
 	switch l.level {
 	case DebugLevel, InfoLevel, WarnLevel, ErrorLevel:
-		l.logOutputWithMessage(msg, "ERROR", params)
+		l.logOutput(append(params, StringParam("message", msg), StringParam("level", "ERROR")))
 	}
 }
 
 func (l *jsonMapLogger) SetLevel(level LogLevel) {
 	l.level = level
-}
-
-func (l *jsonMapLogger) logOutputWithMessage(msg, level string, params []Param) {
-	l.logOutput(append(params, StringParam("message", msg), StringParam("level", level)))
 }
 
 func (l *jsonMapLogger) logOutput(params []Param) {

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	typeValue = "request.2"
+	TypeValue = "request.2"
 
 	methodKey       = "method"
 	protocolKey     = "protocol"

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger_default.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log/logger_default.go
@@ -42,7 +42,7 @@ func (l *defaultLogger) Request(r Request) {
 	idsMap := l.idsExtractor.ExtractIDs(r.Request)
 
 	l.logger.Log(
-		wlog.StringParam(wlog.TypeKey, typeValue),
+		wlog.StringParam(wlog.TypeKey, TypeValue),
 		wlog.OptionalStringParam(methodKey, r.Request.Method),
 		wlog.StringParam(protocolKey, r.Request.Proto),
 		wlog.StringParam(pathKey, reqPath),

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/params.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log/params.go
@@ -119,7 +119,7 @@ func OriginFromInitPkg(skipPkg int) Param {
 func OriginFromCallLine() Param {
 	return paramFunc(func(entry wlog.LogEntry) {
 		origin := ""
-		if file, line, ok := initLineCaller(9); ok {
+		if file, line, ok := initLineCaller(8); ok {
 			origin = file + ":" + strconv.Itoa(line)
 		}
 		entry.OptionalStringValue(OriginKey, origin)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -42,7 +42,7 @@ github.com/palantir/pkg/transform
 # github.com/palantir/witchcraft-go-error v1.3.0
 github.com/palantir/witchcraft-go-error
 github.com/palantir/witchcraft-go-error/internal/errors
-# github.com/palantir/witchcraft-go-logging v1.5.0
+# github.com/palantir/witchcraft-go-logging v1.5.2
 github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging
 github.com/palantir/witchcraft-go-logging/internal/gopath
 github.com/palantir/witchcraft-go-logging/wlog

--- a/witchcraft/internal/metricloggers/diag1logger.go
+++ b/witchcraft/internal/metricloggers/diag1logger.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricloggers
+
+import (
+	"github.com/palantir/pkg/metrics"
+	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
+	"github.com/palantir/witchcraft-go-logging/wlog/diaglog/diag1log"
+)
+
+var _ diag1log.Logger = (*diag1Logger)(nil)
+
+type diag1Logger struct {
+	logger   diag1log.Logger
+	recorder metricRecorder
+}
+
+func NewDiag1Logger(logger diag1log.Logger, registry metrics.Registry) diag1log.Logger {
+	return &diag1Logger{
+		logger:   logger,
+		recorder: newMetricRecorder(registry, diag1log.TypeValue),
+	}
+}
+
+func (m *diag1Logger) Diagnostic(diagnostic logging.Diagnostic, params ...diag1log.Param) {
+	m.logger.Diagnostic(diagnostic, params...)
+	m.recorder.RecordSLSLog()
+}

--- a/witchcraft/internal/metricloggers/req2logger.go
+++ b/witchcraft/internal/metricloggers/req2logger.go
@@ -29,7 +29,7 @@ type req2Logger struct {
 func NewReq2Logger(logger req2log.Logger, registry metrics.Registry) req2log.Logger {
 	return &req2Logger{
 		logger:   logger,
-		recorder: newMetricRecorder(registry, "request.2"),
+		recorder: newMetricRecorder(registry, req2log.TypeValue),
 	}
 }
 

--- a/witchcraft/internal/metricloggers/req2logger.go
+++ b/witchcraft/internal/metricloggers/req2logger.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metricloggers
+
+import (
+	"github.com/palantir/pkg/metrics"
+	"github.com/palantir/witchcraft-go-logging/wlog/reqlog/req2log"
+)
+
+var _ req2log.Logger = (*req2Logger)(nil)
+
+type req2Logger struct {
+	logger   req2log.Logger
+	recorder metricRecorder
+}
+
+func NewReq2Logger(logger req2log.Logger, registry metrics.Registry) req2log.Logger {
+	return &req2Logger{
+		logger:   logger,
+		recorder: newMetricRecorder(registry, "request.2"),
+	}
+}
+
+func (r *req2Logger) Request(req req2log.Request) {
+	r.logger.Request(req)
+	r.recorder.RecordSLSLog()
+}
+
+func (r *req2Logger) PathParamPerms() req2log.ParamPerms {
+	return r.logger.PathParamPerms()
+}
+
+func (r *req2Logger) QueryParamPerms() req2log.ParamPerms {
+	return r.logger.QueryParamPerms()
+}
+
+func (r *req2Logger) HeaderParamPerms() req2log.ParamPerms {
+	return r.logger.HeaderParamPerms()
+}

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -71,13 +71,13 @@ func (s *Server) initLoggers(useConsoleLog bool, logLevel wlog.LogLevel, registr
 		trc1log.New(logWriterFn("trace")), registry)
 	s.auditLogger = metricloggers.NewAudit2Logger(
 		audit2log.New(logWriterFn("audit")), registry)
-	s.diagLogger = diag1log.New(logWriterFn("diagnostic"))
-	s.reqLogger = req2log.New(logWriterFn("request"),
+	s.diagLogger = metricloggers.NewDiag1Logger(diag1log.New(logWriterFn("diagnostic")), registry)
+	s.reqLogger = metricloggers.NewReq2Logger(req2log.New(logWriterFn("request"),
 		req2log.Extractor(s.idsExtractor),
 		req2log.SafePathParams(s.safePathParams...),
 		req2log.SafeHeaderParams(s.safeHeaderParams...),
 		req2log.SafeQueryParams(s.safeQueryParams...),
-	)
+	), registry)
 }
 
 // Returns a io.Writer that can be used as the underlying writer for a logger.


### PR DESCRIPTION
## Before this PR
The "logging.sls" metric is recorded for all logger types except for diag1 and req2 loggers.

## After this PR
==COMMIT_MSG==
Records the "logging.sls" metric for diag1 and req2 loggers.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/182)
<!-- Reviewable:end -->
