### PR TITLE
fix: Use consistent time string comparison when checking auth tokens.

### DIFF
--- a/changelog/@unreleased/pr-432.v2.yml
+++ b/changelog/@unreleased/pr-432.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Use consistent time string comparison when checking auth tokens.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/432

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/nmiyake/pkg/dirs v1.0.0
-	github.com/palantir/conjure-go-runtime/v2 v2.30.0
+	github.com/palantir/conjure-go-runtime/v2 v2.31.0
 	github.com/palantir/go-encrypted-config-value v1.1.0
 	github.com/palantir/go-metrics v1.1.1
 	github.com/palantir/pkg/httpserver v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb9NAWI=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/palantir/conjure-go-runtime/v2 v2.30.0 h1:mlkmbaWjbQ6xH6MrSuWcZbKY5F6uAIVNWsJRdMLDJN0=
-github.com/palantir/conjure-go-runtime/v2 v2.30.0/go.mod h1:EQ/4brZZrvO6WFRwAQfvpYx8ANt2aIpxU5Pd4lVIF0U=
+github.com/palantir/conjure-go-runtime/v2 v2.31.0 h1:aOMoP7BnyT/HWGRwjTASuPbJN8xfhgmFFZE5Tw7iZPY=
+github.com/palantir/conjure-go-runtime/v2 v2.31.0/go.mod h1:zPO6BsRPfpwn8SnaYmyc79PpasaRcp/JURTMVBMuedo=
 github.com/palantir/go-encrypted-config-value v1.1.0 h1:GwyTWSEthp3dRII2AL+lgdM5ajc8uBVQdv7dZSG91hY=
 github.com/palantir/go-encrypted-config-value v1.1.0/go.mod h1:6c5zDN0XqZLxJiV3yLZmoEkUpaB4W3xJdKY6UPn24qI=
 github.com/palantir/go-metrics v1.1.1 h1:YL/UmptBjrC6iSCTVr7vfuIcjL0M359Da3/gBGNny10=

--- a/status/status.go
+++ b/status/status.go
@@ -65,7 +65,11 @@ func (h *healthHandlerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 func (h *healthHandlerImpl) computeNewHealthStatus(req *http.Request) (health.HealthStatus, int) {
 	if sharedSecret := h.healthCheckSharedSecret.CurrentString(); sharedSecret != "" {
 		token, err := httpserver.ParseBearerTokenHeader(req)
-		if err != nil || sharedSecret != token {
+		if err != nil {
+			return health.HealthStatus{}, http.StatusUnauthorized
+		}
+
+		if !httpserver.SecretStringEqual(sharedSecret, token) {
 			return health.HealthStatus{}, http.StatusUnauthorized
 		}
 	}

--- a/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/rest.go
+++ b/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver/rest.go
@@ -15,6 +15,8 @@
 package httpserver
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -49,4 +51,16 @@ func ParseBearerTokenHeader(req *http.Request) (string, error) {
 		return "", werror.Error("Illegal authorization header, expected Bearer")
 	}
 	return headerSplit[1], nil
+}
+
+// SecretStringEqual will compare two strings and return true if they are
+// equal. The time taken for the comparison does not depend on the string
+// contents.
+func SecretStringEqual(a, b string) bool {
+	// compute hash of inputs since ConstantTimeCompare will leak if the
+	// length of the expected and actual secrets do not match.
+	aHash := sha256.Sum256([]byte(a))
+	bHash := sha256.Sum256([]byte(b))
+
+	return subtle.ConstantTimeCompare(aHash[:], bHash[:]) == 1
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -17,7 +17,7 @@ github.com/openzipkin/zipkin-go/idgenerator
 github.com/openzipkin/zipkin-go/model
 github.com/openzipkin/zipkin-go/propagation
 github.com/openzipkin/zipkin-go/reporter
-# github.com/palantir/conjure-go-runtime/v2 v2.30.0
+# github.com/palantir/conjure-go-runtime/v2 v2.31.0
 ## explicit; go 1.18
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient
 github.com/palantir/conjure-go-runtime/v2/conjure-go-client/httpclient/internal

--- a/witchcraft/internal/wdebug/resource_test.go
+++ b/witchcraft/internal/wdebug/resource_test.go
@@ -76,4 +76,21 @@ func TestDebugResource(t *testing.T) {
 			test.Verify(t, resp)
 		})
 	}
+
+	t.Run("401 on invalid auth header", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/debug/diagnostic/%s", server.URL, DiagnosticTypeAllocsProfileV1), nil)
+		require.NoError(t, err)
+		req.Header.Set("Auth", "Bearer "+secret.Current().(string))
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+	t.Run("401 on invalid secret", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/debug/diagnostic/%s", server.URL, DiagnosticTypeAllocsProfileV1), nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer invalid")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
 }


### PR DESCRIPTION
## Before this PR
We were directly comparing auth tokens strings.

## After this PR
Utilize the new secret string comparison function from CGR to check auth tokens. Fixes timing attacks on the diagnostic and health status endpoints. 
https://github.com/palantir/conjure-go-runtime/pull/294

==COMMIT_MSG==
Use consistent time string comparison when checking auth tokens.
==COMMIT_MSG==

## Possible downsides?
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/432)
<!-- Reviewable:end -->
