### PR TITLE
fix: Handle server shutdown before succesful start

### DIFF
--- a/changelog/@unreleased/pr-284.v2.yml
+++ b/changelog/@unreleased/pr-284.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Handle server shutdown before succesful start
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/284

--- a/changelog/@unreleased/pr-284.v2.yml
+++ b/changelog/@unreleased/pr-284.v2.yml
@@ -1,5 +1,8 @@
 type: fix
 fix:
-  description: Handle server shutdown before succesful start
+  description: >
+    Handle race condition when `ShutdownServer` is called before successful start.
+    Previously, if the server is told to shut down before it has started, the shutdown request errors and is ignored,
+    leaving the server to start up as if the shutdown was not requested.
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/284

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -51,7 +51,7 @@ type serverStateManager struct {
 
 func (s *serverStateManager) Start() error {
 	// state went from Idle to Initializing: OK
-	if atomic.CompareAndSwapInt32(&s.serverRunning, int32(ServerIdle), int32(ServerInitializing)) {
+	if s.compareAndSwapState(ServerIdle, ServerInitializing) {
 		return nil
 	}
 
@@ -76,6 +76,10 @@ func (s *serverStateManager) State() ServerState {
 
 func (s *serverStateManager) setState(state ServerState) {
 	atomic.StoreInt32(&s.serverRunning, int32(state))
+}
+
+func (s *serverStateManager) compareAndSwapState(oldState, newState ServerState) bool {
+	return atomic.CompareAndSwapInt32(&s.serverRunning, int32(oldState), int32(newState))
 }
 
 func (s *serverStateManager) Status() (int, interface{}) {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -781,7 +781,7 @@ func (s *Server) Start() (rErr error) {
 	}
 
 	if !s.stateManager.compareAndSwapState(ServerInitializing, ServerRunning) {
-		return werror.ErrorWithContextParams(ctx, "server was shut down before it could start")
+		return werror.ErrorWithContextParams(ctx, "Server was shut down before it could start")
 	}
 	return svrStart()
 }

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -781,7 +781,7 @@ func (s *Server) Start() (rErr error) {
 	}
 
 	if !s.stateManager.compareAndSwapState(ServerInitializing, ServerRunning) {
-		return werror.ErrorWithContextParams(ctx, "Server was shut down before it could start")
+		return werror.ErrorWithContextParams(ctx, "server was shut down before it could start")
 	}
 	return svrStart()
 }

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -49,6 +49,7 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/tcpjson"
 	"github.com/palantir/witchcraft-go-logging/wlog/trclog/trc1log"
 	"github.com/palantir/witchcraft-go-logging/wlog/wapp"
+	wparams "github.com/palantir/witchcraft-go-params"
 	"github.com/palantir/witchcraft-go-server/v2/config"
 	"github.com/palantir/witchcraft-go-server/v2/status"
 	refreshablehealth "github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/refreshable"
@@ -779,7 +780,9 @@ func (s *Server) Start() (rErr error) {
 		s.httpServer.SetKeepAlivesEnabled(false)
 	}
 
-	s.stateManager.setState(ServerRunning)
+	if !s.stateManager.compareAndSwapState(ServerInitializing, ServerRunning) {
+		return werror.ErrorWithContextParams(ctx, "server was shut down before it could start")
+	}
 	return svrStart()
 }
 
@@ -930,7 +933,8 @@ func (s *Server) initShutdownSignalHandler(ctx context.Context) {
 	signal.Notify(shutdownSignal, syscall.SIGTERM, syscall.SIGINT)
 
 	go wapp.RunWithRecoveryLogging(ctx, func(ctx context.Context) {
-		<-shutdownSignal
+		sig := <-shutdownSignal
+		ctx = wparams.ContextWithSafeParam(ctx, "signal", sig.String())
 		if err := s.Shutdown(ctx); err != nil {
 			s.svcLogger.Warn("Failed to gracefully shutdown server.", svc1log.Stacktrace(err))
 		}
@@ -987,10 +991,13 @@ func (s *Server) decryptConfigBytes(cfgBytes []byte) ([]byte, error) {
 }
 
 func stopServer(s *Server, stopper func(s *http.Server) error) error {
-	if s.State() != ServerRunning {
+	if s.stateManager.State() == ServerIdle {
 		return werror.Error("server is not running")
 	}
 	s.stateManager.setState(ServerIdle)
+	if s.httpServer == nil {
+		return nil
+	}
 	return stopper(s.httpServer)
 }
 

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -116,6 +116,26 @@ func TestFatalErrorLogging(t *testing.T) {
 				assert.Equal(t, "server was shut down before it could start", log.Message)
 			},
 		},
+		{
+			Name: "fails with async shutdown server inside init func",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
+				go func() {
+					_ = info.ShutdownServer(ctx)
+				}()
+				return nil, nil
+			},
+			VerifyLog: func(t *testing.T, logOutput []byte) {
+				svc1LogLines := getLogMessagesOfType(t, "service.1", logOutput)
+				require.Len(t, svc1LogLines, 2, "Expected exactly 2 service log line to be output")
+				var log logging.ServiceLogV1
+				require.NoError(t, json.Unmarshal(svc1LogLines[0], &log))
+				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_INFO), log.Level)
+				assert.Equal(t, "Shutting down server", log.Message)
+				require.NoError(t, json.Unmarshal(svc1LogLines[1], &log))
+				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_ERROR), log.Level)
+				assert.Equal(t, "server was shut down before it could start", log.Message)
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			logOutputBuffer := &bytes.Buffer{}

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -113,7 +113,7 @@ func TestFatalErrorLogging(t *testing.T) {
 				assert.Equal(t, "Shutting down server", log.Message)
 				require.NoError(t, json.Unmarshal(svc1LogLines[1], &log))
 				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_ERROR), log.Level)
-				assert.Equal(t, "Sstop := stoperver was shut down before it could start", log.Message)
+				assert.Equal(t, "Server was shut down before it could start", log.Message)
 			},
 		},
 	} {

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -99,6 +99,23 @@ func TestFatalErrorLogging(t *testing.T) {
 				assert.NotEmpty(t, log.Stacktrace)
 			},
 		},
