### PR TITLE
Allow encrypted values in config to be concatenated against other strings or encrypted values

### DIFF
--- a/changelog/@unreleased/pr-331.v2.yml
+++ b/changelog/@unreleased/pr-331.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Allow encrypted values in config to be concatenated against other strings
+    or encrypted values.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/331

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -1040,11 +1040,12 @@ func decryptNodeValues(n *yamlv3.Node, kwt *encryptedconfigvalue.KeyWithType) er
 		return nil
 	}
 	if n.Kind == yamlv3.ScalarNode && encryptedconfigvalue.ContainsEncryptedConfigValueStringVars([]byte(n.Value)) {
-		decrypted, err := encryptedconfigvalue.DecryptSingleEncryptedValueStringVarString(n.Value, *kwt)
-		if err != nil {
+		decrypted := encryptedconfigvalue.DecryptAllEncryptedValueStringVars([]byte(n.Value), *kwt)
+		// The existence of encrypted values after an decryption attempt implies decryption failed.
+		if encryptedconfigvalue.ContainsEncryptedConfigValueStringVars(decrypted) {
 			return werror.Error("failed to decrypt encrypted-config-value in YAML node")
 		}
-		n.Value = decrypted
+		n.Value = string(decrypted)
 	}
 	for _, childNode := range n.Content {
 		if err := decryptNodeValues(childNode, kwt); err != nil {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

A side-effect of https://github.com/palantir/witchcraft-go-server/pull/320 is the introduction of the requirement that encrypted values, when present, had to consist of the whole field. This means values like `prefix${enc:value}` were no longer valid. This was done to be consistent with the Java implementation.

In production, this has shown to be too disruptive to be done via a minor version change. As such, this PR relaxes the requirement to once again support encrypted values concatenated against other strings or other encrypted values.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow encrypted values in config to be concatenated against other strings or encrypted values.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

First, we are no longer consistent w/ the Java implementation.

Secondly, there is technically a regression introduced by this PR: if an encrypted value decrypts itself into another encrypted value (e.g. `${enc:valueA}` decrypts into `${enc:valueB}`), WGS will falsely fail on it because it detects the existence of an encrypted value after decryption is done. This seems nonstandard enough to not be an issue but we can revisit by changing the underlying library https://github.com/palantir/go-encrypted-config-value that's being vendored if it become an issue in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/331)
<!-- Reviewable:end -->
