### PR TITLE
Update logging queue metric name to match java

### DIFF
--- a/witchcraft/internal/tcpjson/async_writer.go
+++ b/witchcraft/internal/tcpjson/async_writer.go
@@ -25,7 +25,7 @@ import (
 const (
 	// asyncWriterBufferCap is an arbitrarily high limit for the number of messages allowed to queue before writes will block.
 	asyncWriterBufferCapacity = 1000
-	asyncWriterBufferLenGauge = "sls.logging.queued"
+	asyncWriterBufferLenGauge = "logging.queue"
 )
 
 type asyncWriter struct {


### PR DESCRIPTION
## Before this PR
previously used `sls.logging.queued` whereas the Java logging libraries use `logging.queue`

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update logging queue metric name to match java
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/270)
<!-- Reviewable:end -->
