### PR TITLE
Improvement: add timed keyed health source

### DIFF
--- a/changelog/@unreleased/pr-210.v2.yml
+++ b/changelog/@unreleased/pr-210.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: |
+    Add timed keyed health source
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/210

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2020 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -12,18 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package window
 
 import (

--- a/status/health/window/error_source.go
+++ b/status/health/window/error_source.go
@@ -1,5 +1,3 @@
-// Copyright (c) 2019 Palantir Technologies. All rights reserved.
-//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -172,8 +172,6 @@ func newMultiKeyHealthyIfNoRecentErrorsSource(checkType health.CheckType, messag
 	}, nil
 }
 
-///////////////// Remove Before Review Joe ////////////////////
-
 // multiKeyHealthyIfNotAllErrorsSource is a HealthCheckSource that keeps the latest errors
 // for multiple keys submitted within the last windowSize time frame.
 // It returns unhealthy if there is at least one key with only non-nil errors within the last windowSize time frame.

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -119,6 +119,10 @@ func NewMultiKeyHealthyIfNoRecentErrorsSource(checkType health.CheckType, messag
 }
 
 func newMultiKeyHealthyIfNoRecentErrorsSource(checkType health.CheckType, messageInCaseOfError string, windowSize time.Duration, timeProvider TimeProvider) (KeyedErrorHealthCheckSource, error) {
+	if windowSize <= 0 {
+		return nil, werror.Error("windowSize must be positive", werror.SafeParam("windowSize", windowSize.String()))
+	}
+
 	return &multiKeyHealthyIfNoRecentErrorsSource{
 		windowSize:           windowSize,
 		errorStore:           NewTimedKeyStore(timeProvider),

--- a/status/health/window/key_error_source.go
+++ b/status/health/window/key_error_source.go
@@ -16,7 +16,6 @@ package window
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -112,12 +111,9 @@ func (m *multiKeyHealthyIfNoRecentErrorsSource) HealthStatus(ctx context.Context
 	m.sourceMutex.Lock()
 	defer m.sourceMutex.Unlock()
 
-	var healthCheckResult health.HealthCheckResult
-
-	fmt.Println(m.errorStore.Oldest())
 	pruneOldKeys(m.errorStore, m.windowSize, m.timeProvider)
-	fmt.Println(m.errorStore.Oldest())
 
+	var healthCheckResult health.HealthCheckResult
 	params := make(map[string]interface{})
 	for _, item := range m.errorStore.List() {
 		// nil error is not error

--- a/status/health/window/key_error_source_test.go
+++ b/status/health/window/key_error_source_test.go
@@ -544,3 +544,125 @@ func TestAnchoredMultiKeyHealthyIfNotAllErrorsSource_GapThenRepairingThenError(t
 		},
 	}, source.HealthStatus(ctx))
 }
+
+func TestMultiKeyUnhealthyIfNoRecentErrorsSource(t *testing.T) {
+	messageInCaseOfError := "message in case of error"
+	for _, testCase := range []struct {
+		name          string
+		keyErrorPairs []keyErrorPair
+		expectedCheck health.HealthCheckResult
+		timeProvider  TimeProvider
+	}{
+		{
+			name:          "healthy when there are no items",
+			keyErrorPairs: nil,
+			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
+			timeProvider:  NewOrdinaryTimeProvider(),
+		},
+		{
+			name: "healthy when all keys are completely healthy",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1"},
+				{key: "1"},
+				{key: "2"},
+				{key: "3"},
+			},
+			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
+			timeProvider:  NewOrdinaryTimeProvider(),
+		},
+		{
+			name: "unhealthy when some keys are unhealthy",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1"},
+				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "1"},
+				{key: "2", err: werror.Error("Error #1 for key 2")},
+				{key: "3"},
+			},
+			expectedCheck: health.HealthCheckResult{
+				Type:    testCheckType,
+				State:   health.HealthStateError,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"2": "Error #1 for key 2",
+				},
+			},
+			timeProvider: NewOrdinaryTimeProvider(),
+		},
+		{
+			name: "healthy when outside window",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1", err: werror.Error("Error #1 for key 1")},
+			},
+			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
+			timeProvider: &sliceTimeProvider{[]time.Time{
+				time.Now().Add(-1 * time.Hour),
+				time.Now().Add(-1 * time.Hour),
+			}},
+		},
+		{
+			name: "unhealthy when inside window",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "1", err: werror.Error("Error #2 for key 1")},
+			},
+			expectedCheck: health.HealthCheckResult{
+				Type:    testCheckType,
+				State:   health.HealthStateError,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "Error #2 for key 1",
+				},
+			},
+			timeProvider: &sliceTimeProvider{[]time.Time{time.Now().Add(-1 * time.Hour), time.Now(), time.Now()}},
+		},
+		{
+			name: "healthy when last keys are healthy",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1"},
+				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "1"},
+				{key: "2", err: werror.Error("Error #1 for key 2")},
+				{key: "2"},
+				{key: "3"},
+			},
+			expectedCheck: whealth.HealthyHealthCheckResult(testCheckType),
+			timeProvider:  NewOrdinaryTimeProvider(),
+		},
+		{
+			name: "unhealthy when all keys are completely unhealthy",
+			keyErrorPairs: []keyErrorPair{
+				{key: "1", err: werror.Error("Error #1 for key 1")},
+				{key: "2", err: werror.Error("Error #1 for key 2")},
+				{key: "2", err: werror.Error("Error #2 for key 2")},
+				{key: "3", err: werror.Error("Error #1 for key 3")},
+			},
+			expectedCheck: health.HealthCheckResult{
+				Type:    testCheckType,
+				State:   health.HealthStateError,
+				Message: &messageInCaseOfError,
+				Params: map[string]interface{}{
+					"1": "Error #1 for key 1",
+					"2": "Error #2 for key 2",
+					"3": "Error #1 for key 3",
+				},
+			},
+			timeProvider: NewOrdinaryTimeProvider(),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			source, err := newMultiKeyHealthyIfNoRecentErrorsSource(testCheckType, messageInCaseOfError, time.Minute, testCase.timeProvider)
+			require.NoError(t, err)
+			for _, keyErrorPair := range testCase.keyErrorPairs {
+				source.Submit(keyErrorPair.key, keyErrorPair.err)
+			}
+			expectedStatus := health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					testCheckType: testCase.expectedCheck,
+				},
+			}
+			actualStatus := source.HealthStatus(context.Background())
+			assert.Equal(t, expectedStatus, actualStatus)
+		})
+	}
+}

