### PR TITLE
fix: Fix tls integration test to allow for go 1.21 upgrade.

### DIFF
--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -318,7 +318,7 @@ func TestClientTLS(t *testing.T) {
 	// Assert regular client receives error
 	_, err = testServerClient().Get(fmt.Sprintf("https://localhost:%d/example", port))
 	require.Error(t, err, "Client allowed to make request without cert")
-	assert.Contains(t, err.Error(), "tls: bad certificate")
+	assert.ErrorContains(t, err, "tls", "expected error to contain 'tls' in its string representation")
 
 	// Assert client w/ certs does not receive error
 	tlsConf, err := tlsconfig.NewClientConfig(tlsconfig.ClientRootCAFiles(path.Join(wd, "testdata/ca-cert.pem")), tlsconfig.ClientKeyPairFiles(path.Join(wd, "testdata/client-cert.pem"), path.Join(wd, "testdata/client-key.pem")))


### PR DESCRIPTION
## Before this PR
The go 1.20->1.21 version bump is failing because the TLS error strings changes between versions:
https://github.com/palantir/witchcraft-go-server/pull/760

## After this PR
==COMMIT_MSG==
Fix tls integration test to allow for go 1.21 upgrade.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

