### PR TITLE
improvement: add a diagnostic handler to fetch the current system time

### DIFF
--- a/changelog/@unreleased/pr-653.v2.yml
+++ b/changelog/@unreleased/pr-653.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: add a diagnostic handler to fetch the current system time
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/653

--- a/witchcraft/internal/wdebug/resource_test.go
+++ b/witchcraft/internal/wdebug/resource_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/codecs"
 	"github.com/palantir/pkg/refreshable"
@@ -64,6 +65,19 @@ func TestDebugResource(t *testing.T) {
 				var body bytes.Buffer
 				require.NoError(t, codecs.Binary.Decode(resp.Body, &body))
 				require.NotEmpty(t, body.Bytes())
+			},
+		},
+		{
+			DiagnosticType: DiagnosticTypeSystemTimeV1,
+			Verify: func(t *testing.T, resp *http.Response) {
+				require.Equal(t, 200, resp.StatusCode)
+				require.Equal(t, "text/plain", resp.Header.Get("Content-Type"))
+				require.Equal(t, "true", resp.Header.Get("Safe-Loggable"))
+				var systemTime string
+				require.NoError(t, codecs.Plain.Decode(resp.Body, &systemTime))
+				parsed, err := time.Parse(time.RFC3339Nano, systemTime)
+				require.NoError(t, err)
+				require.NotEmpty(t, parsed)
 			},
 		},
 	} {


### PR DESCRIPTION
## Before this PR
The Java implementation of Witchcraft provided a default diagnostic option to fetch the current system time as observed by the service. There was no go equivalent. This has added friction when diagnosing issues stemming from clock drift between hosts.

## After this PR
Adds a new default diagnostic type and handler for fetching the current system time matching the Witchcraft Java naming and behavior.

==COMMIT_MSG==
add a diagnostic handler to fetch the current system time
==COMMIT_MSG==