### PR TITLE
improvement: Expose ServiceConfig() on ConfigurableServiceDiscovery

### DIFF
--- a/changelog/@unreleased/pr-422.v2.yml
+++ b/changelog/@unreleased/pr-422.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Expose ServiceConfig() on ConfigurableServiceDiscovery
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/422


### PR DESCRIPTION
## Before this PR
There is no way to get the merged configuration without building a client (which doesn't expose it either).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose ServiceConfig() on ConfigurableServiceDiscovery
==COMMIT_MSG==

## Possible downsides?
More people offroad rather than using NewClient?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/422)
<!-- Reviewable:end -->
