### PR TITLE
Set the TCP logger connection health status to a WARNING state on errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/palantir/pkg/signals v1.0.1
 	github.com/palantir/pkg/tlsconfig v1.0.2
 	github.com/palantir/witchcraft-go-error v1.4.3
-	github.com/palantir/witchcraft-go-health v1.5.0
+	github.com/palantir/witchcraft-go-health v1.6.0
 	github.com/palantir/witchcraft-go-logging v1.9.0
 	github.com/palantir/witchcraft-go-params v1.2.0
 	github.com/palantir/witchcraft-go-tracing v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/palantir/witchcraft-go-error v1.2.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8Jf
 github.com/palantir/witchcraft-go-error v1.3.0/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
 github.com/palantir/witchcraft-go-error v1.4.3 h1:coynUoBOhfvd/vsH7gu2v4dlSO+hvlazHh6HMh/jF1U=
 github.com/palantir/witchcraft-go-error v1.4.3/go.mod h1:/cl2dMkuBbnfxDtFiC//8JfvZxmRkYRhgv3bBux9AD0=
-github.com/palantir/witchcraft-go-health v1.5.0 h1:lj0lhFA1UbqOIdENjXkRPs7IqRhxSu+38nGUbVtU1rA=
-github.com/palantir/witchcraft-go-health v1.5.0/go.mod h1:oOIMYzOgTJci1XwvmUTrxe4YAY1CmSprbeR6QdY+5w0=
+github.com/palantir/witchcraft-go-health v1.6.0 h1:djrK0RO5+7NhtCdkfH0i6V+fPC6+1bqruzaoei6+x3w=
+github.com/palantir/witchcraft-go-health v1.6.0/go.mod h1:oOIMYzOgTJci1XwvmUTrxe4YAY1CmSprbeR6QdY+5w0=
 github.com/palantir/witchcraft-go-logging v1.5.2/go.mod h1:x2wqelmEPV2sqOgxnYpx7em44I2nzWuovl7d7cMv+pM=
 github.com/palantir/witchcraft-go-logging v1.9.0 h1:YGsqh6T58F6vPTLii9tvvZTYO6rTb9uDmO4KrYxKvMU=
 github.com/palantir/witchcraft-go-logging v1.9.0/go.mod h1:6hkyOVxxkoSOVSsL+ZoBVQiFzRSFthlnn47xFOnm6+w=

--- a/vendor/github.com/palantir/witchcraft-go-health/sources/window/error_options.go
+++ b/vendor/github.com/palantir/witchcraft-go-health/sources/window/error_options.go
@@ -54,6 +54,7 @@ type errorSourceConfig struct {
 	requireFirstFullWindow bool
 	maxErrorAge            time.Duration
 	timeProvider           TimeProvider
+	healthState            health.HealthState_Value
 }
 
 func defaultErrorSourceConfig(checkType health.CheckType) errorSourceConfig {
@@ -65,6 +66,7 @@ func defaultErrorSourceConfig(checkType health.CheckType) errorSourceConfig {
 		requireFirstFullWindow: false,
 		maxErrorAge:            0,
 		timeProvider:           NewOrdinaryTimeProvider(),
+		healthState:            health.HealthState_ERROR,
 	}
 }
 
@@ -130,5 +132,15 @@ func WithMaximumErrorAge(maxErrorAge time.Duration) ErrorOption {
 func WithTimeProvider(timeProvider TimeProvider) ErrorOption {
 	return func(conf *errorSourceConfig) {
 		conf.timeProvider = timeProvider
+	}
+}
+
+// WithFailingHealthStateValue overrides the default health state value used when computing the health status in failure cases.
+// All options that reduce errors to a REPAIRING health state will continue to work as expected, as this option
+// strictly configures the base health state value before computing the full health status.
+// If not set, the default health state value will be an ERROR.
+func WithFailingHealthStateValue(healthState health.HealthState_Value) ErrorOption {
+	return func(conf *errorSourceConfig) {
+		conf.healthState = healthState
 	}
 }

--- a/vendor/github.com/palantir/witchcraft-go-health/sources/window/error_source.go
+++ b/vendor/github.com/palantir/witchcraft-go-health/sources/window/error_source.go
@@ -49,6 +49,7 @@ type errorHealthCheckSource struct {
 	repairingGracePeriod time.Duration
 	repairingDeadline    time.Time
 	maxErrorAge          time.Duration
+	healthState          health.HealthState_Value
 }
 
 // MustNewErrorHealthCheckSource creates a new ErrorHealthCheckSource which will panic if any error is encountered.
@@ -93,6 +94,7 @@ func NewErrorHealthCheckSource(checkType health.CheckType, errorMode ErrorMode, 
 		repairingGracePeriod: conf.repairingGracePeriod,
 		repairingDeadline:    conf.timeProvider.Now(),
 		maxErrorAge:          conf.maxErrorAge,
+		healthState:          conf.healthState,
 	}
 
 	// If requireFirstFullWindow, extend the repairing deadline to one windowSize from now.
@@ -165,7 +167,7 @@ func (e *errorHealthCheckSource) getFailureResult() health.HealthCheckResult {
 	}
 	healthCheckResult := health.HealthCheckResult{
 		Type:    e.checkType,
-		State:   health.New_HealthState(health.HealthState_ERROR),
+		State:   health.New_HealthState(e.healthState),
 		Message: &e.checkMessage,
 		Params:  params,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -57,7 +57,7 @@ github.com/palantir/pkg/uuid/internal/uuid
 # github.com/palantir/witchcraft-go-error v1.4.3
 github.com/palantir/witchcraft-go-error
 github.com/palantir/witchcraft-go-error/internal/errors
-# github.com/palantir/witchcraft-go-health v1.5.0
+# github.com/palantir/witchcraft-go-health v1.6.0
 github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health
 github.com/palantir/witchcraft-go-health/reporter
 github.com/palantir/witchcraft-go-health/sources

--- a/witchcraft/internal/tcpjson/tcp_logger.go
+++ b/witchcraft/internal/tcpjson/tcp_logger.go
@@ -70,7 +70,10 @@ func newTCPWriterInternal(provider ConnProvider, serializerFunc envelopeSerializ
 		provider:           provider,
 		closedChan:         make(chan struct{}),
 		conn:               nil,
-		health:             window.MustNewErrorHealthCheckSource(TCPWriterHealthCheckName, window.HealthyIfNoRecentErrors),
+		health: window.MustNewErrorHealthCheckSource(
+			TCPWriterHealthCheckName,
+			window.HealthyIfNoRecentErrors,
+			window.WithFailingHealthStateValue(health.HealthState_WARNING)),
 	}
 }
 

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -165,7 +165,7 @@ func TestHealthStatus(t *testing.T) {
 				assert.Error(t, err)
 				return w
 			},
-			expected: health.HealthState_ERROR,
+			expected: health.HealthState_WARNING,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Before this PR
An ERROR health state value was used which can cause product teams to get paged for transient issues connecting/writing to the TCP receiver. Given product teams have no control over the TCP receiver, we do not want them to be paged immediately unless the issue persists.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Sets the TCP logger connection health status to a WARNING state on errors
==COMMIT_MSG==

This PR also helps for a soft rollout and non-spurious pages where we can elevate to an ERROR health state down the road.

I opted for no changelog given the code is fully internal and we have not rolled this out broadly yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/260)
<!-- Reviewable:end -->
