### PR TITLE
Feature: Add HealthStatusChangeHandler interface.

### DIFF
--- a/changelog/@unreleased/pr-195.v2.yml
+++ b/changelog/@unreleased/pr-195.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: |
+    Add HealthStatusChangeHandler interface. Invoke health status change handlers whenever health checks have changed state.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/195

--- a/status/change_handler.go
+++ b/status/change_handler.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+)
+
+type HealthStatusChangeHandler interface {
+	HandleHealthStatusChange(ctx context.Context, prevStatus, currStatus health.HealthStatus)
+}
+
+type healthStatusChangeHandlerFn func(ctx context.Context, prevStatus, currStatus health.HealthStatus)
+
+func (fn healthStatusChangeHandlerFn) HandleHealthStatusChange(ctx context.Context, prevStatus, currStatus health.HealthStatus) {
+	fn(ctx, prevStatus, currStatus)
+}

--- a/status/logging_change_handler.go
+++ b/status/logging_change_handler.go
@@ -42,26 +42,9 @@ func logIfHealthChanged(ctx context.Context, previousHealth, newHealth health.He
 			svc1log.FromContext(ctx).Error("Health status code changed.", svc1log.SafeParams(params))
 		}
 		return
-	} else if checksDiffer(previousHealth.Checks, newHealth.Checks) {
-		svc1log.FromContext(ctx).Info("Health checks content changed without status change.", svc1log.SafeParams(map[string]interface{}{
-			"statusCode":      newCode,
-			"newHealthStatus": newHealth.Checks,
-		}))
 	}
-}
-
-func checksDiffer(previousChecks, newChecks map[health.CheckType]health.HealthCheckResult) bool {
-	if len(previousChecks) != len(newChecks) {
-		return true
-	}
-	for previousCheckType, previouscheckResult := range previousChecks {
-		newCheckResult, checkTypePresent := newChecks[previousCheckType]
-		if !checkTypePresent {
-			return true
-		}
-		if previouscheckResult.State != newCheckResult.State {
-			return true
-		}
-	}
-	return false
+	svc1log.FromContext(ctx).Info("Health checks content changed without status change.", svc1log.SafeParams(map[string]interface{}{
+		"statusCode":      newCode,
+		"newHealthStatus": newHealth.Checks,
+	}))
 }

--- a/status/logging_change_handler.go
+++ b/status/logging_change_handler.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+)
+
+func loggingHealthStatusChangeHandler() HealthStatusChangeHandler {
+	return healthStatusChangeHandlerFn(func(ctx context.Context, prevStatus, currStatus health.HealthStatus) {
+		logIfHealthChanged(ctx, prevStatus, currStatus)
+	})
+}
+
+func logIfHealthChanged(ctx context.Context, previousHealth, newHealth health.HealthStatus) {
+	previousCode, newCode := HealthStatusCode(previousHealth), HealthStatusCode(newHealth)
+	if previousCode != newCode {
+		params := map[string]interface{}{
+			"previousHealthStatusCode": previousCode,
+			"newHealthStatusCode":      newCode,
+			"newHealthStatus":          newHealth.Checks,
+		}
+		if newCode == http.StatusOK {
+			svc1log.FromContext(ctx).Info("Health status code changed.", svc1log.SafeParams(params))
+		} else {
+			svc1log.FromContext(ctx).Error("Health status code changed.", svc1log.SafeParams(params))
+		}
+		return
+	} else if checksDiffer(previousHealth.Checks, newHealth.Checks) {
+		svc1log.FromContext(ctx).Info("Health checks content changed without status change.", svc1log.SafeParams(map[string]interface{}{
+			"statusCode":      newCode,
+			"newHealthStatus": newHealth.Checks,
+		}))
+	}
+}
+
+func checksDiffer(previousChecks, newChecks map[health.CheckType]health.HealthCheckResult) bool {
+	if len(previousChecks) != len(newChecks) {
+		return true
+	}
+	for previousCheckType, previouscheckResult := range previousChecks {
+		newCheckResult, checkTypePresent := newChecks[previousCheckType]
+		if !checkTypePresent {
+			return true
+		}
+		if previouscheckResult.State != newCheckResult.State {
+			return true
+		}
+	}
+	return false
+}

--- a/status/logging_change_handler_test.go
+++ b/status/logging_change_handler_test.go
@@ -92,19 +92,6 @@ func TestLoggingChangeHandler(t *testing.T) {
 				msg:   "Health checks content changed without status change.",
 			},
 		},
