### PR TITLE
improvement: Use $NETWORK_LOGGING_URL for sls-log-tcp-json-receiver URIs

### DIFF
--- a/changelog/@unreleased/pr-337.v2.yml
+++ b/changelog/@unreleased/pr-337.v2.yml
@@ -1,5 +1,5 @@
 type: improvement
 improvement:
-  description: Use $NETWORK_LOGGING_URL if set
+  description: Use $NETWORK_LOGGING_URL for sls-log-tcp-json-receiver URIs
   links:
   - https://github.com/palantir/witchcraft-go-server/pull/337

--- a/changelog/@unreleased/pr-337.v2.yml
+++ b/changelog/@unreleased/pr-337.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use $NETWORK_LOGGING_URL if set
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/337

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -638,9 +638,14 @@ func (s *Server) Start() (rErr error) {
 
 	// enable TCP logging if the envelope metadata and the TCP receiver are both configured
 	receiverCfg := baseRefreshableRuntimeCfg.ServiceDiscovery().CurrentServicesConfig().ClientConfig("sls-log-tcp-json-receiver")
+	// If we've been provided a URL in the environment, prefer that to whatever is in config.
+	receiverURIs := receiverCfg.URIs
+	if envURL := os.Getenv("NETWORK_LOGGING_URL"); envURL != "" {
+		receiverURIs = []string{envURL}
+	}
 	envelopeMetadata, err := tcpjson.GetEnvelopeMetadata()
 	if err != nil {
-		if len(receiverCfg.URIs) > 0 {
+		if len(receiverURIs) > 0 {
 			// Presence of TCP receiver config without envelope metadata may indicate a mis-configuration,
 			// but can also be expected in environments where the config is always hard-coded.
 			// In this case we emit a warning log to help debug potential issues, but otherwise proceed as normal.
@@ -648,7 +653,7 @@ func (s *Server) Start() (rErr error) {
 		}
 		// If both the envelope metadata and the TCP receiver are not configured, then it is expected
 		// that TCP logging should not be enabled and thus it is safe to proceed without any warning logs.
-	} else if len(receiverCfg.URIs) == 0 {
+	} else if len(receiverURIs) == 0 {
 		// The existence of envelope metadata means TCP logging was expected to be enabled, but the TCP receiver must be mis-configured.
 		// Since the server may otherwise be functional, an error log is emitted to indicate logging issues, rather
 		// than setting the TCP writer health to a state that can cause pages.
@@ -662,7 +667,7 @@ func (s *Server) Start() (rErr error) {
 		if err != nil {
 			return werror.Wrap(err, "tls client config could be created for the TCP JSON reciever")
 		}
-		connProvider, err := tcpjson.NewTCPConnProvider(receiverCfg.URIs, tcpjson.WithTLSConfig(tlsConfig))
+		connProvider, err := tcpjson.NewTCPConnProvider(receiverURIs, tcpjson.WithTLSConfig(tlsConfig))
 		if err != nil {
 			return err
 		}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -638,7 +638,9 @@ func (s *Server) Start() (rErr error) {
 
 	// Initialize network logging client if configured
 	ctx, netLoggerHealth := s.initNetworkLogging(ctx, baseInstallCfg, baseRefreshableRuntimeCfg)
-	internalHealthCheckSources = append(internalHealthCheckSources, netLoggerHealth)
+	if netLoggerHealth != nil {
+		internalHealthCheckSources = append(internalHealthCheckSources, netLoggerHealth)
+	}
 
 	// Set the service log level if configured
 	if loggerCfg := baseRefreshableRuntimeCfg.LoggerConfig().CurrentLoggerConfigPtr(); loggerCfg != nil {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -636,61 +636,9 @@ func (s *Server) Start() (rErr error) {
 	}
 	internalHealthCheckSources := []healthstatus.HealthCheckSource{configReloadHealthCheckSource}
 
-	// enable TCP logging if the envelope metadata and the TCP receiver are both configured
-	receiverCfg := baseRefreshableRuntimeCfg.ServiceDiscovery().CurrentServicesConfig().ClientConfig("sls-log-tcp-json-receiver")
-	// If we've been provided a URL in the environment, prefer that to whatever is in config.
-	receiverURIs := receiverCfg.URIs
-	if envURL := os.Getenv("NETWORK_LOGGING_URL"); envURL != "" {
-		receiverURIs = []string{envURL}
-	}
-	envelopeMetadata, err := tcpjson.GetEnvelopeMetadata()
-	if err != nil {
-		if len(receiverURIs) > 0 {
-			// Presence of TCP receiver config without envelope metadata may indicate a mis-configuration,
-			// but can also be expected in environments where the config is always hard-coded.
-			// In this case we emit a warning log to help debug potential issues, but otherwise proceed as normal.
-			s.svcLogger.Warn("TCP logging will not be enabled since all environment variables are not set.", svc1log.Stacktrace(err))
-		}
-		// If both the envelope metadata and the TCP receiver are not configured, then it is expected
-		// that TCP logging should not be enabled and thus it is safe to proceed without any warning logs.
-	} else if len(receiverURIs) == 0 {
-		// The existence of envelope metadata means TCP logging was expected to be enabled, but the TCP receiver must be mis-configured.
-		// Since the server may otherwise be functional, an error log is emitted to indicate logging issues, rather
-		// than setting the TCP writer health to a state that can cause pages.
-		s.svcLogger.Error("TCP logging is disabled. No TCP JSON receiver URIs are configured but log envelope metadata exists.")
-	} else {
-		// enable TCP logging since the metadata and receiver are both configured
-		tlsConfig, err := tlsconfig.NewClientConfig(
-			tlsconfig.ClientRootCAFiles(receiverCfg.Security.CAFiles...),
-			tlsconfig.ClientKeyPairFiles(receiverCfg.Security.CertFile, receiverCfg.Security.KeyFile),
-		)
-		if err != nil {
-			return werror.Wrap(err, "tls client config could be created for the TCP JSON reciever")
-		}
-		connProvider, err := tcpjson.NewTCPConnProvider(receiverURIs, tcpjson.WithTLSConfig(tlsConfig))
-		if err != nil {
-			return err
-		}
-
-		// Overwrite envelope fields from config if wrapped logging is enabled
-		if baseInstallCfg.UseWrappedLogs {
-			envelopeMetadata.Product = baseInstallCfg.ProductName
-			envelopeMetadata.ProductVersion = baseInstallCfg.ProductVersion
-		}
-
-		// Create a TCP connection and an asynchronous buffered wrapper.
-		// Note that we intentionally do not call their Close() methods.
-		// While this does leak the resources of the open connection, we want every possible message to reach the output.
-		// Closing early at any point before program termination risks other operations' last log messages being lost.
-		// The resource leak has been deemed acceptable given server.Start() is typically a singleton and the main execution thread.
-		tcpWriter := tcpjson.NewTCPWriter(envelopeMetadata, connProvider)
-		s.asyncLogWriter = tcpjson.StartAsyncWriter(tcpWriter, metricsRegistry)
-		internalHealthCheckSources = append(internalHealthCheckSources, tcpWriter)
-
-		// re-initialize the loggers with the TCP writer and overwrite the context
-		s.initDefaultLoggers(baseInstallCfg.UseConsoleLog, wlog.InfoLevel, metricsRegistry)
-		ctx = s.withLoggers(ctx)
-	}
+	// Initialize network logging client if configured
+	ctx, netLoggerHealth := s.initNetworkLogging(ctx, baseInstallCfg, baseRefreshableRuntimeCfg)
+	internalHealthCheckSources = append(internalHealthCheckSources, netLoggerHealth)
 
 	// Set the service log level if configured
 	if loggerCfg := baseRefreshableRuntimeCfg.LoggerConfig().CurrentLoggerConfigPtr(); loggerCfg != nil {
@@ -942,6 +890,65 @@ func (s *Server) initStackTraceHandler(ctx context.Context) {
 	}
 
 	signals.RegisterStackTraceHandlerOnSignals(ctx, stackTraceHandler, errHandler, syscall.SIGQUIT)
+}
+
+// initNetworkLogging enables TCP logging if the envelope metadata and the TCP receiver are both configured.
+func (s *Server) initNetworkLogging(ctx context.Context, install config.Install, runtime config.RefreshableRuntime) (context.Context, healthstatus.HealthCheckSource) {
+	receiverCfg := runtime.ServiceDiscovery().CurrentServicesConfig().ClientConfig("sls-log-tcp-json-receiver")
+	// If we've been provided a URL in the environment, prefer that to whatever is in config.
+	receiverURIs := receiverCfg.URIs
+	if envURL := os.Getenv("NETWORK_LOGGING_URL"); envURL != "" {
+		receiverURIs = []string{envURL}
+	} else if len(receiverURIs) == 0 {
+		// If no URIs are configured and NETWORK_LOGGING_URL is unset, TCP logging is disabled.
+		return ctx, nil
+	}
+	envelopeMetadata, err := tcpjson.GetEnvelopeMetadata()
+	if err != nil {
+		// Presence of TCP receiver config without envelope metadata may indicate a mis-configuration,
+		// but can also be expected in environments where the config is always hard-coded.
+		// In this case we emit a warning log to help debug potential issues, but otherwise proceed as normal.
+		s.svcLogger.Warn("TCP logging will not be enabled since all environment variables are not set.", svc1log.Stacktrace(err))
+		return ctx, nil
+	}
+
+	// enable TCP logging since the metadata and receiver are both configured
+	tlsConfig, err := tlsconfig.NewClientConfig(
+		tlsconfig.ClientRootCAFiles(receiverCfg.Security.CAFiles...),
+		tlsconfig.ClientKeyPairFiles(receiverCfg.Security.CertFile, receiverCfg.Security.KeyFile),
+	)
+	if err != nil {
+		// The existence of receiverURIs means TCP logging was expected to be enabled, but the TCP receiver must be mis-configured.
+		// Since the server may otherwise be functional, an error log is emitted to indicate logging issues, rather
+		// than setting the TCP writer health to a state that can cause pages.
+		s.svcLogger.Warn("TCP logging will not be enabled since TLS config is unset or invalid.", svc1log.Stacktrace(err))
+		return ctx, nil
+	}
+	connProvider, err := tcpjson.NewTCPConnProvider(receiverURIs, tcpjson.WithTLSConfig(tlsConfig))
+	if err != nil {
+		s.svcLogger.Error("TCP logging will not be enabled since connection provider is invalid.", svc1log.Stacktrace(err))
+		return ctx, nil
+	}
+
+	// Overwrite envelope fields from config if wrapped logging is enabled
+	if install.UseWrappedLogs {
+		envelopeMetadata.Product = install.ProductName
+		envelopeMetadata.ProductVersion = install.ProductVersion
+	}
+
+	// Create a TCP connection and an asynchronous buffered wrapper.
+	// Note that we intentionally do not call their Close() methods.
+	// While this does leak the resources of the open connection, we want every possible message to reach the output.
+	// Closing early at any point before program termination risks other operations' last log messages being lost.
+	// The resource leak has been deemed acceptable given server.Start() is typically a singleton and the main execution thread.
+	tcpWriter := tcpjson.NewTCPWriter(envelopeMetadata, connProvider)
+	s.asyncLogWriter = tcpjson.StartAsyncWriter(tcpWriter, metrics.FromContext(ctx))
+
+	// re-initialize the loggers with the TCP writer and overwrite the context
+	s.initDefaultLoggers(install.UseConsoleLog, wlog.InfoLevel, metrics.FromContext(ctx))
+	ctx = s.withLoggers(ctx)
+
+	return ctx, tcpWriter
 }
 
 func (s *Server) initShutdownSignalHandler(ctx context.Context) {

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -453,6 +453,8 @@ func TestServer_Start_WithPortInUse(t *testing.T) {
 	}
 }
 
+// TestServer_InitNetworkLogging verifies that in various cases of network logging misconfiguration,
+// we are always able to continue past those errors and attempt to initialize the server.
 func TestServer_InitNetworkLogging(t *testing.T) {
 	const errString = "must error to get Start to return!"
 	for _, test := range []struct {


### PR DESCRIPTION
Reapplies #332 reverted in #333. This time, we do not crash the server in any case related to network logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/337)
<!-- Reviewable:end -->
