### PR TITLE
improvement: Server.WithHealth supports multiple calls by appending

### DIFF
--- a/changelog/@unreleased/pr-279.v2.yml
+++ b/changelog/@unreleased/pr-279.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Server.WithHealth supports multiple calls by appending
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/279

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -43,7 +43,7 @@ func TestAddHealthCheckSources(t *testing.T) {
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
 	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, nil, ioutil.Discard, func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
-		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithHealth(healthCheckWithType{typ: "FOO"}, healthCheckWithType{typ: "BAR"})
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithHealth(healthCheckWithType{typ: "FOO"}).WithHealth(healthCheckWithType{typ: "BAR"})
 	})
 
 	defer func() {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -369,8 +369,9 @@ func (s *Server) WithClientAuth(clientAuth tls.ClientAuthType) *Server {
 // WithHealth configures the server to use the specified health check sources to report the server's health. If multiple
 // healthSource's results have the same key, the result from the latest entry in healthSources will be used. These
 // results are combined with the server's built-in health source, which uses the `SERVER_STATUS` key.
+// Results are appended: multiple calls to WithHealth will not overwrite the previous value.
 func (s *Server) WithHealth(healthSources ...healthstatus.HealthCheckSource) *Server {
-	s.healthCheckSources = healthSources
+	s.healthCheckSources = append(s.healthCheckSources, healthSources...)
 	return s
 }
 


### PR DESCRIPTION
Previously, all user-provided healthchecks must be provided in a single call to WithHealth. This has forced applications to build their own healthcheck accumulators.

I have written this code in multiple repos:
```go
server.New().
WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo) (cleanup func(), rErr error) {
	var healthchecks []status.HealthCheckSource
	registerHealth := func(s status.HealthCheckSource) { healthchecks = append(healthchecks, s) }
	defer info.Router.WithHealth(healthchecks...)

	// use registerHealth as a variable to pass to other constructors or things that produce a healthcheck
}
```

This behavior change is technically a break if anyone is relying on overwriting the values, but I have not been able to find and example of that use case. I considered adding a new API for this (`AppendHealth`?) but decided the API bloat wasn't worth it. Happy to reconsider if others disagree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/279)
<!-- Reviewable:end -->
