### PR TITLE
Revert #332

### DIFF
--- a/changelog/@unreleased/pr-333.v2.yml
+++ b/changelog/@unreleased/pr-333.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: 'Revert #332 to no longer discover network logging URIs via environment
+    variables and instead rely solely on service-discovery config'
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/333


### PR DESCRIPTION
## Before this PR
#332 added support to override the network logging URIs with an environment variable rather than via explicit configuration. This ended up causing issues internally due to the nature of how config was populated and whether or not security material was specified. Reverting this PR is the safest route to get WGS services back to a fully functional state.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Revert #332 to no longer discover network logging URIs via environment variables and instead rely solely on service-discovery config
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/333)
<!-- Reviewable:end -->
