### PR TITLE
Collect all internal and user defined health check sources

### DIFF
--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -44,7 +44,7 @@ func (s *Server) initRouters(installCfg config.Install) (rRouter wrouter.Router,
 	return routerWithContextPath, mgmtRouterWithContextPath
 }
 
-func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg refreshableBaseRuntimeConfig, configHealthCheckSource healthstatus.HealthCheckSource) error {
+func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg refreshableBaseRuntimeConfig) error {
 	// add debugging endpoints to management router
 	if err := addPprofRoutes(mgmtRouterWithContextPath); err != nil {
 		return werror.Wrap(err, "failed to register debugging routes")
@@ -58,7 +58,7 @@ func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg 
 	statusResource := wresource.New("status", mgmtRouterWithContextPath)
 
 	// add health endpoints
-	if err := routes.AddHealthRoutes(statusResource, healthstatus.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager, configHealthCheckSource)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
+	if err := routes.AddHealthRoutes(statusResource, healthstatus.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager)...), refreshable.NewString(runtimeCfg.Map(func(in interface{}) interface{} {
 		return in.(config.Runtime).HealthChecks.SharedSecret
 	})), s.healthStatusChangeHandlers); err != nil {
 		return werror.Wrap(err, "failed to register health routes")

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -613,6 +613,7 @@ func (s *Server) Start() (rErr error) {
 	if err != nil {
 		return err
 	}
+	internalHealthCheckSources := []healthstatus.HealthCheckSource{configReloadHealthCheckSource}
 
 	// extract the TCP JSON receiver from the runtime config
 	servicesCfg := baseRefreshableRuntimeCfg.CurrentBaseRuntimeConfig().ServiceDiscovery
@@ -708,10 +709,12 @@ func (s *Server) Start() (rErr error) {
 		}
 	}
 
+	// add all internally defined health check sources to the user supplied ones after running the initFn.
+	s.healthCheckSources = append(s.healthCheckSources, internalHealthCheckSources...)
+
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any
-	// health/liveness/readiness configuration updated by initFn is applied. Includes the
-	// configReloadHealthCheckSource, which is always appended to s.healthCheckSources.
-	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg, configReloadHealthCheckSource); err != nil {
+	// health/liveness/readiness configuration updated by initFn is applied.
+	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Before this PR
There was special-case handling for the config HealthCheckSource, which made it difficult to add any additional health check sources.

## After this PR
==COMMIT_MSG==
Collect all internal and user-defined health check sources before adding the status routes
==COMMIT_MSG==

Now all internal health check sources (except for `s.stateManager` itself) will be added to the user-supplied health check sources. The motivation for this is because we are looking to add a new health check source for the TCPWriter, and it's not trivial to add currently. Once this is refactored we can just append to the `internalHealthCheckSources` and everything will "just work".

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/253)
<!-- Reviewable:end -->
