### PR TITLE
improvement: Expose server.WithRuntimeConfigProviderFunc for dynamically reading runtime config bytes

### DIFF
--- a/changelog/@unreleased/pr-390.v2.yml
+++ b/changelog/@unreleased/pr-390.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Expose server.WithRuntimeConfigProviderFunc for dynamically reading
+    runtime config bytes
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/390

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -336,6 +336,13 @@ func (s *Server) WithRuntimeConfigProvider(r refreshable.Refreshable) *Server {
 	return s
 }
 
+// WithRuntimeConfigProviderFunc configures the server to use the returned Refreshable as its runtime configuration.
+// The value provided by the refreshable must be a []byte for the yaml runtime configuration.
+func (s *Server) WithRuntimeConfigProviderFunc(f func(ctx context.Context) (refreshable.Refreshable, error)) *Server {
+	s.runtimeConfigProvider = f
+	return s
+}
+
 // WithRuntimeConfigFromFile configures the server to use the file at the provided path as its runtime configuration.
 // The server will create a refreshable.Refreshable using the file at the provided path (and will thus live-reload the
 // configuration based on updates to the file).


### PR DESCRIPTION
Currently, the witchcraft builder does not allow the caller to customize how the runtime configuration bytes are provided. `WithRuntimeConfigProvider` accepts a constructed refreshable, but we'd like to leverage witchcraft's ctx and error handling by deferring construction with the custom function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/390)
<!-- Reviewable:end -->
