### PR TITLE
improvement: Upgrade witchcraft-go-logging to 1.53.0

### DIFF
--- a/changelog/@unreleased/pr-776.v2.yml
+++ b/changelog/@unreleased/pr-776.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Upgrade witchcraft-go-logging to 1.53.0
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/776

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/palantir/pkg/tlsconfig v1.3.0
 	github.com/palantir/witchcraft-go-error v1.34.0
 	github.com/palantir/witchcraft-go-health v1.15.0
-	github.com/palantir/witchcraft-go-logging v1.51.0
+	github.com/palantir/witchcraft-go-logging v1.53.0
 	github.com/palantir/witchcraft-go-params v1.31.0
 	github.com/palantir/witchcraft-go-tracing v1.33.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/palantir/witchcraft-go-error v1.34.0 h1:ir/stMAXuONEUXK1DIHV+3Bt/Ot7t
 github.com/palantir/witchcraft-go-error v1.34.0/go.mod h1:XMzUHbCg9vwOkMirfQxBtNnFIWBZo7UURXpCwOiwsmo=
 github.com/palantir/witchcraft-go-health v1.15.0 h1:rXKAefpl1fKkYhFS/BYR+NoebeFUn09CLXr1O4aRNOA=
 github.com/palantir/witchcraft-go-health v1.15.0/go.mod h1:MS0LBzTRcaCViJuIYzzwfZWBxFw0SNIRRglTve7t3x4=
-github.com/palantir/witchcraft-go-logging v1.51.0 h1:2KhBmbwfIR7ctEvVr1t9rJDhKiSD/BkPoI+/ITQtulU=
-github.com/palantir/witchcraft-go-logging v1.51.0/go.mod h1:/Y6GrI+AsKQfy28B3J88wWKadvfDm/E6X8FNhaPaQV0=
+github.com/palantir/witchcraft-go-logging v1.53.0 h1:aKC7Eld5rwEnJzDstY1c4FnNu5dFF7yHoXMT8FIvMvY=
+github.com/palantir/witchcraft-go-logging v1.53.0/go.mod h1:nl1cIo7vYQfFuznvd7TlWrcyLmkneKeeg4GTQHa2TFw=
 github.com/palantir/witchcraft-go-params v1.31.0 h1:WnSbITvTk/DYWK2aZ5xCTKnjv0McHVnk7BE3CuvnddE=
 github.com/palantir/witchcraft-go-params v1.31.0/go.mod h1:hspt+NCM0m7T8fjVwVFurdR9a+af7wcmPJYQJnqkdCM=
 github.com/palantir/witchcraft-go-tracing v1.33.0 h1:OHs2dEtfda0A4BTMGDjB2fZRR+oGQFJqp2HvJMlPWXo=

--- a/integration/recovery_test.go
+++ b/integration/recovery_test.go
@@ -143,6 +143,7 @@ func TestServerPanicRecoveryMiddleware(t *testing.T) {
 						"params": objmatcher.MapMatcher{
 							"stacktrace": objmatcher.NewAnyMatcher(),
 						},
+						"stacktrace": objmatcher.NewAnyMatcher(),
 						"unsafeParams": objmatcher.MapMatcher{
 							"recovered": objmatcher.NewEqualsMatcher("panic inside handler"),
 						},
@@ -204,6 +205,7 @@ func TestServerPanicRecoveryMiddleware(t *testing.T) {
 						"params": objmatcher.MapMatcher{
 							"stacktrace": objmatcher.NewAnyMatcher(),
 						},
+						"stacktrace": objmatcher.NewAnyMatcher(),
 						"unsafeParams": objmatcher.MapMatcher{
 							"recovered": objmatcher.NewEqualsMatcher("panic inside handler after write"),
 						},
@@ -262,6 +264,7 @@ func TestServerPanicRecoveryMiddleware(t *testing.T) {
 						"params": objmatcher.MapMatcher{
 							"stacktrace": objmatcher.NewAnyMatcher(),
 						},
+						"stacktrace": objmatcher.NewAnyMatcher(),
 						"unsafeParams": objmatcher.MapMatcher{
 							"recovered": objmatcher.NewEqualsMatcher("panic before handler"),
 						},
@@ -307,6 +310,7 @@ func TestServerPanicRecoveryMiddleware(t *testing.T) {
 						"params": objmatcher.MapMatcher{
 							"stacktrace": objmatcher.NewAnyMatcher(),
 						},
+						"stacktrace": objmatcher.NewAnyMatcher(),
 						"unsafeParams": objmatcher.MapMatcher{
 							"recovered": objmatcher.NewEqualsMatcher("panic after handler"),
 						},

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/diaglog/diag1log/thread_dump.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/diaglog/diag1log/thread_dump.go
@@ -38,6 +38,40 @@ func ThreadDumpV1FromGoroutines(goroutinesContent []byte) logging.ThreadDumpV1 {
 	return threads
 }
 
+func ThreadDumpV1ToGoroutines(threads logging.ThreadDumpV1) string {
+	var out strings.Builder
+	for _, thread := range threads.Threads {
+		if thread.Name != nil {
+			out.WriteString(*thread.Name)
+			out.WriteString(":\n")
+		}
+		for _, frame := range thread.StackTrace {
+			if frame.Procedure != nil {
+				if frame.Params["goroutineCreator"] == true {
+					out.WriteString("created by ")
+				}
+				out.WriteString(*frame.Procedure)
+				out.WriteString("(...)\n")
+			}
+			if frame.File != nil {
+				out.WriteByte('\t')
+				out.WriteString(*frame.File)
+				if frame.Line != nil {
+					out.WriteByte(':')
+					out.WriteString(strconv.Itoa(*frame.Line))
+				}
+				if frame.Address != nil {
+					out.WriteString(" +")
+					out.WriteString(*frame.Address)
+				}
+				out.WriteByte('\n')
+			}
+
+		}
+	}
+	return out.String()
+}
+
 var titleLinePattern = regexp.MustCompile(`^(goroutine (\d+) \[([^]]+)]):$`)
 
 func unmarshalThreadDump(goroutine []byte) logging.ThreadInfoV1 {

--- a/vendor/github.com/palantir/witchcraft-go-logging/wlog/logentry.go
+++ b/vendor/github.com/palantir/witchcraft-go-logging/wlog/logentry.go
@@ -82,9 +82,6 @@ func (m *MapValueEntries) AnyMapValue(key string, values map[string]interface{})
 	if len(values) == 0 {
 		return
 	}
-	if len(values) == 0 {
-		return
-	}
 	if m.anyMapValues == nil {
 		m.anyMapValues = make(map[string]map[string]interface{})
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/palantir/witchcraft-go-health/reporter
 github.com/palantir/witchcraft-go-health/sources
 github.com/palantir/witchcraft-go-health/sources/periodic
 github.com/palantir/witchcraft-go-health/status
-# github.com/palantir/witchcraft-go-logging v1.51.0
+# github.com/palantir/witchcraft-go-logging v1.53.0
 ## explicit; go 1.21
 github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging
 github.com/palantir/witchcraft-go-logging/internal/gopath


### PR DESCRIPTION
Excavator blocked in #770 due to change in logging output on panics (https://github.com/palantir/witchcraft-go-logging/pull/352)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-server/776)
<!-- Reviewable:end -->
