### PR TITLE
improvement: Emit metrics at a 30s frequency.

### DIFF
--- a/changelog/@unreleased/pr-704.v2.yml
+++ b/changelog/@unreleased/pr-704.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Emit metrics at a 30s frequency.
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/704

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -548,7 +548,7 @@ func (s *Server) WithHealthStatusChangeHandlers(handlers ...status.HealthStatusC
 }
 
 const (
-	defaultMetricEmitFrequency = time.Second * 60
+	defaultMetricEmitFrequency = time.Second * 30
 
 	ecvKeyPath        = "var/conf/encrypted-config-value.key"
 	installConfigPath = "var/conf/install.yml"


### PR DESCRIPTION
## Before this PR
Java implementations of witchcraft emit metrics at a 30s frequency. 

## After this PR
Align on emitting metrics at a 30s sample frequency. 
==COMMIT_MSG==
Emit metrics at a 30s frequency.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

