### PR TITLE
Improvement: Expand the logToStdoutBasedOnEnv to take into account environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ traffic itself is still encrypted.
 `witchcraft-server` is configured with service, event, metric, request and trace loggers from the 
 `witchcraft-go-logging` project and emits structured JSON logs using [`zap`](https://github.com/uber-go/zap) as the
 logger implementation. The default behavior emits logs to the `var/log` directory (`var/log/service.log`, 
-`var/log/request.log`, etc.) unless the server is run in a Docker container, in which case the logs are always emitted 
+`var/log/request.log`, etc.) unless the server is run in a Docker container or a container that has an environment variable called `$CONTAINER` set, in which case the logs are always emitted
 to `stdout`. The `use-console-log` property in the install configuration can also be set to "true" to always output logs 
 to `stdout`. The runtime configuration supports configuring the log output level for service logs.
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ traffic itself is still encrypted.
 `witchcraft-server` is configured with service, event, metric, request and trace loggers from the 
 `witchcraft-go-logging` project and emits structured JSON logs using [`zap`](https://github.com/uber-go/zap) as the
 logger implementation. The default behavior emits logs to the `var/log` directory (`var/log/service.log`, 
-`var/log/request.log`, etc.) unless the server is run in a Docker container or a container that has an environment variable called `$CONTAINER` set, in which case the logs are always emitted
-to `stdout`. The `use-console-log` property in the install configuration can also be set to "true" to always output logs 
+`var/log/request.log`, etc.) unless the server is run in a Docker container or has the environment variable `$CONTAINER` set, in which case the logs are always emitted to `stdout`. The `use-console-log` property in the install configuration can also be set to "true" to always output logs 
 to `stdout`. The runtime configuration supports configuring the log output level for service logs.
 
 The `context.Context` provided to request handlers is configured with all of the standard loggers (service logger, event

--- a/changelog/@unreleased/pr-205.v2.yml
+++ b/changelog/@unreleased/pr-205.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expand the logToStdoutBasedOnEnv to take into account environment variables
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/205

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	defaultLogOutputFormat = "var/log/%s.log"
+	containerEnvVariable   = "CONTAINER"
 )
 
 // initLoggers initializes the Server loggers with instrumented loggers that record metrics in the given registry.
@@ -98,7 +99,16 @@ func newDefaultLogOutputWriter(slsFilename string, logToStdout bool, stdoutWrite
 
 // logToStdoutBasedOnEnv returns true if the runtime environment is a non-jail Docker container, false otherwise.
 func logToStdoutBasedOnEnv() bool {
-	return isDocker() && !isJail()
+	return isContainer() && !isJail()
+}
+
+func isContainer() bool {
+	return isDocker() || isContainerByEnvVar()
+}
+
+func isContainerByEnvVar() bool {
+	_, present := os.LookupEnv(containerEnvVariable)
+	return present
 }
 
 func isDocker() bool {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
- logToStdoutBasedOnEnv would look at a file on disk called `"/.dockerenv"` to determine it if was in a container
- This will not work for container runtimes other than docker
- Add an additional configuration point to opt into this based on an env var

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
- If the environment variable called `CONTAINER` is present and the logger is not explicitly configured, logToStdoutBasedOnEnv will now return true
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/205)
<!-- Reviewable:end -->
