### PR TITLE
Upgrade runtime configuration reloaded message to info

### DIFF
--- a/changelog/@unreleased/pr-309.v2.yml
+++ b/changelog/@unreleased/pr-309.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Upgrade runtime configuration reloaded message to info
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/309

--- a/witchcraft/refreshable/refreshable_file.go
+++ b/witchcraft/refreshable/refreshable_file.go
@@ -91,7 +91,7 @@ func (d *fileRefreshable) evaluateFileOnDisk(ctx context.Context) {
 	if loadedChecksum == d.fileChecksum {
 		return
 	}
-	svc1log.FromContext(ctx).Debug("Attempting to update file refreshable")
+	svc1log.FromContext(ctx).Info("Attempting to update file refreshable")
 	if err := d.innerRefreshable.Update(fileBytes); err != nil {
 		svc1log.FromContext(ctx).Error("Failed to update refreshable with new file bytes", svc1log.Stacktrace(err))
 		return


### PR DESCRIPTION
This message is usually very useful in helping understand changes in behaviour of a service when running in steady state that may have resulted from configuration updates. However, most services do not run at `debug` logging in steady state, meaning that we have no signal on new configuration getting picked up by the server.

Other implementations of Witchcraft also log changes in runtime config at `info` because of the same reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/309)
<!-- Reviewable:end -->
