### PR TITLE
improvement: Tolerate missing client CA files at startup

### DIFF
--- a/changelog/@unreleased/pr-847.v2.yml
+++ b/changelog/@unreleased/pr-847.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Tolerate missing client CA files at startup
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/847

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -81,13 +81,10 @@ type Server struct {
 	useSelfSignedServerCertificate bool
 
 	// ignoreMissingClientCAFiles specifies whether the server should fall back to the default system CAs if
-	// there are any errors with parsing the certificates at the paths specified in serverConfig.ClientCAFiles.
-	// This option should be used when the server expects the CA certificates used to verify the
+	// there are any errors with reading any file at the paths specified in serverConfig.ClientCAFiles.
+	// This flag should be set to true the server expects the CA certificates used to verify the
 	// certificates of clients to exist at the paths specified in serverConfig.ClientCAFiles eventually,
 	// but not necessarily at startup.
-	//
-	// If false, the server will fail to start up if there are any issues parsing certificates from any of the paths
-	// specified in serverConfig.ClientCAFiles
 	ignoreMissingClientCAFiles bool
 
 	// manages storing and retrieving server state (idle, initializing, running)
@@ -375,7 +372,7 @@ func (s *Server) WithSelfSignedCertificate() *Server {
 }
 
 // WithIgnoreMissingClientCAFiles configures the server to fall back to the default system CAs if
-// there are any errors with parsing the certificates at the paths specified in serverConfig.ClientCAFiles.
+// there are any errors with reading any of the files at the paths specified in serverConfig.ClientCAFiles.
 // This option should be used when the server expects the CA certificates used to verify the
 // certificates of clients to exist at the paths specified in serverConfig.ClientCAFiles eventually,
 // but not necessarily at startup.

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -80,6 +80,16 @@ type Server struct {
 	// If false, the key material at the paths specified in serverConfig.CertFile and serverConfig.KeyFile is used.
 	useSelfSignedServerCertificate bool
 
+	// ignoreMissingClientCAFiles specifies whether the server should fall back to the default system CAs if
+	// there are any errors with parsing the certificates at the paths specified in serverConfig.ClientCAFiles.
+	// This option should be used when the server expects the CA certificates used to verify the
+	// certificates of clients to exist at the paths specified in serverConfig.ClientCAFiles eventually,
+	// but not necessarily at startup.
+	//
+	// If false, the server will fail to start up if there are any issues parsing certificates from any of the paths
+	// specified in serverConfig.ClientCAFiles
+	ignoreMissingClientCAFiles bool
+
 	// manages storing and retrieving server state (idle, initializing, running)
 	stateManager serverStateManager
 
@@ -361,6 +371,16 @@ func (s *Server) WithRuntimeConfigFromFile(fpath string) *Server {
 // using separate external mechanisms.
 func (s *Server) WithSelfSignedCertificate() *Server {
 	s.useSelfSignedServerCertificate = true
+	return s
+}
+
+// WithIgnoreMissingClientCAFiles configures the server to fall back to the default system CAs if
+// there are any errors with parsing the certificates at the paths specified in serverConfig.ClientCAFiles.
+// This option should be used when the server expects the CA certificates used to verify the
+// certificates of clients to exist at the paths specified in serverConfig.ClientCAFiles eventually,
+// but not necessarily at startup.
+func (s *Server) WithIgnoreMissingClientCAFiles() *Server {
+	s.ignoreMissingClientCAFiles = true
 	return s
 }
 


### PR DESCRIPTION
## Before this PR
Currently, `serverconfig.ClientCAFiles` specifies the paths the server expects the CA certificates used to verify the certificates of clients to exist. However, if at startup certificates don't exist there, or there is a failure to parse them, the server fails to come up. 

## After this PR
A server can now be configured fall back to the default system CAs if the certificates at paths specified in `serverconfig.ClientCAFiles` don't exist at startup time. This is achieved by constructing the sever using `WithIgnoreMissingClientCAFiles`.

==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?

