### PR TITLE
Fix the "server.uptime" metric to include go tags

### DIFF
--- a/changelog/@unreleased/pr-420.v2.yml
+++ b/changelog/@unreleased/pr-420.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Fix the "server.uptime" metric emission to include the go tags when
+    updating the metric value
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/420

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -263,7 +263,7 @@ func initServerUptimeMetric(ctx context.Context, metricsRegistry metrics.Registr
 			case <-ctx.Done():
 				return
 			case <-t.C:
-				metricsRegistry.Gauge("server.uptime").Update(int64(time.Since(initTime) / time.Microsecond))
+				metrics.FromContext(ctx).Gauge("server.uptime").Update(int64(time.Since(initTime) / time.Microsecond))
 			}
 		}
 	})


### PR DESCRIPTION
## Before this PR
The `server.uptime` metric would emit 2 distinct time series
-  One that includes the `go_*` tags, which comes from [here](https://github.com/palantir/witchcraft-go-server/blob/a82cd6443c1719a958260630130f8a5a55a0b6b8/witchcraft/server_metrics.go#L255)
-  A second with an empty tag set, which comes from the emission func [here](https://github.com/palantir/witchcraft-go-server/blob/a82cd6443c1719a958260630130f8a5a55a0b6b8/witchcraft/server_metrics.go#L266)

Since the emission func is the one that constantly emits the metric, the only metric that would be updated will be the one with no tags, whereas the one with tags will only have a single data point.

The reason this happens is because the metric emission func uses the raw metrics registry which does not contain logic to pull out the previously added tags. Converting over to use `metrics.FromContext()` returns a metrics registry that also adds all tags that exist on the context which in this case would be the `go_*` tags.

This was not caught in tests because the metric-emission is on a 5-second loop, which is much longer than any of the tests operate for and given the first metric emission was successful, all tests succeed.

The regression was introduced in #388 (specifically here: https://github.com/palantir/witchcraft-go-server/pull/388/files#diff-38904cf54b90330c0c8a3c67562246dfc7b15a36476406cea151d7f0b7d79809R266)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix the "server.uptime" metric emission to include the go tags when updating the metric value
==COMMIT_MSG==

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/420)
<!-- Reviewable:end -->
