### PR TITLE
improvement: SERVICE_DEPENDENCY check reports REPAIRING instead of WARNING for initial 5 minutes

### DIFF
--- a/changelog/@unreleased/pr-579.v2.yml
+++ b/changelog/@unreleased/pr-579.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: SERVICE_DEPENDENCY check reports REPAIRING instead of WARNING for initial
+    5 minutes
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/579

--- a/witchcraft/internal/dependencyhealth/healthcheck.go
+++ b/witchcraft/internal/dependencyhealth/healthcheck.go
@@ -113,7 +113,11 @@ func (h *ServiceDependencyHealthCheck) HealthStatus(context.Context) health.Heal
 	}
 	if containsUnhealthyService {
 		result.Message = &serviceDependencyMsgServiceFailed
-		result.State = health.New_HealthState(health.HealthState_WARNING)
+		if h.hosts.FullWindowElapsed() {
+			result.State = health.New_HealthState(health.HealthState_WARNING)
+		} else {
+			result.State = health.New_HealthState(health.HealthState_REPAIRING)
+		}
 	}
 
 	return health.HealthStatus{


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/579)
<!-- Reviewable:end -->
