### PR TITLE
improvement: Return a proper unauthorized response if the health check shared secret is incorrect

### DIFF
--- a/changelog/@unreleased/pr-486.v2.yml
+++ b/changelog/@unreleased/pr-486.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Return a proper unauthorized response if the health check shared secret
+    is incorrect
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/486

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -347,7 +347,7 @@ func TestHealthSharedSecret(t *testing.T) {
 	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", "bad-secret"))
 	resp, err = client.Do(request)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
 
 	select {
 	case err := <-serverErr:

--- a/status/routes/routes_test.go
+++ b/status/routes/routes_test.go
@@ -196,7 +196,7 @@ func TestAddHealthRoute(t *testing.T) {
 			},
 			"top-secret",
 			"bad-secret",
-			401,
+			403,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -222,11 +222,12 @@ func TestAddHealthRoute(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedChecks := test.metadata
-			// 401 does not return any health check data
-			if test.expectedStatus == 401 {
-				expectedChecks.Checks = map[health.CheckType]health.HealthCheckResult{}
+			switch test.expectedStatus {
+			case 401, 403:
+				// Error response is returned.
+			default:
+				assert.Equal(t, expectedChecks, gotObj)
 			}
-			assert.Equal(t, expectedChecks, gotObj)
 		})
 	}
 }

--- a/status/status.go
+++ b/status/status.go
@@ -18,12 +18,12 @@ import (
 	"net/http"
 	"sync/atomic"
 
+	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/refreshable"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
-	"github.com/palantir/witchcraft-go-server/vendor/github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
-	wparams "github.com/palantir/witchcraft-go-server/vendor/github.com/palantir/witchcraft-go-params"
+	wparams "github.com/palantir/witchcraft-go-params"
 )
 
 // HealthHandler is responsible for checking the health-check-shared-secret if it is provided and

--- a/status/status.go
+++ b/status/status.go
@@ -23,7 +23,6 @@ import (
 	"github.com/palantir/pkg/refreshable"
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
-	wparams "github.com/palantir/witchcraft-go-params"
 )
 
 // HealthHandler is responsible for checking the health-check-shared-secret if it is provided and
@@ -54,12 +53,12 @@ func (h *healthHandlerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 	if sharedSecret := h.healthCheckSharedSecret.CurrentString(); sharedSecret != "" {
 		token, err := httpserver.ParseBearerTokenHeader(req)
 		if err != nil {
-			errors.WriteErrorResponse(w, errors.NewUnauthorized(wparams.NewSafeParam("message", err.Error())))
+			errors.WriteErrorResponse(w, errors.NewUnauthorized())
 			return
 		}
 
 		if !httpserver.SecretStringEqual(sharedSecret, token) {
-			errors.WriteErrorResponse(w, errors.NewUnauthorized(wparams.NewSafeParam("message", "Incorrect health check shared secret")))
+			errors.WriteErrorResponse(w, errors.NewUnauthorized())
 			return
 		}
 	}

--- a/status/status.go
+++ b/status/status.go
@@ -58,7 +58,7 @@ func (h *healthHandlerImpl) ServeHTTP(w http.ResponseWriter, req *http.Request) 
 		}
 
 		if !httpserver.SecretStringEqual(sharedSecret, token) {
-			errors.WriteErrorResponse(w, errors.NewUnauthorized())
+			errors.WriteErrorResponse(w, errors.NewPermissionDenied())
 			return
 		}
 	}


### PR DESCRIPTION
## Before this PR
If the health check shared secret is set and a request on the health endpoint does not set it or set it incorrectly, we return an empty health check response. This is confusing.

This stems from the fact that the status code for the health request is the health status code for the server and not for the health request itself.

## After this PR
If the health check shared secret is set and a request on the health endpoint does not set it or set it incorrectly, we return an error message.

==COMMIT_MSG==
Return a proper unauthorized response if the health check shared secret is incorrect
==COMMIT_MSG==

## Possible downsides?
Any automation that does not check the status code before attempting to unmarshal the health response might see an unexpected error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/486)
<!-- Reviewable:end -->
