### PR TITLE
fix: Report duration of `server.response` in microseconds

### DIFF
--- a/changelog/@unreleased/pr-652.v2.yml
+++ b/changelog/@unreleased/pr-652.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Report duration of `server.response` in microseconds.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/652


### PR DESCRIPTION
## Before this PR
`server.response` metric was reported with resolution in milliseconds, even though the convention with the Java implementation of Witchcraft is to report it in microseconds. This results in response latency being reported with values that are 1000x faster than they actually are.

## After this PR
==COMMIT_MSG==
Report duration of `server.response` in microseconds.
==COMMIT_MSG==

You can also check the reasoning by running the following test locally:

```go
func TestTimer_Update(t *testing.T) {
	timerWithConversion := metrics.NewRootMetricsRegistry().Timer("with-conversion")
	timerWithConversion.Update(time.Second / time.Microsecond)
	// The value is incorrectly reported as 1,000 microseconds
	assert.Equal(t, int64(1_000), timerWithConversion.Max())

	timerWithoutConversion := metrics.NewRootMetricsRegistry().Timer("without-conversion")
	timerWithoutConversion.Update(time.Second)
	// The value is correctly reported as 1,000,000 microseconds
	assert.Equal(t, int64(1_000_000), timerWithoutConversion.Max())
}
```

## Possible downsides?
This might cause some confusion as the value will be reported correctly now. As a result, if looking at a longer time-frame, a user might think that the endpoint was responding much faster in the past, but got 1000x slower after this problem was fixed.