-		{
-			name: "no log when checks and code do not change",
-			prev: health.HealthStatus{
-				Checks: map[health.CheckType]health.HealthCheckResult{
-					"TEST": whealth.HealthyHealthCheckResult("TEST"),
-				},
-			},
-			curr: health.HealthStatus{
-				Checks: map[health.CheckType]health.HealthCheckResult{
-					"TEST": whealth.HealthyHealthCheckResult("TEST"),
-				},
-			},
-		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			var buf bytes.Buffer

--- a/status/logging_change_handler_test.go
+++ b/status/logging_change_handler_test.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+	whealth "github.com/palantir/witchcraft-go-server/status/health"
+	"github.com/stretchr/testify/assert"
+)
+
+type expectedLog struct {
+	level, msg string
+}
+
+func (l *expectedLog) matches(logOutput string) bool {
+	return strings.Contains(logOutput, l.level) && strings.Contains(logOutput, l.msg)
+}
+
+func TestLoggingChangeHandler(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		prev, curr health.HealthStatus
+		expected   *expectedLog
+	}{
+		{
+			name: "log error when new status code is greater than 200",
+			prev: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.HealthyHealthCheckResult("TEST"),
+				},
+			},
+			curr: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.UnhealthyHealthCheckResult("TEST", "message"),
+				},
+			},
+			expected: &expectedLog{
+				level: "ERROR",
+				msg:   "Health status code changed.",
+			},
+		},
+		{
+			name: "log info when new status code is 200",
+			prev: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.UnhealthyHealthCheckResult("TEST", "message"),
+				},
+			},
+			curr: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.HealthyHealthCheckResult("TEST"),
+				},
+			},
+			expected: &expectedLog{
+				level: "INFO",
+				msg:   "Health status code changed.",
+			},
+		},
+		{
+			name: "log when checks differ",
+			prev: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.HealthyHealthCheckResult("TEST"),
+				},
+			},
+			curr: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST_2": whealth.HealthyHealthCheckResult("TEST_2"),
+				},
+			},
+			expected: &expectedLog{
+				level: "INFO",
+				msg:   "Health checks content changed without status change.",
+			},
+		},
+		{
+			name: "no log when checks and code do not change",
+			prev: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.HealthyHealthCheckResult("TEST"),
+				},
+			},
+			curr: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": whealth.HealthyHealthCheckResult("TEST"),
+				},
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			ctx := svc1log.WithLogger(context.Background(), svc1log.New(&buf, wlog.DebugLevel))
+			loggingHealthStatusChangeHandler().HandleHealthStatusChange(ctx, testCase.prev, testCase.curr)
+			if testCase.expected == nil {
+				assert.Empty(t, buf.String())
+			} else {
+				assert.True(t, testCase.expected.matches(buf.String()))
+			}
+		})
+	}
+}
+
+func init() {
+	wlog.SetDefaultLoggerProvider(wlog.NewJSONMarshalLoggerProvider())
+}

--- a/status/multi_change_handler.go
+++ b/status/multi_change_handler.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+
+	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
+)
+
+func multiHealthStatusChangeHandler(healthStatusChangeHandlers []HealthStatusChangeHandler) HealthStatusChangeHandler {
+	return healthStatusChangeHandlerFn(func(ctx context.Context, prev, curr health.HealthStatus) {
+		for _, handler := range healthStatusChangeHandlers {
+			handler.HandleHealthStatusChange(ctx, prev, curr)
+		}
+	})
+}

--- a/status/routes/routes.go
+++ b/status/routes/routes.go
@@ -31,8 +31,8 @@ func AddReadinessRoutes(resource wresource.Resource, source status.Source) error
 	return resource.Get("readiness", status.ReadinessEndpoint, handler(source))
 }
 
