### PR TITLE
feature: TCP writer uses a buffered channel to queue messages

### DIFF
--- a/changelog/@unreleased/pr-262.v2.yml
+++ b/changelog/@unreleased/pr-262.v2.yml
@@ -2,7 +2,5 @@ type: feature
 feature:
   description: |-
     TCP writer uses a buffered channel to queue messages
-
-    In the case that the TCP logger connection is slow or failing, we do not want to block the primary process from continuing. We may consider using this for the file based logger(s) as well, though disk IO speed has never been a problem.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/262

--- a/changelog/@unreleased/pr-262.v2.yml
+++ b/changelog/@unreleased/pr-262.v2.yml
@@ -1,6 +1,6 @@
 type: feature
 feature:
   description: |-
-    TCP writer uses a buffered channel to queue messages
+    TCP writer uses a buffered channel to queue messages. In the case that the TCP logger connection is slow or failing, we do not want to block the primary process from continuing.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/262

--- a/changelog/@unreleased/pr-262.v2.yml
+++ b/changelog/@unreleased/pr-262.v2.yml
@@ -1,0 +1,8 @@
+type: feature
+feature:
+  description: |-
+    TCP writer uses a buffered channel to queue messages
+
+    In the case that the TCP logger connection is slow or failing, we do not want to block the primary process from continuing. We may consider using this for the file based logger(s) as well, though disk IO speed has never been a problem.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/262

