### PR TITLE
Add service discovery configuration

### DIFF
--- a/changelog/@unreleased/pr-252.v2.yml
+++ b/changelog/@unreleased/pr-252.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: |-
+    Add service discovery configuration for generating clients
+
+    Services can now declare all dependent client configurations in a single location and share common settings across all clients. Although the new service-discovery block is in the runtime configuration, it is not currently live-reloadable.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/252

--- a/changelog/@unreleased/pr-252.v2.yml
+++ b/changelog/@unreleased/pr-252.v2.yml
@@ -3,6 +3,6 @@ feature:
   description: |-
     Add service discovery configuration for generating clients
 
-    Services can now declare all dependent client configurations in a single location and share common settings across all clients. Although the new service-discovery block is in the runtime configuration, it is not currently live-reloadable.
+    Services can now declare all dependent client configurations in a single location and share common settings across all clients. Although the new service-discovery block is in the runtime configuration, it is not currently live-reloadable. The service-discovery block is not yet consumed from within witchcraft-go-server, but instead provides a means to standardize how and where clients are configured.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/252

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -17,15 +17,17 @@ package config
 import (
 	"strings"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient"
 	"github.com/palantir/witchcraft-go-logging/wlog"
 )
 
 // Runtime specifies the base runtime configuration fields that should be included in all witchcraft-server-go
 // server runtime configurations.
 type Runtime struct {
-	DiagnosticsConfig DiagnosticsConfig  `yaml:"diagnostics,omitempty"`
-	HealthChecks      HealthChecksConfig `yaml:"health-checks,omitempty"`
-	LoggerConfig      *LoggerConfig      `yaml:"logging,omitempty"`
+	DiagnosticsConfig DiagnosticsConfig         `yaml:"diagnostics,omitempty"`
+	HealthChecks      HealthChecksConfig        `yaml:"health-checks,omitempty"`
+	LoggerConfig      *LoggerConfig             `yaml:"logging,omitempty"`
+	ServiceDiscovery  httpclient.ServicesConfig `yaml:"service-discovery,omitempty"`
 }
 
 type DiagnosticsConfig struct {


### PR DESCRIPTION
## Before this PR
No standardized way to add service discovery information to runtime config.

## After this PR
==COMMIT_MSG==
Add service discovery configuration for generating clients

Services can now declare all dependent client configurations in a single location and share common settings across all clients. Although the new service-discovery block is in the runtime configuration, it is not currently live-reloadable. The service-discovery block is not yet consumed from within witchcraft-go-server, but instead provides a means to standardize how and where clients are configured.
==COMMIT_MSG==

## Possible downsides?
- The CGR services config block is currently **not** live-reloadable (albeit within runtime config)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/252)
<!-- Reviewable:end -->
