### PR TITLE
Emit an error log instead of setting the TCPWriter health state to warning

### DIFF
--- a/changelog/@unreleased/pr-261.v2.yml
+++ b/changelog/@unreleased/pr-261.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Emit an error log instead of setting the TCPWriter health state to warning
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/261

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -36,7 +36,6 @@ import (
 	"github.com/palantir/pkg/signals"
 	"github.com/palantir/pkg/tlsconfig"
 	werror "github.com/palantir/witchcraft-go-error"
-	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	healthstatus "github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
 	"github.com/palantir/witchcraft-go-logging/wlog"
@@ -1032,25 +1031,3 @@ func traceSamplerFromSampleRate(sampleRate float64) wtracing.Sampler {
 func neverSample(id uint64) bool { return false }
 
 func alwaysSample(id uint64) bool { return true }
-
-type alwaysWarnHealthCheckSource struct {
-	healthStatus health.HealthStatus
-}
-
-func newAlwaysWarnHealthCheckSource(checkType health.CheckType, message string) healthstatus.HealthCheckSource {
-	return &alwaysWarnHealthCheckSource{
-		healthStatus: health.HealthStatus{
-			Checks: map[health.CheckType]health.HealthCheckResult{
-				checkType: {
-					Type:    checkType,
-					State:   health.New_HealthState(health.HealthState_WARNING),
-					Message: &message,
-				},
-			},
-		},
-	}
-}
-
-func (a *alwaysWarnHealthCheckSource) HealthStatus(_ context.Context) health.HealthStatus {
-	return a.healthStatus
-}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -630,12 +630,9 @@ func (s *Server) Start() (rErr error) {
 		// that TCP logging should not be enabled and thus it is safe to proceed without any warning logs.
 	} else if len(receiverCfg.URIs) == 0 {
 		// The existence of envelope metadata means TCP logging was expected to be enabled, but the TCP receiver must be mis-configured.
-		// Since the server may otherwise be functional, the TCP writer health check is set to a
-		// permanent warning state to indicate the logging issues.
-		internalHealthCheckSources = append(internalHealthCheckSources,
-			newAlwaysWarnHealthCheckSource(tcpjson.TCPWriterHealthCheckName,
-				"TCP logging is disabled. No TCP JSON receiver URIs are configured but log envelope metadata exists."),
-		)
+		// Since the server may otherwise be functional, an error log is emitted to indicate logging issues, rather
+		// than setting the TCP writer health to a state that can cause pages.
+		s.svcLogger.Error("TCP logging is disabled. No TCP JSON receiver URIs are configured but log envelope metadata exists.")
 	} else {
 		// enable TCP logging since the metadata and receiver are both configured
 		tlsConfig, err := tlsconfig.NewClientConfig(


### PR DESCRIPTION
## Before this PR
If the environment variables existed and the TCP receiver config did not, then the TCP writer health check would permanently be in a WARNING state, which would eventually page product teams after a period of time, since the service was unhealthy.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Emit an error log instead of setting the TCPWriter health state to warning
==COMMIT_MSG==

## Possible downsides?
- This is much harder to surface issues downstream. I am also open to the idea of just emitting a metric that could be monitored or setting the health to a state which would not cause pages?f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/261)
<!-- Reviewable:end -->
