### PR TITLE
Improvement: report unauthorized error as a health check

### DIFF
--- a/changelog/@unreleased/pr-295.v2.yml
+++ b/changelog/@unreleased/pr-295.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: If user is unauthorized to view health checks return an unauthorized error health check rather than no health check.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/295

--- a/status/routes/routes_test.go
+++ b/status/routes/routes_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/palantir/pkg/refreshable"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/sources"
 	healthstatus "github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-server/v2/status"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/wresource"
@@ -224,7 +225,9 @@ func TestAddHealthRoute(t *testing.T) {
 			expectedChecks := test.metadata
 			// 401 does not return any health check data
 			if test.expectedStatus == 401 {
-				expectedChecks.Checks = map[health.CheckType]health.HealthCheckResult{}
+				expectedChecks.Checks = map[health.CheckType]health.HealthCheckResult{
+					"HEALTH_STATUS_UNAUTHORIZED": sources.UnhealthyHealthCheckResult("HEALTH_STATUS_UNAUTHORIZED", "unauthorized to access health status; please verify the health-check-shared-secret", map[string]interface{}{}),
+				}
 			}
 			assert.Equal(t, expectedChecks, gotObj)
 		})

--- a/status/status.go
+++ b/status/status.go
@@ -15,16 +15,15 @@
 package status
 
 import (
-	"github.com/palantir/witchcraft-go-health/sources"
 	"net/http"
 	"sync/atomic"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/refreshable"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-health/sources"
 	"github.com/palantir/witchcraft-go-health/status"
 )
-
 
 var healthStatusUnauthorized = health.HealthStatus{
 	Checks: map[health.CheckType]health.HealthCheckResult{

--- a/status/status.go
+++ b/status/status.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"github.com/palantir/witchcraft-go-health/sources"
 	"net/http"
 	"sync/atomic"
 
@@ -23,6 +24,13 @@ import (
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
 )
+
+
+var healthStatusUnauthorized = health.HealthStatus{
+	Checks: map[health.CheckType]health.HealthCheckResult{
+		"HEALTH_STATUS_UNAUTHORIZED": sources.UnhealthyHealthCheckResult("HEALTH_STATUS_UNAUTHORIZED", "unauthorized to access health status; please verify the health-check-shared-secret", nil),
+	},
+}
 
 // HealthHandler is responsible for checking the health-check-shared-secret if it is provided and
 // invoking a HealthCheckSource if the secret is correct or unset.
@@ -66,7 +74,7 @@ func (h *healthHandlerImpl) computeNewHealthStatus(req *http.Request) (health.He
 	if sharedSecret := h.healthCheckSharedSecret.CurrentString(); sharedSecret != "" {
 		token, err := httpserver.ParseBearerTokenHeader(req)
 		if err != nil || sharedSecret != token {
-			return health.HealthStatus{}, http.StatusUnauthorized
+			return healthStatusUnauthorized, http.StatusUnauthorized
 		}
 	}
 	metadata := h.check.HealthStatus(req.Context())


### PR DESCRIPTION
## Before this PR
We believe we hit this case last week but it's difficult to confirm due to a lack of logging and the way an empty health status get's reported in autopilot. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
If user is unauthorized to view health checks return an unauthorized error health check rather than no health check.
==COMMIT_MSG==

## Possible downsides?
Possibly confusing to users/might interact poorly if existing monitoring/error catching depends on an empty health status object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/295)
<!-- Reviewable:end -->