-func AddHealthRoutes(resource wresource.Resource, source status.HealthCheckSource, sharedSecret refreshable.String) error {
-	return resource.Get("health", status.HealthEndpoint, status.NewHealthCheckHandler(source, sharedSecret))
+func AddHealthRoutes(resource wresource.Resource, source status.HealthCheckSource, sharedSecret refreshable.String, healthStatusChangeHandlers []status.HealthStatusChangeHandler) error {
+	return resource.Get("health", status.HealthEndpoint, status.NewHealthCheckHandler(source, sharedSecret, healthStatusChangeHandlers))
 }
 
 // handler returns an HTTP handler that writes a response based on the provided source. The status code of the response

--- a/status/routes/routes_test.go
+++ b/status/routes/routes_test.go
@@ -201,7 +201,7 @@ func TestAddHealthRoute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			r := wrouter.New(whttprouter.New())
 			resource := wresource.New("test", r)
-			err := AddHealthRoutes(resource, healthCheck{value: test.metadata}, refreshable.NewString(refreshable.NewDefaultRefreshable(test.sharedSecret)))
+			err := AddHealthRoutes(resource, healthCheck{value: test.metadata}, refreshable.NewString(refreshable.NewDefaultRefreshable(test.sharedSecret)), nil)
 			require.NoError(t, err)
 
 			server := httptest.NewServer(r)

--- a/status/status.go
+++ b/status/status.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
-	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-server/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-server/witchcraft/refreshable"
 )
@@ -34,11 +33,6 @@ var HealthStateStatusCodes = map[health.HealthState]int{
 	health.HealthStateWarning:   521,
 	health.HealthStateError:     522,
 	health.HealthStateTerminal:  523,
-}
-
-type healthStatusWithCode struct {
-	statusCode int
-	checks     map[health.CheckType]health.HealthCheckResult
 }
 
 // Source provides status that should be sent as a response.
@@ -77,38 +71,37 @@ func (c *combinedHealthCheckSource) HealthStatus(ctx context.Context) health.Hea
 // HealthHandler is responsible for checking the health-check-shared-secret if it is provided and
 // invoking a HealthCheckSource if the secret is correct or unset.
 type healthHandlerImpl struct {
-	healthCheckSharedSecret refreshable.String
-	check                   HealthCheckSource
-	previousHealth          *atomic.Value
+	healthCheckSharedSecret   refreshable.String
+	check                     HealthCheckSource
+	previousHealth            *atomic.Value
+	healthStatusChangeHandler HealthStatusChangeHandler
 }
 
-func NewHealthCheckHandler(checkSource HealthCheckSource, sharedSecret refreshable.String) http.Handler {
+func NewHealthCheckHandler(checkSource HealthCheckSource, sharedSecret refreshable.String, healthStatusChangeHandlers []HealthStatusChangeHandler) http.Handler {
 	previousHealth := &atomic.Value{}
-	previousHealth.Store(&healthStatusWithCode{
-		statusCode: 0,
-		checks:     map[health.CheckType]health.HealthCheckResult{},
-	})
+	previousHealth.Store(health.HealthStatus{})
+	allHandlers := []HealthStatusChangeHandler{loggingHealthStatusChangeHandler()}
+	if len(healthStatusChangeHandlers) > 0 {
+		allHandlers = append(allHandlers, healthStatusChangeHandlers...)
+	}
 	return &healthHandlerImpl{
-		healthCheckSharedSecret: sharedSecret,
-		check:                   checkSource,
-		previousHealth:          previousHealth,
+		healthCheckSharedSecret:   sharedSecret,
+		check:                     checkSource,
+		previousHealth:            previousHealth,
+		healthStatusChangeHandler: multiHealthStatusChangeHandler(allHandlers),
 	}
 }
 
 func (h *healthHandlerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	metadata, newHealthStatusCode := h.computeNewHealthStatus(req)
-	newHealth := &healthStatusWithCode{
-		statusCode: newHealthStatusCode,
-		checks:     metadata.Checks,
-	}
 	previousHealth := h.previousHealth.Load()
 	if previousHealth != nil {
-		if previousHealthTyped, ok := previousHealth.(*healthStatusWithCode); ok {
-			logIfHealthChanged(req.Context(), previousHealthTyped, newHealth)
+		if previousHealthTyped, ok := previousHealth.(health.HealthStatus); ok {
+			logIfHealthChanged(req.Context(), previousHealthTyped, metadata)
 		}
 	}
 
-	h.previousHealth.Store(newHealth)
+	h.previousHealth.Store(metadata)
 
 	httpserver.WriteJSONResponse(w, metadata, newHealthStatusCode)
 }
@@ -121,10 +114,10 @@ func (h *healthHandlerImpl) computeNewHealthStatus(req *http.Request) (health.He
 		}
 	}
 	metadata := h.check.HealthStatus(req.Context())
-	return metadata, healthStatusCode(metadata)
+	return metadata, HealthStatusCode(metadata)
 }
 
