### PR TITLE
add debug-shared-secret-file

### DIFF
--- a/changelog/@unreleased/pr-673.v2.yml
+++ b/changelog/@unreleased/pr-673.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Users are able to pass in the path to the file that stores the shared
+    secret to the `debug-shared-secret-file` field. However, if the `debug-shared-secret`
+    field is defined, it takes precedence.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/673

--- a/changelog/@unreleased/pr-673.v2.yml
+++ b/changelog/@unreleased/pr-673.v2.yml
@@ -1,5 +1,5 @@
-type: fix
-fix:
+type: improvement
+improvement:
   description: Users are able to pass in the path to the file that stores the shared
     secret to the `debug-shared-secret-file` field. However, if the `debug-shared-secret`
     field is defined, it takes precedence.

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -31,7 +31,12 @@ type Runtime struct {
 }
 
 type DiagnosticsConfig struct {
+	// DebugSharedSecret is a string which, if provided, will be used as the access key to the diagnostics route.
+	// This takes precedence over DebugSharedSecretFile.
 	DebugSharedSecret string `yaml:"debug-shared-secret"`
+	// DebugSharedSecretFile is an on-disk location containing the shared secret. If DebugSharedSecretFile is provided and
+	// DebugSharedSecret is not, the content of the file will be used as the shared secret.
+	DebugSharedSecretFile string `yaml:"debug-shared-secret-file"`
 }
 
 type HealthChecksConfig struct {

--- a/config/zz_generated_refreshables.go
+++ b/config/zz_generated_refreshables.go
@@ -75,6 +75,7 @@ type RefreshableDiagnosticsConfig interface {
 	SubscribeToDiagnosticsConfig(func(DiagnosticsConfig)) (unsubscribe func())
 
 	DebugSharedSecret() refreshable.String
+	DebugSharedSecretFile() refreshable.String
 }
 
 type RefreshingDiagnosticsConfig struct {
@@ -104,6 +105,12 @@ func (r RefreshingDiagnosticsConfig) SubscribeToDiagnosticsConfig(consumer func(
 func (r RefreshingDiagnosticsConfig) DebugSharedSecret() refreshable.String {
 	return refreshable.NewString(r.MapDiagnosticsConfig(func(i DiagnosticsConfig) interface{} {
 		return i.DebugSharedSecret
+	}))
+}
+
+func (r RefreshingDiagnosticsConfig) DebugSharedSecretFile() refreshable.String {
+	return refreshable.NewString(r.MapDiagnosticsConfig(func(i DiagnosticsConfig) interface{} {
+		return i.DebugSharedSecretFile
 	}))
 }
 

--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/palantir/pkg/httpserver"
+	"github.com/palantir/witchcraft-go-server/v2/config"
+	"github.com/palantir/witchcraft-go-server/v2/witchcraft"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testDiagnosticType = "go.goroutines.v1"
+	testSecret         = "secretForTest"
+	tmpDir             = "/tmp"
+	tmpFilePath        = "/tmp/tmpFile"
+)
+
+func TestServer_DiagnosticsSharedSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		secret        string
+		runtimeConfig config.Runtime
+		prepare       func()
+		cleanup       func()
+	}{
+		{
+			name:          "no secret specified in runtime config",
+			secret:        "any secret should work",
+			runtimeConfig: config.Runtime{},
+		},
+		{
+			name:   "debug-shared-secret is specified in runtime config",
+			secret: testSecret,
+			runtimeConfig: config.Runtime{
+				DiagnosticsConfig: config.DiagnosticsConfig{DebugSharedSecret: testSecret},
+			},
+		},
+		{
+			name:   "debug-shared-secret-file is specified in runtime config",
+			secret: testSecret,
+			runtimeConfig: config.Runtime{
+				DiagnosticsConfig: config.DiagnosticsConfig{DebugSharedSecretFile: tmpFilePath},
+			},
+			prepare: func() {
+				err := os.MkdirAll(tmpDir, 0755)
+				require.NoError(t, err)
+				err = os.WriteFile(tmpFilePath, []byte(testSecret), 0644)
+				require.NoError(t, err)
+			},
+			cleanup: func() {
+				err := os.Remove(tmpFilePath)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:   "both debug-shared-secret and debug-shared-secret-file is specified in runtime config",
+			secret: testSecret,
+			runtimeConfig: config.Runtime{
+				DiagnosticsConfig: config.DiagnosticsConfig{
+					DebugSharedSecret: testSecret, DebugSharedSecretFile: filepath.Join(tmpDir, "fileDoesntExist"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.prepare != nil {
+				tt.prepare()
+				defer tt.cleanup()
+			}
+
+			port, err := httpserver.AvailablePort()
+			require.NoError(t, err)
+			server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, nil, io.Discard,
+				func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
+					return createTestServer(t, initFn, installCfg, logOutputBuffer).
+						WithRuntimeConfig(tt.runtimeConfig)
+				})
+
+			defer func() {
+				require.NoError(t, server.Close())
+			}()
+			defer cleanup()
+			client := testServerClient()
+
+			request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/debug/diagnostic/%s", port, basePath, testDiagnosticType), nil)
+			require.NoError(t, err)
+			request.Header.Set("Authorization", "Bearer "+tt.secret)
+			resp, err := client.Do(request)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			select {
+			case err := <-serverErr:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+}

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -196,7 +196,10 @@ func getSecretRefreshable(ctx context.Context, diagnosticsConfig config.Refresha
 		return nil, err
 	}
 	secretStringFromFileRefreshable := refreshable.NewString(fileRefreshable.Map(func(i interface{}) interface{} {
-		secretBytes := i.([]byte)
+		secretBytes, ok := i.([]byte)
+		if !ok {
+			return ""
+		}
 		return string(secretBytes)
 	}))
 	return secretStringFromFileRefreshable, nil

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -15,6 +15,7 @@
 package witchcraft
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	netpprof "net/http/pprof"
@@ -23,12 +24,14 @@ import (
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
 	"github.com/palantir/pkg/metrics"
+	"github.com/palantir/pkg/refreshable"
 	werror "github.com/palantir/witchcraft-go-error"
 	healthstatus "github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-server/v2/config"
 	"github.com/palantir/witchcraft-go-server/v2/status/routes"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/middleware"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/wdebug"
+	refreshablefile "github.com/palantir/witchcraft-go-server/v2/witchcraft/refreshable"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/v2/wrouter"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
@@ -44,8 +47,12 @@ func (s *Server) initRouters(installCfg config.Install) (rRouter wrouter.Router,
 }
 
 // addRoutes registers /debug/diagnostic/* and /status/*
-func (s *Server) addRoutes(mgmtRouterWithContextPath wrouter.Router, runtimeCfg config.RefreshableRuntime) error {
-	if err := wdebug.RegisterRoute(mgmtRouterWithContextPath, runtimeCfg.DiagnosticsConfig().DebugSharedSecret()); err != nil {
+func (s *Server) addRoutes(ctx context.Context, mgmtRouterWithContextPath wrouter.Router, runtimeCfg config.RefreshableRuntime) error {
+	secretRefreshable, err := getSecretRefreshable(ctx, runtimeCfg.DiagnosticsConfig())
+	if err != nil {
+		return err
+	}
+	if err := wdebug.RegisterRoute(mgmtRouterWithContextPath, secretRefreshable); err != nil {
 		return err
 	}
 
@@ -171,4 +178,26 @@ func heap(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprintf(w, "Could not dump heap: %s\n", err)
 		return
 	}
+}
+
+func getSecretRefreshable(ctx context.Context, diagnosticsConfig config.RefreshableDiagnosticsConfig) (refreshable.String, error) {
+	secretFromConfig := diagnosticsConfig.DebugSharedSecret()
+	secretFilePath := diagnosticsConfig.DebugSharedSecretFile()
+	// if both fields are undefined, then the server doesn't use a secret for the /debug/diagnostics/* route
+	if secretFromConfig.CurrentString() == "" && secretFilePath.CurrentString() == "" {
+		return refreshable.NewString(refreshable.NewDefaultRefreshable("")), nil
+	}
+
+	if secretFromConfig.CurrentString() != "" {
+		return secretFromConfig, nil
+	}
+	fileRefreshable, err := refreshablefile.NewFileRefreshable(ctx, secretFilePath.CurrentString())
+	if err != nil {
+		return nil, err
+	}
+	secretStringFromFileRefreshable := refreshable.NewString(fileRefreshable.Map(func(i interface{}) interface{} {
+		secretBytes := i.([]byte)
+		return string(secretBytes)
+	}))
+	return secretStringFromFileRefreshable, nil
 }

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -754,7 +754,7 @@ func (s *Server) Start() (rErr error) {
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any
 	// health/liveness/readiness configuration updated by initFn is applied.
-	if err := s.addRoutes(mgmtRouter, baseRefreshableRuntimeCfg); err != nil {
+	if err := s.addRoutes(ctx, mgmtRouter, baseRefreshableRuntimeCfg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
There is no way to pass in a file for the shared-secret for the diagnostics route. This forces the users to inline the shared-secret.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Users are able to pass in the path to the file that stores the shared secret to the `debug-shared-secret-file` field. However, if the `debug-shared-secret` field is defined, it takes precedence.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