--- a/status/health/window/time_provider.go
+++ b/status/health/window/time_provider.go
@@ -46,16 +46,3 @@ func (o *offsetTimeProvider) Now() time.Time {
 func (o *offsetTimeProvider) RestlessSleep(duration time.Duration) {
 	o.offset = time.Duration(o.offset.Nanoseconds() + duration.Nanoseconds())
 }
-
-type sliceTimeProvider struct {
-	times []time.Time
-}
-
-func (f *sliceTimeProvider) Now() time.Time {
-	if len(f.times) == 0 {
-		return time.Now()
-	}
-	val := f.times[0]
-	f.times = f.times[1:]
-	return val
-}

--- a/status/health/window/time_provider.go
+++ b/status/health/window/time_provider.go
@@ -46,3 +46,16 @@ func (o *offsetTimeProvider) Now() time.Time {
 func (o *offsetTimeProvider) RestlessSleep(duration time.Duration) {
 	o.offset = time.Duration(o.offset.Nanoseconds() + duration.Nanoseconds())
 }
+
+type sliceTimeProvider struct {
+	times []time.Time
+}
+
+func (f *sliceTimeProvider) Now() time.Time {
+	if len(f.times) == 0 {
+		return time.Now()
+	}
+	val := f.times[0]
+	f.times = f.times[1:]
+	return val
+}


### PR DESCRIPTION
## Before this PR
There is no easy way to have a health check that will only remain unhealthy for X amount of time or unless a new non-nil error is submitted to renew the timer. The key can also be cleared to healthy if a nil error is submitted.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
MultiKeyHealthyIfNoRecentErrorsSource fulfills the above. More information on use case here: https://palantir.quip.com/UMGBAi1IhwRH
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Adds another health source that could confuse people when trying to pick one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/210)
<!-- Reviewable:end -->