+		{
+			Name: "fails with shutdown server inside init func",
+			InitFn: func(ctx context.Context, info witchcraft.InitInfo) (func(), error) {
+				return nil, info.ShutdownServer(ctx)
+			},
+			VerifyLog: func(t *testing.T, logOutput []byte) {
+				svc1LogLines := getLogMessagesOfType(t, "service.1", logOutput)
+				require.Len(t, svc1LogLines, 2, "Expected exactly 2 service log line to be output")
+				var log logging.ServiceLogV1
+				require.NoError(t, json.Unmarshal(svc1LogLines[0], &log))
+				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_INFO), log.Level)
+				assert.Equal(t, "Shutting down server", log.Message)
+				require.NoError(t, json.Unmarshal(svc1LogLines[1], &log))
+				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_ERROR), log.Level)
+				assert.Equal(t, "Sstop := stoperver was shut down before it could start", log.Message)
+			},
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			logOutputBuffer := &bytes.Buffer{}

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -113,7 +113,7 @@ func TestFatalErrorLogging(t *testing.T) {
 				assert.Equal(t, "Shutting down server", log.Message)
 				require.NoError(t, json.Unmarshal(svc1LogLines[1], &log))
 				assert.Equal(t, logging.New_LogLevel(logging.LogLevel_ERROR), log.Level)
-				assert.Equal(t, "Server was shut down before it could start", log.Message)
+				assert.Equal(t, "server was shut down before it could start", log.Message)
 			},
 		},
 	} {


### PR DESCRIPTION
## Before this PR
If `ShutdownServer` was called before the server is actually started (for example, in the init func or a goroutine it spawns), we get a "server is not running" error and the startup continues as if it never happened.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Handle server shutdown before succesful start
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/284)
<!-- Reviewable:end -->
