### PR TITLE
Only enable TCP logging if both log metadata and receiver are configured

### DIFF
--- a/changelog/@unreleased/pr-258.v2.yml
+++ b/changelog/@unreleased/pr-258.v2.yml
@@ -1,5 +1,8 @@
 type: improvement
 improvement:
-  description: Only enable TCP logging if both log metadata and receiver are configured
+  description: |-
+    Only enable TCP logging if both log metadata and receiver are configured
+
+    TCP logging will now only be enabled if both envelope metadata and the TCP reciever are properly configured. If the TCP receiver is configured without the envelope metadata then a warning log line will be produced to indicate a possible mis-configuration, but will otherwise proceed as normal. Some environments use hard-coded config, where it may be expected that the TCP receiver is configured, but the envelope metadata is not. Conversely, if the envelope metadata is configured and the TCP receiver is not, then the `TCP_LOGGER_CONNECTION_STATUS` health check will be set to a permanent warning state to indicate that TCP logging is disabled, since the reciever must be mis-configured.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/258

--- a/changelog/@unreleased/pr-258.v2.yml
+++ b/changelog/@unreleased/pr-258.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Only enable TCP logging if both log metadata and receiver are configured
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/258

--- a/witchcraft/internal/tcpjson/envelope.go
+++ b/witchcraft/internal/tcpjson/envelope.go
@@ -17,6 +17,8 @@ package tcpjson
 import (
 	"encoding/json"
 	"os"
+
+	werror "github.com/palantir/witchcraft-go-error"
 )
 
 type LogEnvelopeV1 struct {
@@ -39,18 +41,75 @@ type LogEnvelopeMetadata struct {
 	ProductVersion string `json:"productVersion"`
 }
 
-func GetEnvelopeMetadata() LogEnvelopeMetadata {
-	return LogEnvelopeMetadata{
-		Deployment:     os.Getenv("LOG_ENVELOPE_DEPLOYMENT_NAME"),
-		Environment:    os.Getenv("LOG_ENVELOPE_ENVIRONMENT_NAME"),
-		EnvironmentID:  os.Getenv("LOG_ENVELOPE_ENVIRONMENT"),
-		Host:           os.Getenv("LOG_ENVELOPE_HOST"),
-		NodeID:         os.Getenv("LOG_ENVELOPE_NODE_ID"),
-		Product:        os.Getenv("LOG_ENVELOPE_PRODUCT_NAME"),
-		ProductVersion: os.Getenv("LOG_ENVELOPE_PRODUCT_VERSION"),
-		Service:        os.Getenv("LOG_ENVELOPE_SERVICE_NAME"),
-		ServiceID:      os.Getenv("LOG_ENVELOPE_SERVICE_ID"),
-		Stack:          os.Getenv("LOG_ENVELOPE_STACK_NAME"),
-		StackID:        os.Getenv("LOG_ENVELOPE_STACK_ID"),
+const (
+	envVarDeployment     = "LOG_ENVELOPE_DEPLOYMENT_NAME"
+	envVarEnvironment    = "LOG_ENVELOPE_ENVIRONMENT_NAME"
+	envVarEnvironmentID  = "LOG_ENVELOPE_ENVIRONMENT_ID"
+	envVarHost           = "LOG_ENVELOPE_HOST"
+	envVarNodeID         = "LOG_ENVELOPE_NODE_ID"
+	envVarProduct        = "LOG_ENVELOPE_PRODUCT_NAME"
+	envVarProductVersion = "LOG_ENVELOPE_PRODUCT_VERSION"
+	envVarService        = "LOG_ENVELOPE_SERVICE_NAME"
+	envVarServiceID      = "LOG_ENVELOPE_SERVICE_ID"
+	envVarStack          = "LOG_ENVELOPE_STACK_NAME"
+	envVarStackID        = "LOG_ENVELOPE_STACK_ID"
+)
+
+// GetEnvelopeMetadata retrieves all log envelope environment variables
+// and returns the fully populated LogEnvelopeMetadata and a nil error.
+// If any expected environment variables are not found or empty, then an empty LogEnvelopeMetadata
+// will be returned along with an error that contains the missing environment variables.
+func GetEnvelopeMetadata() (LogEnvelopeMetadata, error) {
+	metadata := LogEnvelopeMetadata{
+		Deployment:     os.Getenv(envVarDeployment),
+		Environment:    os.Getenv(envVarEnvironment),
+		EnvironmentID:  os.Getenv(envVarEnvironmentID),
+		Host:           os.Getenv(envVarHost),
+		NodeID:         os.Getenv(envVarNodeID),
+		Product:        os.Getenv(envVarProduct),
+		ProductVersion: os.Getenv(envVarProductVersion),
+		Service:        os.Getenv(envVarService),
+		ServiceID:      os.Getenv(envVarServiceID),
+		Stack:          os.Getenv(envVarStack),
+		StackID:        os.Getenv(envVarStackID),
 	}
+	var missingEnvVars []string
+	if metadata.Deployment == "" {
+		missingEnvVars = append(missingEnvVars, envVarDeployment)
+	}
+	if metadata.Environment == "" {
+		missingEnvVars = append(missingEnvVars, envVarEnvironment)
+	}
+	if metadata.EnvironmentID == "" {
+		missingEnvVars = append(missingEnvVars, envVarEnvironmentID)
+	}
+	if metadata.Host == "" {
+		missingEnvVars = append(missingEnvVars, envVarHost)
+	}
+	if metadata.NodeID == "" {
+		missingEnvVars = append(missingEnvVars, envVarNodeID)
+	}
+	if metadata.Product == "" {
+		missingEnvVars = append(missingEnvVars, envVarProduct)
+	}
+	if metadata.ProductVersion == "" {
+		missingEnvVars = append(missingEnvVars, envVarProductVersion)
+	}
+	if metadata.Service == "" {
+		missingEnvVars = append(missingEnvVars, envVarService)
+	}
+	if metadata.ServiceID == "" {
+		missingEnvVars = append(missingEnvVars, envVarServiceID)
+	}
+	if metadata.Stack == "" {
+		missingEnvVars = append(missingEnvVars, envVarStack)
+	}
+	if metadata.StackID == "" {
+		missingEnvVars = append(missingEnvVars, envVarStackID)
+	}
+	if len(missingEnvVars) > 0 {
+		return LogEnvelopeMetadata{}, werror.Error("all log envelope environment variables are not set",
+			werror.SafeParam("missingEnvVars", missingEnvVars))
+	}
+	return metadata, nil
 }

--- a/witchcraft/internal/tcpjson/tcp_logger.go
+++ b/witchcraft/internal/tcpjson/tcp_logger.go
@@ -37,8 +37,8 @@ var (
 const (
 	errWriterClosed = "writer is closed"
 
-	// tcpWriterHealthCheckName is the name used for the external health check
-	tcpWriterHealthCheckName = "TCP_LOGGER_CONNECTION_STATUS"
+	// TCPWriterHealthCheckName is the name used for the external health check
+	TCPWriterHealthCheckName health.CheckType = "TCP_LOGGER_CONNECTION_STATUS"
 )
 
 // envelopeSerializerFunc provides a way to change the serialization method for the provided payload.
@@ -70,7 +70,7 @@ func newTCPWriterInternal(provider ConnProvider, serializerFunc envelopeSerializ
 		provider:           provider,
 		closedChan:         make(chan struct{}),
 		conn:               nil,
-		health:             window.MustNewErrorHealthCheckSource(tcpWriterHealthCheckName, window.HealthyIfNoRecentErrors),
+		health:             window.MustNewErrorHealthCheckSource(TCPWriterHealthCheckName, window.HealthyIfNoRecentErrors),
 	}
 }
 

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -173,7 +173,7 @@ func TestHealthStatus(t *testing.T) {
 			gotHealthState := tcpWriter.HealthStatus(context.Background())
 			assert.NotNil(t, gotHealthState)
 			assert.Len(t, gotHealthState.Checks, 1)
-			assert.Equal(t, tc.expected, gotHealthState.Checks[tcpWriterHealthCheckName].State.Value())
+			assert.Equal(t, tc.expected, gotHealthState.Checks[TCPWriterHealthCheckName].State.Value())
 		})
 	}
 }


### PR DESCRIPTION
## Before this PR
If the URIs for the log receiver were set then we would enable the TCP logging output. Some internal infrastructure does not allow service-discovery in configuration so the fields are hardcoded per environment, which makes it impossible to determine whether we enable or disable the TCP logger solely on the presence of the URIs.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Only enable TCP logging if both log metadata and receiver are configured
==COMMIT_MSG==

In order to enable the TCP logger both the log envelope metadata AND log receiver must be configured. 
There are a few cases that need to be handled based on the two fields:
1. metadata is not configured (or partially) and receiver is **NOT** configured.
	a. Noop and logging will continue as normal
2. metadata is not configured (or partially) and the receiver **IS** configured.
	a. We emit a WARN log line to be able to trace the fact that TCP logging is disabled
	b. This is the case of hardcoding receiver config
3. metadata is configured and receiver is **NOT** configured
	a. This is an unexpected state, since we want to guarantee that if env vars are set, then we should be TCP logging.
	b. We set the `TCP_LOGGER_CONNECTION_STATUS` to a permanent `WARN` state with info that it's not configured correctly.
4. both metadata and receiver are configured
	a. enable TCP logging as usual

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/258)
<!-- Reviewable:end -->