--- a/witchcraft/internal/tcpjson/async_writer.go
+++ b/witchcraft/internal/tcpjson/async_writer.go
@@ -1,0 +1,50 @@
+package tcpjson
+
+import (
+	"io"
+	"log"
+
+	"github.com/palantir/pkg/metrics"
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+const (
+	asyncWriterBufferCap = 1000
+	asyncWriterBufferLenGauge = "sls.logging.queued"
+)
+
+type asyncWriter struct {
+	buffer chan []byte
+	output io.Writer
+	stop chan struct{}
+}
+
+func StartAsyncWriter(output io.Writer, registry metrics.Registry) io.WriteCloser {
+	buffer := make(chan []byte, asyncWriterBufferCap)
+	stop := make(chan struct{})
+	go func() {
+		gauge := registry.Gauge(asyncWriterBufferLenGauge)
+		for {
+			select {
+			case item := <-buffer:
+				if _, err := output.Write(item); err != nil {
+					log.Printf("write failed: %s", werror.GenerateErrorString(err, false))
+				}
+				gauge.Update(int64(len(buffer)))
+			case <-stop:
+				return
+			}
+		}
+	}()
+	return &asyncWriter{buffer: buffer, output: output}
+}
+
+func (w *asyncWriter) Write(b []byte) (int, error) {
+	w.buffer <- b
+	return len(b), nil
+}
+
+func (w *asyncWriter) Close() (err error) {
+	close(w.stop)
+	return nil
+}

--- a/witchcraft/internal/tcpjson/async_writer.go
+++ b/witchcraft/internal/tcpjson/async_writer.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tcpjson
 
 import (
@@ -9,14 +23,14 @@ import (
 )
 
 const (
-	asyncWriterBufferCap = 1000
+	asyncWriterBufferCap      = 1000
 	asyncWriterBufferLenGauge = "sls.logging.queued"
 )
 
 type asyncWriter struct {
 	buffer chan []byte
 	output io.Writer
-	stop chan struct{}
+	stop   chan struct{}
 }
 
 func StartAsyncWriter(output io.Writer, registry metrics.Registry) io.WriteCloser {

--- a/witchcraft/internal/tcpjson/async_writer_test.go
+++ b/witchcraft/internal/tcpjson/async_writer_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/palantir/pkg/metrics"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAsyncWriter(t *testing.T) {
@@ -41,4 +42,10 @@ func TestAsyncWriter(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		assert.Contains(t, written, strconv.Itoa(i))
 	}
+
+	t.Run("fails when closed", func(t *testing.T) {
+		require.NoError(t, w.Close())
+		_, err := w.Write([]byte("will fail!"))
+		require.EqualError(t, err, "write to closed asyncWriter")
+	})
 }

--- a/witchcraft/internal/tcpjson/async_writer_test.go
+++ b/witchcraft/internal/tcpjson/async_writer_test.go
@@ -1,0 +1,30 @@
+package tcpjson
+
+import (
+	"bytes"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/palantir/pkg/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsyncWriter(t *testing.T) {
+	out := &bytes.Buffer{}
+	w := StartAsyncWriter(out, metrics.DefaultMetricsRegistry)
+	for i := 0; i < 5; i ++ {
+		str := strconv.Itoa(i)
+		go func() {
+			_, _ = w.Write([]byte(str))
+		}()
+	}
+	time.Sleep(time.Millisecond)
+
+	written := out.String()
+	t.Log(written)
+	assert.Len(t, written, 5)
+	for i := 0; i < 5; i ++ {
+		assert.Contains(t, written, strconv.Itoa(i))
+	}
+}

--- a/witchcraft/internal/tcpjson/async_writer_test.go
+++ b/witchcraft/internal/tcpjson/async_writer_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tcpjson
 
 import (
@@ -13,7 +27,7 @@ import (
 func TestAsyncWriter(t *testing.T) {
 	out := &bytes.Buffer{}
 	w := StartAsyncWriter(out, metrics.DefaultMetricsRegistry)
-	for i := 0; i < 5; i ++ {
+	for i := 0; i < 5; i++ {
 		str := strconv.Itoa(i)
 		go func() {
 			_, _ = w.Write([]byte(str))
@@ -24,7 +38,7 @@ func TestAsyncWriter(t *testing.T) {
 	written := out.String()
 	t.Log(written)
 	assert.Len(t, written, 5)
-	for i := 0; i < 5; i ++ {
+	for i := 0; i < 5; i++ {
 		assert.Contains(t, written, strconv.Itoa(i))
 	}
 }

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/metricloggers"
+	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/tcpjson"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -63,7 +64,8 @@ func (s *Server) initLoggers(useConsoleLog bool, logLevel wlog.LogLevel, registr
 	logWriterFn := func(slsFilename string) io.Writer {
 		internalWriter := newDefaultLogOutputWriter(slsFilename, useConsoleLog, loggerStdoutWriter)
 		if tcpWriter != nil {
-			internalWriter = io.MultiWriter(internalWriter, tcpWriter)
+			asyncTCPWriter := tcpjson.StartAsyncWriter(tcpWriter, registry)
+			internalWriter = io.MultiWriter(internalWriter, asyncTCPWriter)
 		}
 		return metricloggers.NewMetricWriter(internalWriter, registry, slsFilename)
 	}

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -30,7 +30,6 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/metricloggers"
-	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/tcpjson"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -64,8 +63,7 @@ func (s *Server) initLoggers(useConsoleLog bool, logLevel wlog.LogLevel, registr
 	logWriterFn := func(slsFilename string) io.Writer {
 		internalWriter := newDefaultLogOutputWriter(slsFilename, useConsoleLog, loggerStdoutWriter)
 		if tcpWriter != nil {
-			asyncTCPWriter := tcpjson.StartAsyncWriter(tcpWriter, registry)
-			internalWriter = io.MultiWriter(internalWriter, asyncTCPWriter)
+			internalWriter = io.MultiWriter(internalWriter, tcpWriter)
 		}
 		return metricloggers.NewMetricWriter(internalWriter, registry, slsFilename)
 	}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -646,13 +646,15 @@ func (s *Server) Start() (rErr error) {
 			return err
 		}
 		tcpWriter := tcpjson.NewTCPWriter(envelopeMetadata, connProvider)
+		asyncTCPWriter := tcpjson.StartAsyncWriter(tcpWriter, metricsRegistry)
 		defer func() {
+			_ = asyncTCPWriter.Close()
 			_ = tcpWriter.Close()
 		}()
 		internalHealthCheckSources = append(internalHealthCheckSources, tcpWriter)
 
 		// re-initialize the loggers with the TCP writer and overwrite the context
-		s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel, metricsRegistry, tcpWriter)
+		s.initLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel, metricsRegistry, asyncTCPWriter)
 		ctx = s.withLoggers(ctx)
 	}
 


### PR DESCRIPTION
In the case that the TCP logger connection is slow or failing, we do not want to block the primary process from continuing. We may consider using this for the file based logger(s) as well, though disk IO speed has never been a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/262)
<!-- Reviewable:end -->
