### PR TITLE
TCPWriter: Close connections on network timeout errors

### DIFF
--- a/changelog/@unreleased/pr-267.v2.yml
+++ b/changelog/@unreleased/pr-267.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Close TCP connections if there are network timeouts
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/267

--- a/witchcraft/internal/tcpjson/tcp_logger.go
+++ b/witchcraft/internal/tcpjson/tcp_logger.go
@@ -106,8 +106,8 @@ func (d *TCPWriter) Write(p []byte) (n int, err error) {
 		n, err := conn.Write(envelope[total:])
 		total += n
 		if err != nil {
-			if nerr, ok := err.(net.Error); !ok || !nerr.Temporary() {
-				// permanent error so close the connection
+			if nerr, ok := err.(net.Error); !ok || nerr.Timeout() || !nerr.Temporary() {
+				// permanent error or timeout so close the connection
 				_ = d.closeConn()
 				return total, err
 			}

--- a/witchcraft/internal/tcpjson/tcp_logger.go
+++ b/witchcraft/internal/tcpjson/tcp_logger.go
@@ -106,7 +106,7 @@ func (d *TCPWriter) Write(p []byte) (n int, err error) {
 		n, err := conn.Write(envelope[total:])
 		total += n
 		if err != nil {
-			if nerr, ok := err.(net.Error); !(ok && (nerr.Temporary() || nerr.Timeout())) {
+			if nerr, ok := err.(net.Error); !ok || !nerr.Temporary() {
 				// permanent error so close the connection
 				_ = d.closeConn()
 				return total, err

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -80,15 +80,12 @@ func TestWrite(t *testing.T) {
 // TestWrite_Timeout asserts that the connection is closed on a timeout error.
 func TestWrite_Timeout(t *testing.T) {
 	// startup an in-memory TLS server to write TCP logs to
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-	server.TLS = tlsConfig.Clone()
-	server.StartTLS()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer server.Close()
 
 	// get a TCP connection using the TCPConnProvider
 	uris := []string{fmt.Sprintf("%s://%s", server.Listener.Addr().Network(), server.Listener.Addr().String())}
-	connProvider, err := NewTCPConnProvider(uris, tlsConfig.Clone())
+	connProvider, err := NewTCPConnProvider(uris, &tls.Config{InsecureSkipVerify: true})
 	require.NoError(t, err)
 	conn, err := connProvider.GetConn()
 	require.NoError(t, err)

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -108,6 +108,7 @@ func TestWrite_Timeout(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, isTimeoutError(err))
 	require.False(t, isTemporaryError(err))
+	assert.Nil(t, tcpWriter.conn)
 
 	// subsequent writes should error since the connection should be closed
 	_, err = tcpWriter.Write(logPayload)

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -17,11 +17,15 @@ package tcpjson
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
@@ -70,6 +74,64 @@ func TestWrite(t *testing.T) {
 			require.True(t, bytes.Equal(buf, expectedEnvelope))
 		})
 	}
+}
+
+// TestWrite_Timeout asserts that the connection is closed on a timeout error.
+func TestWrite_Timeout(t *testing.T) {
+	// startup an in-memory TLS server to write TCP logs to
+	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.TLS = tlsConfig.Clone()
+	server.StartTLS()
+	defer server.Close()
+
+	// get a TCP connection using the TCPConnProvider
+	uris := []string{fmt.Sprintf("%s://%s", server.Listener.Addr().Network(), server.Listener.Addr().String())}
+	connProvider, err := NewTCPConnProvider(uris, tlsConfig.Clone())
+	require.NoError(t, err)
+	conn, err := connProvider.GetConn()
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// create the TCPWriter with a small net conn wrapper so that we can control the state of the connection below.
+	tcpWriter := NewTCPWriter(testMetadata, &netConnProvider{conn: conn})
+
+	// initial write should succeed
+	n, err := tcpWriter.Write(logPayload)
+	require.NoError(t, err)
+	require.Equal(t, len(logPayload), n)
+
+	// set a deadline which should cause the Write to timeout
+	err = conn.SetDeadline(time.Now())
+	require.NoError(t, err)
+	_, err = tcpWriter.Write(logPayload)
+	require.Error(t, err)
+	require.True(t, isTimeoutError(err))
+	require.False(t, isTemporaryError(err))
+
+	// subsequent writes should error since the connection should be closed
+	_, err = tcpWriter.Write(logPayload)
+	require.Error(t, err)
+	require.False(t, isTimeoutError(err))
+	require.False(t, isTemporaryError(err))
+	// We check the internal conn since the returned error is a single string, "use of closed network connection",
+	// which can change across go versions, and thus brittle to assert against. The internal conn, is expected to be
+	// reset to nil when the connection is closed.
+	assert.Nil(t, tcpWriter.conn)
+}
+
+func isTimeoutError(err error) bool {
+	if ne, ok := err.(net.Error); ok {
+		return ne.Timeout()
+	}
+	return false
+}
+
+func isTemporaryError(err error) bool {
+	if ne, ok := err.(net.Error); ok {
+		return ne.Temporary()
+	}
+	return false
 }
 
 // TestWriteFromSvc1log is more of an integration style test which verifies the envelopes written
@@ -215,6 +277,14 @@ type failingConnProvider struct {
 
 func (t *failingConnProvider) GetConn() (net.Conn, error) {
 	return nil, t.err
+}
+
+type netConnProvider struct {
+	conn net.Conn
+}
+
+func (n *netConnProvider) GetConn() (net.Conn, error) {
+	return n.conn, nil
 }
 
 // BenchmarkEnvelopeSerializer records the total time and memory allocations for each envelope serializer.

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -115,18 +115,10 @@ func TestWrite_Timeout(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, isTimeoutError(err))
 	require.False(t, isTemporaryError(err))
-	var found bool
-	for errStr := range map[string]struct{}{
-		// go1.16
-		"use of closed network connection": {},
-		// go1.15
-		"use of closed connection": {},
-	} {
-		if strings.HasSuffix(err.Error(), errStr) {
-			found = true
-		}
-	}
-	assert.True(t, found)
+	require.True(t,
+		strings.Contains(err.Error(), "use of closed network connection") ||
+			strings.Contains(err.Error(), "tls: use of closed connection"),
+	)
 }
 
 func isTimeoutError(err error) bool {

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -101,6 +101,8 @@ func TestWrite_Timeout(t *testing.T) {
 	n, err := tcpWriter.Write(logPayload)
 	require.NoError(t, err)
 	require.Equal(t, len(logPayload), n)
+	// conn is cached since it's active
+	require.NotNil(t, tcpWriter.conn)
 
 	// set a deadline which should cause the Write to timeout
 	err = conn.SetDeadline(time.Now())
@@ -109,6 +111,8 @@ func TestWrite_Timeout(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, isTimeoutError(err))
 	require.False(t, isTemporaryError(err))
+	// conn is nil, since it should be closed
+	require.Nil(t, tcpWriter.conn)
 
 	// subsequent writes should error since the connection should be closed
 	_, err = tcpWriter.Write(logPayload)
@@ -119,6 +123,8 @@ func TestWrite_Timeout(t *testing.T) {
 		strings.Contains(err.Error(), "use of closed network connection") ||
 			strings.Contains(err.Error(), "tls: use of closed connection"),
 	)
+	// conn is nil, since it should be closed
+	require.Nil(t, tcpWriter.conn)
 }
 
 func isTimeoutError(err error) bool {

--- a/witchcraft/internal/tcpjson/tcp_logger_test.go
+++ b/witchcraft/internal/tcpjson/tcp_logger_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -114,14 +115,18 @@ func TestWrite_Timeout(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, isTimeoutError(err))
 	require.False(t, isTemporaryError(err))
-	closedNetworkErrors := map[string]struct{}{
+	var found bool
+	for errStr := range map[string]struct{}{
 		// go1.16
 		"use of closed network connection": {},
 		// go1.15
 		"use of closed connection": {},
+	} {
+		if strings.HasSuffix(err.Error(), errStr) {
+			found = true
+		}
 	}
-	_, ok := closedNetworkErrors[err.Error()]
-	assert.True(t, ok)
+	assert.True(t, found)
 }
 
 func isTimeoutError(err error) bool {


### PR DESCRIPTION
## Before this PR
Connections could get stuck in a "connection timed out" state and the underlying net.Conn would never be reset causing logs to be dropped.

According to the docs for `tls.Conn.SetDeadline()` (https://pkg.go.dev/crypto/tls#Conn.SetDeadline), after a write has timed out once, the TLS state is corrupt and thus the same error is returned. My hypothesis is that once we hit the timeout, we got stuck in this state since we never closed the connection.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Close TCP connections if there are network timeouts
==COMMIT_MSG==

## Notes
I wasn't able to repro the exact issues we were seeing below, since the `connection timed out` error comes from the [ETIMEDOUT syscall](https://github.com/golang/sys/blob/77fc1eacc6aaf85d786cc0e8343c191ce26ef821/unix/zerrors_linux_amd64.go#L738) on Linux.
```
2021/03/16 18:38:25 write failed: write tcp <src-ip>:<src-port> -> <dst-ip>:<dst-port>: write: connection timed out
```
However when digging into `syscall.ETIMEDOUT`, I realized it happens to implement the `net.Error` interface and returns true for [`Timeout()`](https://github.com/golang/go/blob/7a1e963058460d4136603b86386f2bae6fe0d5f2/src/syscall/syscall_unix.go#L145) and ALSO returns true for [`Temporary()`](https://github.com/golang/go/blob/7a1e963058460d4136603b86386f2bae6fe0d5f2/src/syscall/syscall_unix.go#L141) if there was a timeout!

Relevant issue: https://github.com/golang/go/issues/31449

## Possible downsides?
- Not directly caused by this change, but we upon any timeout, we will still drop the log line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/267)
<!-- Reviewable:end -->
