### PR TITLE
Fix: Request logging defaults to status of 200 when not explicitly set

### DIFF
--- a/changelog/@unreleased/pr-212.v2.yml
+++ b/changelog/@unreleased/pr-212.v2.yml
@@ -1,0 +1,8 @@
+type: fix
+fix:
+  description: |
+    Request logging defaults to status of 200 when not explicitly set.
+    This ensures that the request logging middleware's behavior matches
+    that of the go std library and the observed response code from the server.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/212

--- a/witchcraft/internal/negroni/response_writer.go
+++ b/witchcraft/internal/negroni/response_writer.go
@@ -64,6 +64,11 @@ func (rw *responseWriter) Write(b []byte) (int, error) {
 }
 
 func (rw *responseWriter) Status() int {
+	if rw.status == 0 {
+		// This matches the behavior of the go std library response writer, which will default to
+		// http.StatusOK when not set by calling either Write or WriteHeader
+		return http.StatusOK
+	}
 	return rw.status
 }
 

--- a/witchcraft/internal/negroni/response_writer_test.go
+++ b/witchcraft/internal/negroni/response_writer_test.go
@@ -50,7 +50,7 @@ func TestResponseWriterBeforeWrite(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)
 
-	expect(t, rw.Status(), 0)
+	expect(t, rw.Status(), 200) // Defaults to 200 when not set
 	expect(t, rw.Written(), false)
 }
 


### PR DESCRIPTION

## Before this PR
When an endpoint returns an empty response (which the go std library defaults to adding a status of 200), the request log middleware incorrectly logs this as `"status":0` since there is no explicit status set.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->

==COMMIT_MSG==
Request logging defaults to status of 200 when not explicitly set. This ensures that the request logging middleware's behavior matches that of the go std library and the observed response code from the server.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/212)
<!-- Reviewable:end -->
