### PR TITLE
feature: ENDPOINT_FIVE_HUNDREDS health check

### DIFF
--- a/changelog/@unreleased/pr-896.v2.yml
+++ b/changelog/@unreleased/pr-896.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: ENDPOINT_FIVE_HUNDREDS health check
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/896

--- a/witchcraft/internal/middleware/endpoint_five_hundreds.go
+++ b/witchcraft/internal/middleware/endpoint_five_hundreds.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/v2/wrouter"
+)
+
+const (
+	endpointFiveHundredsCheckType   = "ENDPOINT_FIVE_HUNDREDS"
+	endpointFiveHundredsWindowCount = 5
+	endpointFiveHundredsWindowSize  = 2 * time.Minute
+	endpointFiveHundredsMessage     = "There have been HTTP 500s returned by endpoints in every 2 minutes rolling period in the last 10 minutes. This indicates a non-transient error."
+)
+
+type EndpointFiveHundredsHealthCheck struct {
+	endpoints     sync.Map // map[string]*endpointFiveHundredsStatus
+	alwaysHealthy bool
+}
+
+// NewEndpointFiveHundredsHealthCheck creates a new EndpointFiveHundredsHealthCheck and starts its internal goroutine.
+// If alwaysHealthy is true, the health check will always return HEALTHY but any failing/broken endpoints will still be
+// included in the results params map as information.
+func NewEndpointFiveHundredsHealthCheck(ctx context.Context, alwaysHealthy bool) *EndpointFiveHundredsHealthCheck {
+	e := &EndpointFiveHundredsHealthCheck{alwaysHealthy: alwaysHealthy}
+	ticker := time.Tick(endpointFiveHundredsWindowSize)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker:
+				e.shiftWindow()
+			}
+		}
+	}()
+	return e
+}
+
+func (e *EndpointFiveHundredsHealthCheck) MarkResponse(route wrouter.RouteSpec, code int) {
+	endpoint := fmt.Sprintf("%s %s", route.Method, route.PathTemplate)
+	statusI, _ := e.endpoints.LoadOrStore(endpoint, &endpointFiveHundredsStatus{})
+	status := statusI.(*endpointFiveHundredsStatus)
+
+	if code == http.StatusInternalServerError {
+		status.markError()
+	} else if code < 400 {
+		status.markSuccess()
+	}
+}
+
+func (e *EndpointFiveHundredsHealthCheck) HealthStatus(context.Context) health.HealthStatus {
+	status := e.currentStatus()
+	if status == nil {
+		return health.HealthStatus{Checks: map[health.CheckType]health.HealthCheckResult{}}
+	}
+	return health.HealthStatus{Checks: map[health.CheckType]health.HealthCheckResult{status.Type: *status}}
+}
+
+func (e *EndpointFiveHundredsHealthCheck) currentStatus() *health.HealthCheckResult {
+	hasEndpoints := false
+	failingEndpoints := make([]string, 0)
+	brokenEndpoints := make([]string, 0)
+	e.endpoints.Range(func(key, value interface{}) bool {
+		hasEndpoints = true
+		endpoint := key.(string)
+		status := value.(*endpointFiveHundredsStatus)
+		if status.isError() {
+			if status.hadSuccessEver {
+				failingEndpoints = append(failingEndpoints, endpoint)
+			} else {
+				brokenEndpoints = append(brokenEndpoints, endpoint)
+			}
+		}
+		return true
+	})
+	slices.Sort(brokenEndpoints)
+	slices.Sort(failingEndpoints)
+
+	// If no endpoints have been called, return an empty status.
+	if !hasEndpoints {
+		return nil
+	}
+	result := health.HealthCheckResult{
+		Type:  endpointFiveHundredsCheckType,
+		State: health.New_HealthState(health.HealthState_HEALTHY),
+	}
+	if len(failingEndpoints) > 0 || len(brokenEndpoints) > 0 {
+		result.Message = ptrTo(endpointFiveHundredsMessage)
+		result.Params = map[string]interface{}{
+			"brokenEndpoints":  brokenEndpoints,  // endpoints that have never returned a non-500 status code
+			"failingEndpoints": failingEndpoints, // endpoints that have returned 500 status codes in every window
+		}
+		if !e.alwaysHealthy {
+			result.State = health.New_HealthState(health.HealthState_WARNING)
+		}
+	}
+	return &result
+}
+
+func (e *EndpointFiveHundredsHealthCheck) shiftWindow() {
+	e.endpoints.Range(func(key, value interface{}) bool {
+		value.(*endpointFiveHundredsStatus).shift()
+		return true
+	})
+}
+
+// endpointFiveHundredsStatus is a struct that keeps track of the 500 status codes for a single endpoint.
+type endpointFiveHundredsStatus struct {
+	mutex sync.RWMutex
+	// windows[0] is the current window, windows[1] is the previous window, etc.
+	// Only windows[1:] are used to determine if the endpoint is unhealthy.
+	// true indicates a 500 occurred in that window.
+	windows [1 + endpointFiveHundredsWindowCount]bool
+	// hadSuccessEver is true if the endpoint has ever returned a non-500 status code.
+	hadSuccessEver bool
+}
+
+func (e *endpointFiveHundredsStatus) markError() {
+	e.mutex.Lock()
+	e.windows[0] = true
+	e.mutex.Unlock()
+}
+
+func (e *endpointFiveHundredsStatus) markSuccess() {
+	e.mutex.Lock()
+	e.windows[0] = false
+	e.hadSuccessEver = true
+	e.mutex.Unlock()
+}
+
+func (e *endpointFiveHundredsStatus) isError() bool {
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+	// If any windows are false, the endpoint is healthy.
+	for i := 1; i < len(e.windows); i++ {
+		if !e.windows[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *endpointFiveHundredsStatus) shift() {
+	e.mutex.Lock()
+	// shift each window to the right, starting from the end
+	for i := len(e.windows) - 1; i > 0; i-- {
+		e.windows[i] = e.windows[i-1]
+	}
+	// reset the current window
+	e.windows[0] = false
+	e.mutex.Unlock()
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/witchcraft/internal/middleware/endpoint_five_hundreds.go
+++ b/witchcraft/internal/middleware/endpoint_five_hundreds.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	endpointFiveHundredsCheckType   = "ENDPOINT_FIVE_HUNDREDS"
-	endpointFiveHundredsWindowCount = 5
-	endpointFiveHundredsWindowSize  = 2 * time.Minute
-	endpointFiveHundredsMessage     = "There have been HTTP 500s returned by endpoints in every 2 minutes rolling period in the last 10 minutes. This indicates a non-transient error."
+	endpointFiveHundredsCheckType              = "ENDPOINT_FIVE_HUNDREDS"
+	endpointFiveHundredsWindowCount            = 5
+	endpointFiveHundredsWindowSize             = 2 * time.Minute
+	endpointFiveHundredsMessage                = "There have been HTTP 500s returned by endpoints in every 2 minutes rolling period in the last 10 minutes. This indicates a non-transient error."
+	endpointFiveHundredsBrokenEndpointsMessage = "At least one endpoint is consistently failing since startup"
 )
 
 type EndpointFiveHundredsHealthCheck struct {
@@ -106,7 +107,11 @@ func (e *EndpointFiveHundredsHealthCheck) currentStatus() *health.HealthCheckRes
 		State: health.New_HealthState(health.HealthState_HEALTHY),
 	}
 	if len(failingEndpoints) > 0 || len(brokenEndpoints) > 0 {
-		result.Message = ptrTo(endpointFiveHundredsMessage)
+		message := endpointFiveHundredsMessage
+		if len(brokenEndpoints) > 0 {
+			message += "\n" + endpointFiveHundredsBrokenEndpointsMessage
+		}
+		result.Message = &message
 		result.Params = map[string]interface{}{
 			"brokenEndpoints":  brokenEndpoints,  // endpoints that have never returned a non-500 status code
 			"failingEndpoints": failingEndpoints, // endpoints that have returned 500 status codes in every window
@@ -170,8 +175,4 @@ func (e *endpointFiveHundredsStatus) shift() {
 	// reset the current window
 	e.windows[0] = false
 	e.mutex.Unlock()
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/witchcraft/internal/middleware/endpoint_five_hundreds_test.go
+++ b/witchcraft/internal/middleware/endpoint_five_hundreds_test.go
@@ -90,7 +90,7 @@ func TestEndpointFiveHundredsHealthCheck(t *testing.T) {
 			},
 			Expected: &health.HealthCheckResult{
 				Type:    endpointFiveHundredsCheckType,
-				Message: ptrTo(endpointFiveHundredsMessage),
+				Message: ptrTo(endpointFiveHundredsMessage + "\n" + endpointFiveHundredsBrokenEndpointsMessage),
 				State:   health.New_HealthState(health.HealthState_WARNING),
 				Params: map[string]interface{}{
 					"brokenEndpoints":  []string{"GET /test"},
@@ -168,7 +168,7 @@ func TestEndpointFiveHundredsHealthCheck(t *testing.T) {
 			Expected: &health.HealthCheckResult{
 				Type:    endpointFiveHundredsCheckType,
 				State:   health.New_HealthState(health.HealthState_HEALTHY),
-				Message: ptrTo(endpointFiveHundredsMessage),
+				Message: ptrTo(endpointFiveHundredsMessage + "\n" + endpointFiveHundredsBrokenEndpointsMessage),
 				Params: map[string]interface{}{
 					"brokenEndpoints":  []string{"GET /test"},
 					"failingEndpoints": []string{},
@@ -187,7 +187,7 @@ func TestEndpointFiveHundredsHealthCheck(t *testing.T) {
 			},
 			Expected: &health.HealthCheckResult{
 				Type:    endpointFiveHundredsCheckType,
-				Message: ptrTo(endpointFiveHundredsMessage),
+				Message: ptrTo(endpointFiveHundredsMessage + "\n" + endpointFiveHundredsBrokenEndpointsMessage),
 				State:   health.New_HealthState(health.HealthState_WARNING),
 				Params: map[string]interface{}{
 					"brokenEndpoints":  []string{"GET /test"},
@@ -217,4 +217,8 @@ func TestEndpointFiveHundredsHealthCheck(t *testing.T) {
 		})
 	}
 
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
 }

--- a/witchcraft/internal/middleware/endpoint_five_hundreds_test.go
+++ b/witchcraft/internal/middleware/endpoint_five_hundreds_test.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-health/conjure/witchcraft/api/health"
+	"github.com/palantir/witchcraft-go-server/v2/wrouter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointFiveHundredsHealthCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	endpoint := wrouter.RouteSpec{Method: "GET", PathTemplate: "/test"}
+	endpoint2 := wrouter.RouteSpec{Method: "POST", PathTemplate: "/test"}
+	endpoint3 := wrouter.RouteSpec{Method: "DELETE", PathTemplate: "/test"}
+
+	for _, tt := range []struct {
+		Name           string
+		AlwaysHealthy  bool
+		EarlierSuccess bool
+		Responses      [6]map[wrouter.RouteSpec][]int
+		Expected       *health.HealthCheckResult
+	}{
+		{
+			Name:      "No data",
+			Responses: [6]map[wrouter.RouteSpec][]int{},
+			Expected:  nil,
+		},
+		{
+			Name: "200 in window 0",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {200}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:  endpointFiveHundredsCheckType,
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+		{
+			Name: "500 in window 0",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:  endpointFiveHundredsCheckType,
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+		{
+			Name: "All 200s",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {200}},
+				{endpoint: {200}},
+				{endpoint: {200}},
+				{endpoint: {200}},
+				{endpoint: {200}},
+				{endpoint: {200}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:  endpointFiveHundredsCheckType,
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+		{
+			Name: "All 500s",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:    endpointFiveHundredsCheckType,
+				Message: ptrTo(endpointFiveHundredsMessage),
+				State:   health.New_HealthState(health.HealthState_WARNING),
+				Params: map[string]interface{}{
+					"brokenEndpoints":  []string{"GET /test"},
+					"failingEndpoints": []string{},
+				},
+			},
+		},
+		{
+			Name:           "All 500s with earlier success",
+			EarlierSuccess: true,
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:    endpointFiveHundredsCheckType,
+				Message: ptrTo(endpointFiveHundredsMessage),
+				State:   health.New_HealthState(health.HealthState_WARNING),
+				Params: map[string]interface{}{
+					"brokenEndpoints":  []string{},
+					"failingEndpoints": []string{"GET /test"},
+				},
+			},
+		},
+		{
+			Name: "Mix 200s 500s",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}},
+				{endpoint: {200}},
+				{endpoint: {500}},
+				{endpoint: {200}},
+				{endpoint: {500}},
+				{endpoint: {200}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:  endpointFiveHundredsCheckType,
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+		{
+			Name: "Mix 200s 500s same window",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {200, 500}},
+				{endpoint: {200, 500}},
+				{endpoint: {200, 500}},
+				{endpoint: {400, 500}},
+				{endpoint: {400, 500}},
+				{endpoint: {400, 500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:    endpointFiveHundredsCheckType,
+				Message: ptrTo(endpointFiveHundredsMessage),
+				State:   health.New_HealthState(health.HealthState_WARNING),
+				Params: map[string]interface{}{
+					"brokenEndpoints":  []string{},
+					"failingEndpoints": []string{"GET /test"},
+				},
+			},
+		},
+		{
+			Name:          "Always healthy",
+			AlwaysHealthy: true,
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+				{endpoint: {500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:    endpointFiveHundredsCheckType,
+				State:   health.New_HealthState(health.HealthState_HEALTHY),
+				Message: ptrTo(endpointFiveHundredsMessage),
+				Params: map[string]interface{}{
+					"brokenEndpoints":  []string{"GET /test"},
+					"failingEndpoints": []string{},
+				},
+			},
+		},
+		{
+			Name: "multiple endpoints",
+			Responses: [6]map[wrouter.RouteSpec][]int{
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+				{endpoint: {500}, endpoint2: {200}, endpoint3: {200, 500}},
+			},
+			Expected: &health.HealthCheckResult{
+				Type:    endpointFiveHundredsCheckType,
+				Message: ptrTo(endpointFiveHundredsMessage),
+				State:   health.New_HealthState(health.HealthState_WARNING),
+				Params: map[string]interface{}{
+					"brokenEndpoints":  []string{"GET /test"},
+					"failingEndpoints": []string{"DELETE /test"},
+				},
+			},
+		},
+	} {
+		t.Run(tt.Name, func(t *testing.T) {
+			healthcheck := NewEndpointFiveHundredsHealthCheck(ctx, tt.AlwaysHealthy)
+
+			if tt.EarlierSuccess {
+				healthcheck.MarkResponse(endpoint, 200)
+				healthcheck.shiftWindow()
+			}
+
+			for _, window := range tt.Responses {
+				for routeSpec, codes := range window {
+					for _, code := range codes {
+						healthcheck.MarkResponse(routeSpec, code)
+					}
+				}
+				healthcheck.shiftWindow()
+			}
+
+			assert.Equal(t, tt.Expected, healthcheck.currentStatus())
+		})
+	}
+
+}

--- a/witchcraft/internal/middleware/request_test.go
+++ b/witchcraft/internal/middleware/request_test.go
@@ -85,7 +85,7 @@ func TestRequestTelemetryMiddleware(t *testing.T) {
 			),
 		),
 		wrouter.RootRouterParamAddRouteHandlerMiddleware(
-			NewRouteTelemetry(metricsRegistry),
+			NewRouteTelemetry(metricsRegistry, nil),
 		),
 	)
 	err := r.Register(http.MethodGet, "/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -173,7 +173,7 @@ func TestRequestTelemetryMiddleware(t *testing.T) {
 
 func TestRequestMetricRequestMeterMiddleware(t *testing.T) {
 	r := metrics.NewRootMetricsRegistry()
-	reqMiddleware := NewRouteTelemetry(r)
+	reqMiddleware := NewRouteTelemetry(r, nil)
 
 	now = func() time.Time { return time.UnixMilli(0) }
 	w := httptest.NewRecorder()
@@ -235,7 +235,7 @@ func TestRequestMetricHandlerWithTags(t *testing.T) {
 				nil,
 				r,
 			)),
-			wrouter.RootRouterParamAddRouteHandlerMiddleware(NewRouteTelemetry(r)),
+			wrouter.RootRouterParamAddRouteHandlerMiddleware(NewRouteTelemetry(r, nil)),
 		)
 
 		authResource := wresource.New("AuthResource", wRouter)
@@ -325,7 +325,7 @@ func TestRequestDisableTelemetry(t *testing.T) {
 	spanLog := trc1log.NewFromCreator(&spanOutput, wlogzap.LoggerProvider().NewLogger)
 
 	metricRegistry := metrics.NewRootMetricsRegistry()
-	reqRouteTelemetryMiddleware := NewRouteTelemetry(metricRegistry)
+	reqRouteTelemetryMiddleware := NewRouteTelemetry(metricRegistry, nil)
 
 	tracer, err := wzipkin.NewTracer(spanLog)
 	require.NoError(t, err)

--- a/witchcraft/internal/middleware/route.go
+++ b/witchcraft/internal/middleware/route.go
@@ -30,7 +30,7 @@ import (
 	"github.com/palantir/witchcraft-go-tracing/wtracing/propagation/b3"
 )
 
-func NewRouteTelemetry(mr metrics.Registry) wrouter.RouteHandlerMiddleware {
+func NewRouteTelemetry(mr metrics.Registry, endpoint500s *EndpointFiveHundredsHealthCheck) wrouter.RouteHandlerMiddleware {
 	return func(rw http.ResponseWriter, req *http.Request, reqVals wrouter.RequestVals, next wrouter.RouteRequestHandler) {
 		if reqVals.DisableTelemetry {
 			next(rw, req, reqVals)
@@ -47,6 +47,7 @@ func NewRouteTelemetry(mr metrics.Registry) wrouter.RouteHandlerMiddleware {
 			duration := now().Sub(start)
 			newRouteRequestLog(req, reqVals, lrw, duration)
 			markRequestMetricRequestMeter(mr, req, reqVals, lrw, duration)
+			markEndpointFiveHundredsHealthCheck(endpoint500s, reqVals, lrw)
 		}()
 
 		// Add a panic recovery after the context is fully configured to maximize traceability.
@@ -139,5 +140,11 @@ func markRequestMetricRequestMeter(mr metrics.Registry, req *http.Request, reqVa
 	mr.Histogram("server.response.size", reqVals.MetricTags...).Update(int64(lrw.Size()))
 	if lrw.Status()/100 == 5 {
 		mr.Meter("server.response.error", reqVals.MetricTags...).Mark(1)
+	}
+}
+
+func markEndpointFiveHundredsHealthCheck(hc *EndpointFiveHundredsHealthCheck, reqVals wrouter.RequestVals, lrw loggingResponseWriter) {
+	if hc != nil {
+		hc.MarkResponse(reqVals.Spec, lrw.Status())
 	}
 }

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -86,7 +86,7 @@ func (s *Server) addRoutes(ctx context.Context, mgmtRouterWithContextPath wroute
 	return nil
 }
 
-func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.RootRegistry, tracerOptions []wtracing.TracerOption) {
+func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.RootRegistry, endpoint500s *middleware.EndpointFiveHundredsHealthCheck, tracerOptions []wtracing.TracerOption) {
 	rootRouter.AddRequestHandlerMiddleware(
 		// add middleware that injects loggers into request context, extracts UID, SID, and TokenID
 		// into context for loggers, sets a tracer on the context, starts a root span and sets it on the context,
@@ -109,7 +109,7 @@ func (s *Server) addMiddleware(rootRouter wrouter.RootRouter, registry metrics.R
 	rootRouter.AddRequestHandlerMiddleware(s.handlers...)
 
 	// add route middleware
-	rootRouter.AddRouteHandlerMiddleware(middleware.NewRouteTelemetry(registry))
+	rootRouter.AddRouteHandlerMiddleware(middleware.NewRouteTelemetry(registry, endpoint500s))
 
 	// add not found handler
 	rootRouter.RegisterNotFoundHandler(httpserver.NewJSONHandler(

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -51,6 +51,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/v2/config"
 	"github.com/palantir/witchcraft-go-server/v2/status"
 	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/dependencyhealth"
+	"github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/middleware"
 	refreshablehealth "github.com/palantir/witchcraft-go-server/v2/witchcraft/internal/refreshable"
 	refreshablefile "github.com/palantir/witchcraft-go-server/v2/witchcraft/refreshable"
 	"github.com/palantir/witchcraft-go-server/v2/wrouter"
@@ -159,6 +160,12 @@ type Server struct {
 	// example, if the map is set to {"timer":{"5m":{}}}, then the value for "5m" will be omitted from all timer metric
 	// output. If nil, the default value is the map returned by defaultMetricTypeValuesBlacklist().
 	metricTypeValuesBlacklist map[string]map[string]struct{}
+
+	// endpoint500sHealthCheckFunc builds the ENDPOINT_FIVE_HUNDREDS health check source. If nil, the check is disabled.
+	// The health check source is enabled by default.
+	// Use WithDisableEndpointFiveHundredsHealthCheck to disable the health check.
+	// Use WithAlwaysHealthyEndpointFiveHundredsHealthCheck to always report the health check as healthy.
+	endpoint500sHealthCheckFunc func(ctx context.Context) *middleware.EndpointFiveHundredsHealthCheck
 
 	// specifies the TLS client authentication mode used by the server. If not specified, the default value is
 	// tls.NoClientCert.
@@ -527,6 +534,20 @@ func (s *Server) WithMetricTypeValuesBlacklist(blacklist map[string]map[string]s
 	return s
 }
 
+func (s *Server) WithDisableEndpointFiveHundredsHealthCheck() *Server {
+	s.endpoint500sHealthCheckFunc = func(ctx context.Context) *middleware.EndpointFiveHundredsHealthCheck {
+		return nil
+	}
+	return s
+}
+
+func (s *Server) WithAlwaysHealthyEndpointFiveHundredsHealthCheck() *Server {
+	s.endpoint500sHealthCheckFunc = func(ctx context.Context) *middleware.EndpointFiveHundredsHealthCheck {
+		return middleware.NewEndpointFiveHundredsHealthCheck(ctx, true)
+	}
+	return s
+}
+
 // WithLoggerStdoutWriter configures the writer that loggers will write to IF they are configured to write to STDOUT.
 // This configuration is typically only used in specialized scenarios (for example, to write logger output to an
 // in-memory buffer rather than Stdout for tests).
@@ -677,14 +698,21 @@ func (s *Server) Start() (rErr error) {
 		}
 	}
 
+	var endpoint500s *middleware.EndpointFiveHundredsHealthCheck
+	if s.endpoint500sHealthCheckFunc != nil {
+		endpoint500s = s.endpoint500sHealthCheckFunc(ctx)
+	} else {
+		endpoint500s = middleware.NewEndpointFiveHundredsHealthCheck(ctx, false)
+	}
+
 	// initialize routers
 	router, mgmtRouter := s.initRouters(baseInstallCfg)
 
 	// add middleware
-	s.addMiddleware(router.RootRouter(), metricsRegistry, s.getApplicationTracingOptions(baseInstallCfg))
+	s.addMiddleware(router.RootRouter(), metricsRegistry, endpoint500s, s.getApplicationTracingOptions(baseInstallCfg))
 	if mgmtRouter != router {
 		// add middleware to management router as well if it is distinct
-		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, s.getManagementTracingOptions(baseInstallCfg))
+		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, endpoint500s, s.getManagementTracingOptions(baseInstallCfg))
 		// add debugging endpoints to management router
 		if err := addPprofRoutes(mgmtRouter); err != nil {
 			return werror.Wrap(err, "failed to register debugging routes")

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -534,6 +534,7 @@ func (s *Server) WithMetricTypeValuesBlacklist(blacklist map[string]map[string]s
 	return s
 }
 
+// WithDisableEndpointFiveHundredsHealthCheck disables the ENDPOINT_FIVE_HUNDREDS healthcheck.
 func (s *Server) WithDisableEndpointFiveHundredsHealthCheck() *Server {
 	s.endpoint500sHealthCheckFunc = func(ctx context.Context) *middleware.EndpointFiveHundredsHealthCheck {
 		return nil
@@ -541,6 +542,8 @@ func (s *Server) WithDisableEndpointFiveHundredsHealthCheck() *Server {
 	return s
 }
 
+// WithAlwaysHealthyEndpointFiveHundredsHealthCheck configures the server to always report the ENDPOINT_FIVE_HUNDREDS
+// as healthy, even if the parameters include failing or broken endpoints.
 func (s *Server) WithAlwaysHealthyEndpointFiveHundredsHealthCheck() *Server {
 	s.endpoint500sHealthCheckFunc = func(ctx context.Context) *middleware.EndpointFiveHundredsHealthCheck {
 		return middleware.NewEndpointFiveHundredsHealthCheck(ctx, true)


### PR DESCRIPTION
Adds a ENDPOINT_FIVE_HUNDREDS that triggers a WARNING state when one or more wrouter endpoints returns only `500 Internal Server Error` in each 2 minute bucket over a 10 minute period.


