### PR TITLE
Improvement: Add support for application server only middleware

### DIFF
--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -82,7 +82,7 @@ func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg 
 	return nil
 }
 
-func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.RootRegistry, tracerOptions []wtracing.TracerOption) {
+func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.RootRegistry, tracerOptions []wtracing.TracerOption, isApplicationRouter bool) {
 	rootRouter.AddRequestHandlerMiddleware(
 		// add middleware that recovers from panics in request middleware
 		middleware.NewRequestPanicRecovery(s.svcLogger, s.evtLogger),
@@ -111,6 +111,11 @@ func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.R
 
 	// add user-provided middleware
 	rootRouter.AddRequestHandlerMiddleware(s.handlers...)
+
+	// add application server only user-provided middleware if this is the application router
+	if isApplicationRouter {
+		rootRouter.AddRequestHandlerMiddleware(s.applicationServerOnlyHandlers...)
+	}
 
 	// add route middleware
 	rootRouter.AddRouteHandlerMiddleware(middleware.NewRouteRequestLog(s.reqLogger, nil))

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -73,7 +73,8 @@ type Server struct {
 	// applicationServerOnlyHandlers specifies any custom HTTP handlers that should be used by the application server
 	// only (i.e., they will not be added to the management port router if configured). The provided handlers are
 	// invoked in order after the built-in handlers (which provide things such as panic handling) and after the global
-	// middleware handlers. The context in the request will have the appropriate loggers and logger parameters set.
+	// user-defined middleware handlers. The context in the request will have the appropriate loggers and logger
+	// parameters set.
 	applicationServerOnlyHandlers []wrouter.RequestHandlerMiddleware
 
 	// useSelfSignedServerCertificate specifies whether the server uses a dynamically generated self-signed certificate


### PR DESCRIPTION

==COMMIT_MSG==
Add support for application server only middleware
==COMMIT_MSG==

* Currently, any configured middleware is applied to both the main application and management routers. This breaks down if you need any special handling for the main application than from the status ports.
* This change adds the ability to separately configure middleware that applies to the main application router only

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/417)
<!-- Reviewable:end -->
