### PR TITLE
Add counter metric tracking main server connection state changes.

### DIFF
--- a/changelog/@unreleased/pr-911.v2.yml
+++ b/changelog/@unreleased/pr-911.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: |
+    Add counter metric tracking main server connection state changes.
+  links:
+    - https://github.com/palantir/witchcraft-go-server/pull/911
+

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -86,7 +86,8 @@ func TestEmitMetrics(t *testing.T) {
 		seenUptime,
 		seenResponseSize,
 		seenRequestSize,
-		seenResponseError bool
+		seenResponseError,
+		seenConnStateChange bool
 	)
 	for _, metricLog := range metricLogs {
 		switch metricLog.MetricName {
@@ -177,6 +178,11 @@ func TestEmitMetrics(t *testing.T) {
 				"go_version": runtime.Version(),
 			}, metricLog.Tags)
 			assert.NotZero(t, metricLog.Values["value"])
+		case "server.conn_state_change":
+			seenConnStateChange = true
+			assert.Equal(t, "counter", metricLog.MetricType, "server.conn_state_change metric had incorrect type")
+			assert.NotNil(t, metricLog.Values["count"])
+			assert.NotEmpty(t, metricLog.Tags["state"], "server.conn_state_change metric did not have 'state' tag")
 		default:
 			assert.Fail(t, "unexpected metric encountered", "%s", metricLog.MetricName)
 		}
