### PR TITLE
Fix async writer to no longer retain the provided byte slice

### DIFF
--- a/witchcraft/internal/tcpjson/async_writer.go
+++ b/witchcraft/internal/tcpjson/async_writer.go
@@ -63,7 +63,11 @@ func (w *asyncWriter) Write(b []byte) (int, error) {
 	case <-w.stop:
 		return 0, werror.Error("write to closed asyncWriter")
 	default:
-		w.buffer <- b
+		// copy the provided byte slice before pushing it into the buffer channel so the original
+		// byte slice is not retained and thus still compliant with the io.Writer contract
+		bb := make([]byte, len(b))
+		copy(bb, b)
+		w.buffer <- bb
 		return len(b), nil
 	}
 }

--- a/witchcraft/internal/tcpjson/async_writer_test.go
+++ b/witchcraft/internal/tcpjson/async_writer_test.go
@@ -16,11 +16,17 @@ package tcpjson
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/palantir/pkg/metrics"
+	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
+	"github.com/palantir/witchcraft-go-logging/wlog"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -48,4 +54,69 @@ func TestAsyncWriter(t *testing.T) {
 		_, err := w.Write([]byte("will fail!"))
 		require.EqualError(t, err, "write to closed asyncWriter")
 	})
+}
+
+// TestAsyncWriteWithSvc1log verifies the that svc1log lines are properly written to the output
+// when using the async writer. This also ensures the original input bytes are added to the buffered channel
+// correctly and the underlying byte slice is not stored directly which would cause the output to be malformed.
+func TestAsyncWriteWithSvc1log(t *testing.T) {
+	provider := &bufferedConnProvider{}
+	tcpWriter := NewTCPWriter(testMetadata, provider)
+	asyncTCPWriter := StartAsyncWriter(tcpWriter, metrics.DefaultMetricsRegistry)
+	defer func() {
+		_ = asyncTCPWriter.Close()
+	}()
+	logger := svc1log.NewFromCreator(asyncTCPWriter, wlog.DebugLevel, wlog.NewJSONMarshalLoggerProvider().NewLeveledLogger)
+
+	// Write log lines with deterministic messages to verify later
+	const totalLogLines = 100
+	for i := 0; i < totalLogLines; i++ {
+		logger.Debug(strconv.Itoa(i))
+	}
+
+	// Wait for write count to match the total log lines, otherwise fail the test after a timeout
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("Timed out waiting to receive all log lines")
+		default:
+		}
+		if atomic.LoadInt32(&provider.writeCount) == int32(totalLogLines) {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// verify all log lines are received and well formed
+	logLines := bytes.SplitN(provider.buffer.Bytes(), []byte("\n"), totalLogLines)
+	assert.Equal(t, totalLogLines, len(logLines))
+
+	for i, logLine := range logLines {
+		var gotEnvelope LogEnvelopeV1
+		err := json.Unmarshal(logLine, &gotEnvelope)
+		require.NoError(t, err)
+
+		// Verify all envelope metadata
+		assert.Equal(t, testMetadata.Type, gotEnvelope.Type)
+		assert.Equal(t, testMetadata.Deployment, gotEnvelope.Deployment)
+		assert.Equal(t, testMetadata.Environment, gotEnvelope.Environment)
+		assert.Equal(t, testMetadata.EnvironmentID, gotEnvelope.EnvironmentID)
+		assert.Equal(t, testMetadata.Host, gotEnvelope.Host)
+		assert.Equal(t, testMetadata.NodeID, gotEnvelope.NodeID)
+		assert.Equal(t, testMetadata.Product, gotEnvelope.Product)
+		assert.Equal(t, testMetadata.ProductVersion, gotEnvelope.ProductVersion)
+		assert.Equal(t, testMetadata.Service, gotEnvelope.Service)
+		assert.Equal(t, testMetadata.ServiceID, gotEnvelope.ServiceID)
+		assert.Equal(t, testMetadata.Stack, gotEnvelope.Stack)
+		assert.Equal(t, testMetadata.StackID, gotEnvelope.StackID)
+
+		// Verify the payload
+		gotPayload := new(logging.ServiceLogV1)
+		err = gotPayload.UnmarshalJSON(gotEnvelope.Payload)
+		require.NoError(t, err)
+		assert.Equal(t, strconv.Itoa(i), gotPayload.Message)
+		assert.Equal(t, logging.LogLevelDebug, gotPayload.Level)
+	}
 }

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sync/atomic"
 	"testing"
 
 	werror "github.com/palantir/witchcraft-go-error"
@@ -188,8 +189,9 @@ func getEnvelopeBytes(t *testing.T, payload []byte) []byte {
 // bytes buffer instead of to the net.Conn.
 type bufferedConnProvider struct {
 	net.Conn
-	err    error
-	buffer bytes.Buffer
+	err        error
+	buffer     bytes.Buffer
+	writeCount int32
 }
 
 func (t *bufferedConnProvider) GetConn() (net.Conn, error) {
@@ -197,6 +199,7 @@ func (t *bufferedConnProvider) GetConn() (net.Conn, error) {
 }
 
 func (t *bufferedConnProvider) Write(d []byte) (int, error) {
+	atomic.AddInt32(&t.writeCount, 1)
 	return t.buffer.Write(d)
 }
 

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -189,8 +189,10 @@ func getEnvelopeBytes(t *testing.T, payload []byte) []byte {
 // bytes buffer instead of to the net.Conn.
 type bufferedConnProvider struct {
 	net.Conn
-	err        error
-	buffer     bytes.Buffer
+	err    error
+	buffer bytes.Buffer
+	// writeCount tracks the total number of writes that are called.
+	// This field should only be used in testing and should only be updated/read with atomic operations.
 	writeCount int32
 }
 


### PR DESCRIPTION
## Before this PR
The asyncWriter was storing the provided byte slice in the buffer channel which conflicts with the `io.Writer` contract (https://pkg.go.dev/io#Writer), which states to never retain the bytes.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the async writer to copy the provided byte slice rather than retain the original in the buffer channel, which caused the the output to be mangled and non-deterministic
==COMMIT_MSG==

## Possible downsides?
- There will be more memory overhead and GC pressure since we're copying the byte slice on every write.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/264)
<!-- Reviewable:end -->
