### PR TITLE
Refactor RouteParam interface to use builder pattern

### DIFF
--- a/changelog/@unreleased/pr-259.v2.yml
+++ b/changelog/@unreleased/pr-259.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/259

--- a/changelog/@unreleased/pr-259.v2.yml
+++ b/changelog/@unreleased/pr-259.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation. 
+  description: Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/259

--- a/changelog/@unreleased/pr-259.v2.yml
+++ b/changelog/@unreleased/pr-259.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation.
+  description: Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation. 
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/259

--- a/wrouter/route_params.go
+++ b/wrouter/route_params.go
@@ -23,6 +23,21 @@ type routeParamBuilder struct {
 	metricTags metrics.Tags
 }
 
+func (b *routeParamBuilder) toRequestParamPerms() RouteParamPerms {
+	if b.paramPerms != nil {
+		return b.paramPerms
+	}
+	return &requestParamPermsImpl{}
+}
+
+func (b *routeParamBuilder) toMetricTags() metrics.Tags {
+	var tags metrics.Tags
+	if b.metricTags != nil {
+		tags = append(tags, b.metricTags...)
+	}
+	return tags
+}
+
 type RouteParam interface {
 	apply(*routeParamBuilder) error
 }
@@ -98,18 +113,4 @@ func MetricTags(tags metrics.Tags) RouteParam {
 		b.metricTags = tags
 		return nil
 	})
-}
-
-func toRequestParamPerms(b *routeParamBuilder) RouteParamPerms {
-	if b.paramPerms != nil {
-		return b.paramPerms
-	}
-	return &requestParamPermsImpl{}
-}
-
-func toMetricTags(b *routeParamBuilder) metrics.Tags {
-	if b.metricTags != nil {
-		return b.metricTags
-	}
-	return metrics.Tags{}
 }

--- a/wrouter/router_root.go
+++ b/wrouter/router_root.go
@@ -134,8 +134,8 @@ func (r *rootRouter) Register(method, path string, handler http.Handler, params 
 	r.routes = append(r.routes, routeSpec)
 	sort.Sort(routeSpecs(r.routes))
 
-	requestParamPerms := toRequestParamPerms(b)
-	metricTags := toMetricTags(b)
+	requestParamPerms := b.toRequestParamPerms()
+	metricTags := b.toMetricTags()
 
 	// wrap provided handler with a handler that registers the path parameter information in the context
 	r.impl.Register(method, pathTemplate.Segments(), http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
## Before this PR
Whenever adding a new field as a `RouteParam`, it required that all types satisfy an interface which returned a no-op except for the one method that was applicable for said field. 

## After this PR
We use a builder type to construct a RouteParam where all options are added to the routeParamBuilder by using an `apply()` method. 
==COMMIT_MSG==
Refactor RouteParam interface to use builder pattern. Now all RouteParam options are applied to an underlying routeParamBuilder at instantiation.
==COMMIT_MSG==

## Possible downsides?
None. All exported method signatures were kept consistent so that this will be a non-breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/259)
<!-- Reviewable:end -->
