### PR TITLE
improvement: Health change message logged at WARN for DEFERRING and REPAIRING

### DIFF
--- a/changelog/@unreleased/pr-775.v2.yml
+++ b/changelog/@unreleased/pr-775.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Health change message logged at WARN for DEFERRING and REPAIRING
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/775

--- a/status/logging_change_handler.go
+++ b/status/logging_change_handler.go
@@ -16,6 +16,7 @@ package status
 
 import (
 	"context"
+
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"

--- a/status/logging_change_handler.go
+++ b/status/logging_change_handler.go
@@ -16,8 +16,6 @@ package status
 
 import (
 	"context"
-	"net/http"
-
 	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/status"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
@@ -37,9 +35,12 @@ func logIfHealthChanged(ctx context.Context, previousHealth, newHealth health.He
 			"newHealthStatusCode":      newCode,
 			"newHealthStatus":          newHealth.Checks,
 		}
-		if newCode == http.StatusOK {
+		switch newCode {
+		case 200: // HEALTHY
 			svc1log.FromContext(ctx).Info("Health status code changed.", svc1log.SafeParams(params))
-		} else {
+		case 518, 520: // DEFERRING, REPAIRING
+			svc1log.FromContext(ctx).Warn("Health status code changed.", svc1log.SafeParams(params))
+		default:
 			svc1log.FromContext(ctx).Error("Health status code changed.", svc1log.SafeParams(params))
 		}
 		return

--- a/status/logging_change_handler_test.go
+++ b/status/logging_change_handler_test.go
@@ -76,6 +76,23 @@ func TestLoggingChangeHandler(t *testing.T) {
 			},
 		},
 		{
+			name: "log warn when new status code is 520",
+			prev: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": sources.UnhealthyHealthCheckResult("TEST", "message", map[string]interface{}{}),
+				},
+			},
+			curr: health.HealthStatus{
+				Checks: map[health.CheckType]health.HealthCheckResult{
+					"TEST": sources.RepairingHealthCheckResult("TEST", "message", map[string]interface{}{}),
+				},
+			},
+			expected: &expectedLog{
+				level: "WARN",
+				msg:   "Health status code changed.",
+			},
+		},
+		{
 			name: "log when checks differ",
 			prev: health.HealthStatus{
 				Checks: map[health.CheckType]health.HealthCheckResult{


### PR DESCRIPTION
`ERROR` logs are scary -- for health states we expect to recover, downgrade to `WARN`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/775)
<!-- Reviewable:end -->
