### PR TITLE
Rename debug.shared-secret to diagnostics.debug-shared-secret

### DIFF
--- a/changelog/@unreleased/pr-234.v2.yml
+++ b/changelog/@unreleased/pr-234.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Rename `debug.shared-secret` (introduced in 2.2.0) to `diagnostics.debug-shared-secret`
+    in runtime configuration.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/234

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -23,13 +23,13 @@ import (
 // Runtime specifies the base runtime configuration fields that should be included in all witchcraft-server-go
 // server runtime configurations.
 type Runtime struct {
-	DebugConfig  DebugConfig        `yaml:"debug,omitempty"`
-	HealthChecks HealthChecksConfig `yaml:"health-checks,omitempty"`
-	LoggerConfig *LoggerConfig      `yaml:"logging,omitempty"`
+	DiagnosticsConfig DiagnosticsConfig  `yaml:"debug,omitempty"`
+	HealthChecks      HealthChecksConfig `yaml:"health-checks,omitempty"`
+	LoggerConfig      *LoggerConfig      `yaml:"logging,omitempty"`
 }
 
-type DebugConfig struct {
-	SharedSecret string `yaml:"shared-secret"`
+type DiagnosticsConfig struct {
+	DebugSharedSecret string `yaml:"debug-shared-secret"`
 }
 
 type HealthChecksConfig struct {

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -23,7 +23,7 @@ import (
 // Runtime specifies the base runtime configuration fields that should be included in all witchcraft-server-go
 // server runtime configurations.
 type Runtime struct {
-	DiagnosticsConfig DiagnosticsConfig  `yaml:"debug,omitempty"`
+	DiagnosticsConfig DiagnosticsConfig  `yaml:"diagnostics,omitempty"`
 	HealthChecks      HealthChecksConfig `yaml:"health-checks,omitempty"`
 	LoggerConfig      *LoggerConfig      `yaml:"logging,omitempty"`
 }

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -50,7 +50,7 @@ func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg 
 		return werror.Wrap(err, "failed to register debugging routes")
 	}
 	if err := wdebug.RegisterRoute(mgmtRouterWithContextPath, refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
-		return in.(config.Runtime).DebugConfig.SharedSecret
+		return in.(config.Runtime).DiagnosticsConfig.DebugSharedSecret
 	}))); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a change to the config introduced in #216 to match the internal java implementation's config location.

This is obviously a breaking change, but we are tracking the 1 deployed product depending on this config (at pal) and I will just handle the upgrade. I think eating that one-time cost is worth it to get consistency with witchcraft-java wherever we can.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/234)
<!-- Reviewable:end -->