-func healthStatusCode(metadata health.HealthStatus) int {
+func HealthStatusCode(metadata health.HealthStatus) int {
 	worst := http.StatusOK
 	for _, result := range metadata.Checks {
 		code := HealthStateStatusCodes[result.State]
@@ -133,41 +126,4 @@ func healthStatusCode(metadata health.HealthStatus) int {
 		}
 	}
 	return worst
-}
-
-func logIfHealthChanged(ctx context.Context, previousHealth, newHealth *healthStatusWithCode) {
-	if previousHealth.statusCode != newHealth.statusCode {
-		params := map[string]interface{}{
-			"previousHealthStatusCode": previousHealth.statusCode,
-			"newHealthStatusCode":      newHealth.statusCode,
-			"newHealthStatus":          newHealth.checks,
-		}
-		if newHealth.statusCode == http.StatusOK {
-			svc1log.FromContext(ctx).Info("Health status code changed.", svc1log.SafeParams(params))
-		} else {
-			svc1log.FromContext(ctx).Error("Health status code changed.", svc1log.SafeParams(params))
-		}
-		return
-	} else if checksDiffer(previousHealth.checks, newHealth.checks) {
-		svc1log.FromContext(ctx).Info("Health checks content changed without status change.", svc1log.SafeParams(map[string]interface{}{
-			"statusCode":      newHealth.statusCode,
-			"newHealthStatus": newHealth.checks,
-		}))
-	}
-}
-
-func checksDiffer(previousChecks, newChecks map[health.CheckType]health.HealthCheckResult) bool {
-	if len(previousChecks) != len(newChecks) {
-		return true
-	}
-	for previousCheckType, previouscheckResult := range previousChecks {
-		newCheckResult, checkTypePresent := newChecks[previousCheckType]
-		if !checkTypePresent {
-			return true
-		}
-		if previouscheckResult.State != newCheckResult.State {
-			return true
-		}
-	}
-	return false
 }

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -54,7 +54,7 @@ func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg 
 	// add health endpoints
 	if err := routes.AddHealthRoutes(statusResource, status.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager, configHealthCheckSource)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
 		return in.(config.Runtime).HealthChecks.SharedSecret
-	}))); err != nil {
+	})), s.healthStatusChangeHandlers); err != nil {
 		return werror.Wrap(err, "failed to register health routes")
 	}
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -497,6 +497,8 @@ func (s *Server) WithLoggerStdoutWriter(loggerStdoutWriter io.Writer) *Server {
 	return s
 }
 
+// WithHealthStatusChangeHandlers configures the health status change handlers that are called whenever the configured HealthCheckSource
+// returns a health status with differing check states.
 func (s *Server) WithHealthStatusChangeHandlers(handlers ...status.HealthStatusChangeHandler) *Server {
 	s.healthStatusChangeHandlers = append(s.healthStatusChangeHandlers, handlers...)
 	return s

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -110,6 +110,9 @@ type Server struct {
 	// specifies the sources that are used to determine the health of this service
 	healthCheckSources []status.HealthCheckSource
 
+	// specifies the handlers to invoke upon health status changes. The LoggingHealthStatusChangeHandler is added by default.
+	healthStatusChangeHandlers []status.HealthStatusChangeHandler
+
 	// provides the RouterImpl used by the server (and management server if it is separate). If nil, a default function
 	// that returns a new whttprouter is used.
 	routerImplProvider func() wrouter.RouterImpl
@@ -491,6 +494,11 @@ func (s *Server) WithMetricTypeValuesBlacklist(blacklist map[string]map[string]s
 // in-memory buffer rather than Stdout for tests).
 func (s *Server) WithLoggerStdoutWriter(loggerStdoutWriter io.Writer) *Server {
 	s.loggerStdoutWriter = loggerStdoutWriter
+	return s
+}
+
+func (s *Server) WithHealthStatusChangeHandlers(handlers ...status.HealthStatusChangeHandler) *Server {
+	s.healthStatusChangeHandlers = append(s.healthStatusChangeHandlers, handlers...)
 	return s
 }
 


### PR DESCRIPTION
Enable HealthStatusChangeHandler registration.

## Before this PR
Before this PR, we did not expose any ability for custom handling of changes to health status.

## After this PR
Enable registration of HealthStatusChangeHandlers for witchcraft servers. This enables the future addition of a diagnostic logging health status change handler as described [here](https://github.com/palantir/witchcraft-go-server/issues/194).
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/195)
<!-- Reviewable:end -->
