### PR TITLE
Add a subject to the selfSignedCert

### DIFF
--- a/changelog/@unreleased/pr-889.v2.yml
+++ b/changelog/@unreleased/pr-889.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: |
+    Set the Subject field for the self-signed certificate that is generated when "--use-self-signed-cert" is specified.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/889

--- a/witchcraft/server_run.go
+++ b/witchcraft/server_run.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -140,6 +141,10 @@ func newSelfSignedCertificate() (tls.Certificate, error) {
 		SerialNumber: big.NewInt(1),
 		NotBefore:    time.Now().Add(-30 * time.Second),
 		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{"Palantir"},
+		},
 	}
 	certDERBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
 	if err != nil {


### PR DESCRIPTION
## Before this PR
No subject/issuer is set for the self signed certificate, which is causing the `Empty issuer DN not allowed in X509Certificates` error when exercised with a Java client. According to RFC 5280 it is mandatory for there to be an issuer.

## After this PR
Set a subject for the self signed certificate which should resolve this problem. x509.CreateCertificate function will use the Subject field as the Issuer when the template is used as both the certificate and the parent certificate.


