### PR TITLE
fix: Do not register /debug/pprof routes without management port

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ specifies the encoding and format of the response. The following types are curre
 * `metric.names.v1`: Records all metric names and tag sets in the process's metric registry.
 
 #### \[Deprecated] Pprof routes
-The following routes are registered on the management server (if enabled, otherwise the main server) to aid in debugging
+The following routes are registered on the management server (if enabled) to aid in debugging
 and telemetry collection. These are generally deprecated in favor of the diagnostic routes described above.
 * `/debug/pprof`: Provides an HTML index of the other endpoints at this route.
 * `/debug/pprof/profile`: Returns the pprof-formatted cpu profile. See [pprof.Profile](https://golang.org/pkg/net/http/pprof/#Profile).

--- a/changelog/@unreleased/pr-661.v2.yml
+++ b/changelog/@unreleased/pr-661.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Do not register /debug/pprof routes without management port
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/661

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -43,11 +43,8 @@ func (s *Server) initRouters(installCfg config.Install) (rRouter wrouter.Router,
 	return routerWithContextPath, mgmtRouterWithContextPath
 }
 
+// addRoutes registers /debug/diagnostic/* and /status/*
 func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg config.RefreshableRuntime) error {
-	// add debugging endpoints to management router
-	if err := addPprofRoutes(mgmtRouterWithContextPath); err != nil {
-		return werror.Wrap(err, "failed to register debugging routes")
-	}
 	if err := wdebug.RegisterRoute(mgmtRouterWithContextPath, runtimeCfg.DiagnosticsConfig().DebugSharedSecret()); err != nil {
 		return err
 	}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -687,6 +687,10 @@ func (s *Server) Start() (rErr error) {
 	if mgmtRouter != router {
 		// add middleware to management router as well if it is distinct
 		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, s.getManagementTracingOptions(baseInstallCfg))
+		// add debugging endpoints to management router
+		if err := addPprofRoutes(mgmtRouter); err != nil {
+			return werror.Wrap(err, "failed to register debugging routes")
+		}
 	}
 
 	// handle built-in runtime config changes


### PR DESCRIPTION
## Before this PR
/debug/pprof endpoints were registered on the main server

## After this PR
==COMMIT_MSG==
Do not register /debug/pprof routes without management port
==COMMIT_MSG==

## Possible downsides?
Possible workflow break for users using these endpoints

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/661)
<!-- Reviewable:end -->
