### PR TITLE
Add TCPWriter health check source

### DIFF
--- a/changelog/@unreleased/pr-254.v2.yml
+++ b/changelog/@unreleased/pr-254.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add TCPWriter health check source to monitor the TCP connection status
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/254

--- a/witchcraft/internal/tcpjson/tcp_logger.go
+++ b/witchcraft/internal/tcpjson/tcp_logger.go
@@ -52,7 +52,7 @@ type TCPWriter struct {
 
 	mu   sync.RWMutex // guards all fields below
 	conn net.Conn
-	// started will be set to true when the first connection has been established
+	// started is set to true when the first connection has been established
 	// and is used to ensure the initial health status is not in an ERROR state
 	started bool
 }
@@ -158,9 +158,9 @@ func (d *TCPWriter) Close() error {
 }
 
 // HealthStatus implements the status.HealthCheckSource interface for the TCPWriter.
-// An ERROR health status will be returned if attempts have been made to establish a connection but none
+// An ERROR health status is returned if attempts have been made to establish a connection but none
 // currently exist and the writer is not in the process of shutting down.
-// A HEALTHY health status will be returned otherwise, meaning there is an active TCP connection or
+// A HEALTHY health status is returned otherwise, meaning there is an active TCP connection or
 // the TCPWriter has not yet attempted to retrieve a connection.
 func (d *TCPWriter) HealthStatus(_ context.Context) health.HealthStatus {
 	d.mu.RLock()

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -635,6 +635,8 @@ func (s *Server) Start() (rErr error) {
 		defer func() {
 			_ = tcpWriter.Close()
 		}()
+		internalHealthCheckSources = append(internalHealthCheckSources, tcpWriter)
+
 		// re-initialize the loggers with the TCP writer and overwrite the context
 		s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel, metricsRegistry, tcpWriter)
 		ctx = s.withLoggers(ctx)


### PR DESCRIPTION
## Before this PR
No external health checks to monitor the status of TCP logging

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add TCPWriter health check source to monitor the TCP connection status
==COMMIT_MSG==

## Notes
This health check is a bit strange given it's entirely dependent on the amount of logging done by consumers. For example, if no logging is performed, then this will always be healthy even though there is no connection. Maybe it's better to use `Deferring` or `Repairing`? I am proxying the connection status by checking the cached `net.Conn` which should only ever be `nil` when no writes have taken place or a write failed. I am open to other ideas on how to monitor this and also the levels at which we report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/254)
<!-- Reviewable:end -->
