### PR TITLE
Improvement: Avoid server shutdown race conditions by adding new ServerShutdownInProgress state

### DIFF
--- a/changelog/@unreleased/pr-848.v2.yml
+++ b/changelog/@unreleased/pr-848.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Avoid server shutdown race conditions by adding new ServerShutdownInProgress
+    state
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/848

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -30,6 +30,7 @@ const (
 	ServerIdle ServerState = iota
 	ServerInitializing
 	ServerRunning
+	ServerShutdownInProgress
 )
 
 func (s ServerState) String() string {
@@ -40,6 +41,8 @@ func (s ServerState) String() string {
 		return "initializing"
 	case ServerRunning:
 		return "running"
+	case ServerShutdownInProgress:
+		return "shutdown in progress"
 	default:
 		return "unknown state: " + strconv.Itoa(int(s))
 	}
@@ -61,6 +64,8 @@ func (s *serverStateManager) Start() error {
 		return werror.Error("server is already initializing and must be stopped before it can be started again")
 	case ServerRunning:
 		return werror.Error("server is already running and must be stopped before it can be started again")
+	case ServerShutdownInProgress:
+		return werror.Error("server is in the process of shutting down and must complete before it can be started again")
 	default:
 		return werror.Error("server is in an unknown state and must be stopped before it can be started again")
 	}

--- a/witchcraft/server_state.go
+++ b/witchcraft/server_state.go
@@ -30,7 +30,7 @@ const (
 	ServerIdle ServerState = iota
 	ServerInitializing
 	ServerRunning
-	ServerShutdownInProgress
+	ServerShuttingDown
 )
 
 func (s ServerState) String() string {
@@ -41,8 +41,8 @@ func (s ServerState) String() string {
 		return "initializing"
 	case ServerRunning:
 		return "running"
-	case ServerShutdownInProgress:
-		return "shutdown in progress"
+	case ServerShuttingDown:
+		return "shutting down"
 	default:
 		return "unknown state: " + strconv.Itoa(int(s))
 	}
@@ -64,8 +64,8 @@ func (s *serverStateManager) Start() error {
 		return werror.Error("server is already initializing and must be stopped before it can be started again")
 	case ServerRunning:
 		return werror.Error("server is already running and must be stopped before it can be started again")
-	case ServerShutdownInProgress:
-		return werror.Error("server is in the process of shutting down and must complete before it can be started again")
+	case ServerShuttingDown:
+		return werror.Error("server is in the process of shutting down and must complete shutdown before it can be started again")
 	default:
 		return werror.Error("server is in an unknown state and must be stopped before it can be started again")
 	}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -17,6 +17,7 @@ package witchcraft
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"io"
 	"io/ioutil"
 	"math"
@@ -26,7 +27,6 @@ import (
 	"os/signal"
 	"reflect"
 	"runtime/debug"
-	"sync"
 	"syscall"
 	"time"
 
@@ -215,7 +215,7 @@ type Server struct {
 	httpServer *http.Server
 
 	// allows the server to wait until Close() or Shutdown() return prior to returning from Start()
-	shutdownFinished sync.WaitGroup
+	shutdownFinished chan struct{}
 }
 
 // InitFunc is a function type used to initialize a server. ctx is a context configured with loggers and is valid for
@@ -589,10 +589,26 @@ func (s *Server) Start() (rErr error) {
 	if err := s.stateManager.Start(); err != nil {
 		return err
 	}
-	// Reset state if server terminated without calling s.Close() or s.Shutdown()
+	// Channel can be nil if this is the first Start() or closed if the previous run ended with a Close() or Shutdown().
+	// Since stateManager.Start() succeeded, we know that no shutdown of a previous run is ongoing.
+	s.shutdownFinished = make(chan struct{})
+	// Ensure that state is reset to "ServerIdle" before Start() returns.
 	defer func() {
-		if s.State() != ServerIdle {
-			s.stateManager.setState(ServerIdle)
+		curState := s.State()
+		for {
+			switch curState {
+			case ServerIdle:
+				return
+			case ServerShutdownInProgress:
+				// Wait for s.Close() or s.Shutdown() to return if called.
+				// Once the below channel is closed, the state is guaranteed to be "ServerIdle".
+				<-s.shutdownFinished
+			default:
+				if s.stateManager.compareAndSwapState(curState, ServerIdle) {
+					return
+				}
+			}
+			curState = s.State()
 		}
 	}()
 
@@ -685,9 +701,6 @@ func (s *Server) Start() (rErr error) {
 
 	s.initStackTraceHandler(ctx)
 	s.initShutdownSignalHandler(ctx)
-
-	// wait for s.Close() or s.Shutdown() to return if called
-	defer s.shutdownFinished.Wait()
 
 	if s.initFn != nil {
 		traceReporter := wtracing.NewNoopReporter()
@@ -944,19 +957,21 @@ func (s *Server) State() ServerState {
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
-	s.shutdownFinished.Add(1)
-	defer s.shutdownFinished.Done()
-
 	s.svcLogger.Info("Shutting down server")
 	return stopServer(s, func(svr *http.Server) error {
-		return svr.Shutdown(ctx)
+		err := svr.Shutdown(ctx)
+		if err != nil && ctx.Err() != nil && errors.Is(err, ctx.Err()) {
+			// Server shutdown was interrupted by context completion, but this still results in a successful shutdown
+			return nil
+		} else if err != nil {
+			return err
+		} else {
+			return nil
+		}
 	})
 }
 
 func (s *Server) Close() error {
-	s.shutdownFinished.Add(1)
-	defer s.shutdownFinished.Done()
-
 	s.svcLogger.Info("Closing server")
 	return stopServer(s, func(svr *http.Server) error {
 		return svr.Close()
@@ -1035,10 +1050,27 @@ func decryptNodeValues(n *yamlv3.Node, kwt *encryptedconfigvalue.KeyWithType) er
 }
 
 func stopServer(s *Server, stopper func(s *http.Server) error) error {
-	if s.stateManager.State() == ServerIdle {
-		return werror.Error("server is not running")
+	// use compare and swap so that the server can only be stopped once
+	curState := s.stateManager.State()
+	for {
+		if curState == ServerIdle || curState == ServerShutdownInProgress {
+			// already shutting down or stopped
+			return nil
+		}
+		// state could be ServerRunning or ServerInitializing
+		if s.stateManager.compareAndSwapState(curState, ServerShutdownInProgress) {
+			break
+		}
+		curState = s.stateManager.State()
 	}
-	s.stateManager.setState(ServerIdle)
+	// Only commit to finishing the shutdown if we won the state swap
+	defer func() {
+		// can avoid compare and swap here because:
+		// - Nothing else is allowed to move the state from ServerShutdownInProgress to ServerIdle
+		// - Only one goroutine can ever be in this block at a time due to the above compare and swap
+		s.stateManager.setState(ServerIdle)
+		close(s.shutdownFinished)
+	}()
 	if s.httpServer == nil {
 		return nil
 	}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? --> 
Previously, there were several issues with server shutdown:
1. If shutdown was called multiple times, e.g. by different goroutines, all but one would return an error
2. If shutdown was called too frequently around when the first shutdown succeeded, the WaitGroup would panic
3. If the context was closed during a shutdown an error would be emitted
4. The server did not emit an error when restarting the server while a shutdown was in progress
5. Several other extremely unlikely race conditions (because Server has no locking)

Most clients will call `Shutdown` from multiple critical goroutines when they stop/fail unrecoverably. This introduces a race where the first caller begins the shutdown and the rest return errors. Clients often treat an error from Shutdown as a critical failure and `panic`. This can prevent a graceful shutdown from happening as expected, leading to the server being closed before connections are drained and `Start()` exiting with a non-nil error.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
A new server state has been added called "ServerShutdownInProgress". This is used to synchronize shutdown attempts and ensure that exactly one shutdown for any reason will actually do the work of stopping the server. `Start()` on exit checks if the state is a shutdown in progress, and if so waits for the shutdown winner to report completion before exiting. Only the shutdown winner is allowed to complete the shutdown by closing the channel and flipping the state to idle.

I've updated some of the existing usages of `setState` to use the better-protected `compareAndSwapState` with proper protections against concurrent state change attempts.

As a client, the changes are:
- Calling shutdown multiple times or from multiple goroutines will result in the server being shutdown once and additional attempts not performing any actions
- Calling shutdown with a closed context or with a context that closes during shutdown results in a less graceful shutdown (e.g. `Close()`) but will still return a nil error
- Various race conditions around shutdown can no longer occur

I've added the following tests:
1. Starting, stopping, and then starting a server again works as expected
2. Stopping a server multiple times results in a single shutdown with other callers getting nil errors
3. Calling shutdown with a cancelled context succeeds

==COMMIT_MSG==
Avoid server shutdown race conditions by adding new ServerShutdownInProgress state
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