@@ -190,6 +196,7 @@ func TestEmitMetrics(t *testing.T) {
 	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
 	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
 	assert.True(t, seenUptime, "server.uptime metric was not emitted")
+	assert.True(t, seenConnStateChange, "server.conn_state_change metric was not emitted")
 
 	select {
 	case err := <-serverErr:

--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -454,7 +454,8 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		seenResponseSize,
 		seenRequestSize,
 		seenResponseError,
-		seenUptime bool
+		seenUptime,
+		seenConnStateChange bool
 	)
 	for _, metricLog := range metricLogs {
 		switch metricLog.MetricName {
@@ -540,6 +541,9 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			seenUptime = true
 			assert.Equal(t, "gauge", metricLog.MetricType, "server.uptime metric had incorrect type")
 			assert.NotZero(t, metricLog.Values["value"])
+		case "server.conn_state_change":
+			seenConnStateChange = true
+			assert.Equal(t, "counter", metricLog.MetricType, "server.conn_state_change metric had incorrect type")
 		default:
 			assert.Fail(t, "unexpected metric encountered", "%s", metricLog.MetricName)
 		}
@@ -552,6 +556,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
 	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
 	assert.True(t, seenUptime, "server.uptime metric was not emitted")
+	assert.True(t, seenConnStateChange, "server.conn_state_change metric was not emitted")
 
 	select {
 	case err := <-serverErr:
@@ -611,7 +616,8 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		seenResponseSize,
 		seenRequestSize,
 		seenResponseError,
-		seenUptime bool
+		seenUptime,
+		seenConnStateChange bool
 	)
 	for _, metricLog := range metricLogs {
 		switch metricLog.MetricName {
@@ -665,6 +671,10 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 			seenUptime = true
 			assert.Equal(t, "gauge", metricLog.MetricType, "server.uptime metric had incorrect type")
 			assert.NotZero(t, metricLog.Values["value"])
+		case "server.conn_state_change":
+			seenConnStateChange = true
+			assert.Equal(t, "counter", metricLog.MetricType, "server.conn_state_change metric had incorrect type")
+			assert.NotNil(t, metricLog.Values["count"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
 		}
@@ -677,6 +687,7 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
 	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
 	assert.True(t, seenUptime, "server.uptime metric was not emitted")
+	assert.True(t, seenConnStateChange, "server.conn_state_change metric was not emitted")
 
 	select {
 	case err := <-serverErr:
@@ -737,7 +748,8 @@ func TestMetricsBlacklist(t *testing.T) {
 		seenResponseTimer,
 		seenResponseSize,
 		seenRequestSize,
-		seenResponseError bool
+		seenResponseError,
+		seenConnStateChange bool
 	)
 	for _, metricLog := range metricLogs {
 		switch metricLog.MetricName {
@@ -761,6 +773,10 @@ func TestMetricsBlacklist(t *testing.T) {
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
 			assert.NotZero(t, metricLog.Values["count"])
+		case "server.conn_state_change":
+			seenConnStateChange = true
+			assert.Equal(t, "counter", metricLog.MetricType, "server.conn_state_change metric had incorrect type")
+			assert.NotZero(t, metricLog.Values["count"])
 		default:
 			assert.Fail(t, "unexpected metric encountered: %s", metricLog.MetricName)
 		}
@@ -773,6 +789,7 @@ func TestMetricsBlacklist(t *testing.T) {
 	assert.True(t, seenResponseTimer, "server.response metric was not emitted")
 	assert.True(t, seenResponseSize, "server.response.size metric was not emitted")
 	assert.True(t, seenResponseError, "server.response.error metric was not emitted")
+	assert.True(t, seenConnStateChange, "server.conn_state_change metric was not emitted")
 
 	select {
 	case err := <-serverErr:

--- a/witchcraft/server_run.go
+++ b/witchcraft/server_run.go
@@ -24,6 +24,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,7 +34,12 @@ import (
 	"github.com/palantir/witchcraft-go-server/v2/config"
 )
 
-func (s *Server) newServer(productName string, serverConfig config.Server, handler http.Handler) (rHTTPServer *http.Server, rStart func() error, rShutdown func(context.Context) error, rErr error) {
+func (s *Server) newServer(
+	productName string,
+	serverConfig config.Server,
+	handler http.Handler,
+	connStateFunc func(net.Conn, http.ConnState),
+) (rHTTPServer *http.Server, rStart func() error, rShutdown func(context.Context) error, rErr error) {
 	return newServerStartShutdownFns(
 		serverConfig,
 		s.useSelfSignedServerCertificate,
@@ -41,6 +47,7 @@ func (s *Server) newServer(productName string, serverConfig config.Server, handl
 		productName,
 		s.svcLogger,
 		handler,
+		connStateFunc,
 	)
 }
 
@@ -53,6 +60,7 @@ func (s *Server) newMgmtServer(productName string, serverConfig config.Server, h
 		productName+"-management",
 		s.svcLogger,
 		handler,
+		nil,
 	)
 	return start, shutdown, err
 }
@@ -64,6 +72,7 @@ func newServerStartShutdownFns(
 	serverName string,
 	svcLogger svc1log.Logger,
 	handler http.Handler,
+	connStateFunc func(net.Conn, http.ConnState),
 ) (rHTTPServer *http.Server, start func() error, shutdown func(context.Context) error, rErr error) {
 	tlsConfig, err := newTLSConfig(serverConfig, useSelfSignedServerCertificate, clientAuthType)
 	if err != nil {
@@ -75,6 +84,9 @@ func newServerStartShutdownFns(
 		Addr:      addr,
 		TLSConfig: tlsConfig,
 		Handler:   handler,
+	}
+	if connStateFunc != nil {
+		httpServer.ConnState = connStateFunc
 	}
 	return httpServer, func() error {
 		svcLogger.Info("Listening to https", svc1log.SafeParam("address", addr), svc1log.SafeParam("server", serverName))

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -226,6 +226,8 @@ type Server struct {
 
 	// allows the server to wait until Close() or Shutdown() return prior to returning from Start()
 	shutdownFinished chan struct{}
+
+	connStateMetrics bool
 }
 
 // InitFunc is a function type used to initialize a server. ctx is a context configured with loggers and is valid for
@@ -577,6 +579,11 @@ func (s *Server) WithCustomDiagnosticHandlers(handlers ...wdebug.DiagnosticHandl
 	return s
 }
 
+func (s *Server) WithConnectionMetrics() *Server {
+	s.connStateMetrics = true
+	return s
+}
+
 const (
 	defaultMetricEmitFrequency = time.Second * 30
 
@@ -817,7 +824,7 @@ func (s *Server) Start() (rErr error) {
 		}()
 	}
 
-	httpServer, svrStart, _, err := s.newServer(baseInstallCfg.ProductName, baseInstallCfg.Server, router.RootRouter())
+	httpServer, svrStart, _, err := s.newServer(baseInstallCfg.ProductName, baseInstallCfg.Server, router.RootRouter(), s.connStateFunc(ctx))
 	if err != nil {
 		return err
 	}
@@ -831,6 +838,15 @@ func (s *Server) Start() (rErr error) {
 		return werror.ErrorWithContextParams(ctx, "server was shut down before it could start")
 	}
 	return svrStart()
+}
+
+func (s *Server) connStateFunc(ctx context.Context) func(conn net.Conn, state http.ConnState) {
+	if !s.connStateMetrics {
+		return nil
+	}
+	return func(conn net.Conn, state http.ConnState) {
+		metrics.FromContext(ctx).Counter("conn_state_change", metrics.MustNewTag("state", state.String())).Inc(1)
+	}
 }
 
 func (s *Server) withLoggers(ctx context.Context) context.Context {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -226,8 +226,6 @@ type Server struct {
 
 	// allows the server to wait until Close() or Shutdown() return prior to returning from Start()
 	shutdownFinished chan struct{}
-
-	connStateMetrics bool
 }
 
 // InitFunc is a function type used to initialize a server. ctx is a context configured with loggers and is valid for
@@ -579,11 +577,6 @@ func (s *Server) WithCustomDiagnosticHandlers(handlers ...wdebug.DiagnosticHandl
 	return s
 }
 
-func (s *Server) WithConnectionMetrics() *Server {
-	s.connStateMetrics = true
-	return s
-}
-
 const (
 	defaultMetricEmitFrequency = time.Second * 30
 
@@ -824,7 +817,7 @@ func (s *Server) Start() (rErr error) {
 		}()
 	}
 
-	httpServer, svrStart, _, err := s.newServer(baseInstallCfg.ProductName, baseInstallCfg.Server, router.RootRouter(), s.connStateFunc(ctx))
+	httpServer, svrStart, _, err := s.newServer(baseInstallCfg.ProductName, baseInstallCfg.Server, router.RootRouter(), s.connStateCallback(ctx))
 	if err != nil {
 		return err
 	}
@@ -840,12 +833,9 @@ func (s *Server) Start() (rErr error) {
 	return svrStart()
 }
 
-func (s *Server) connStateFunc(ctx context.Context) func(conn net.Conn, state http.ConnState) {
-	if !s.connStateMetrics {
-		return nil
-	}
+func (s *Server) connStateCallback(ctx context.Context) func(conn net.Conn, state http.ConnState) {
 	return func(conn net.Conn, state http.ConnState) {
-		metrics.FromContext(ctx).Counter("conn_state_change", metrics.MustNewTag("state", state.String())).Inc(1)
+		metrics.FromContext(ctx).Counter("server.conn_state_change", metrics.MustNewTag("state", state.String())).Inc(1)
 	}
 }
 


### PR DESCRIPTION
## Before this PR
WGS provided no telemetry around server connections.


## After this PR
WGS provides connection state change telemetry. This enables developers to observe:
- total number of open connections the server has (`count{state="new"} - count{state="closed"}`)
- number of active versus idle connections

==COMMIT_MSG==
Add counter metric tracking main server connection state changes.
==COMMIT_MSG==

## Possible downsides?
This is an additional metric, so this technically costs money for any infrastructure that collects metrics for WGS applications.
