### PR TITLE
Fix audit metrics for dual-logging

### DIFF
--- a/changelog/@unreleased/pr-951.v2.yml
+++ b/changelog/@unreleased/pr-951.v2.yml
@@ -1,0 +1,10 @@
+type: fix
+fix:
+  description: |-
+    Fixes the metrics recorded for audit logs:
+
+    * An `audit.2` log entry will only increment `audit.2` log metric count if dual-logging is disabled, but will also increment `audit.3` metric count if dual-logging is enabled
+    * An `audit.3` log entry will only increment `audit.3` log metric count if dual-logging is disabled, but will also increment `audit.2` metric count if dual-logging is enabled
+    * Number of metric entries for audit 2 or audit 3 log count matches the number of entries recorded for log length
+  links:
+  - https://github.com/palantir/witchcraft-go-server/pull/951

--- a/integration/audit_test.go
+++ b/integration/audit_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -275,7 +276,7 @@ func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAu
 
 			return nil, nil
 		}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc, installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server {
-			installCfg.MetricsEmitFrequency = 100 * time.Millisecond
+			installCfg.MetricsEmitFrequency = 25 * time.Millisecond
 			server := createTestServer(t, initFn, installCfg, logOutputBuffer)
 			if dualLogAuditV2ToAuditV3 {
 				server = server.ExperimentalWithEnableDualLogAuditV2ToAuditV3()
@@ -307,8 +308,12 @@ func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAu
 			require.NoError(t, err)
 		}
 
+		// allow metric emitter to run
+		time.Sleep(50 * time.Millisecond)
+
 		audit2LogEntries := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
 		audit3LogEntries := extractLogEntries[logging.AuditLogV3](t, logOutputBuffer.String(), "audit.3")
+		metricLogEntries := extractLogEntries[logging.MetricLogV1](t, logOutputBuffer.String(), "metric.1")
 
 		wantNumAudit2LogEntries := 0
 		wantNumAudit3LogEntries := 0
@@ -327,7 +332,9 @@ func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAu
 		}
 
 		assert.Equal(t, wantNumAudit2LogEntries, len(audit2LogEntries))
+		assert.Equal(t, wantNumAudit2LogEntries, getNumEntriesFromMetricLogs(metricLogEntries, "audit.2"))
 		assert.Equal(t, wantNumAudit3LogEntries, len(audit3LogEntries))
+		assert.Equal(t, wantNumAudit3LogEntries, getNumEntriesFromMetricLogs(metricLogEntries, "audit.3"))
 
 		auditLog2Idx := 0
 		auditLog3Idx := 0
@@ -449,6 +456,35 @@ func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAu
 	})
 }
 
+func sortMetricByCountValueDescending(a, b logging.MetricLogV1) int {
+	aCountNum, ok := a.Values["count"].(json.Number)
+	if !ok {
+		return 0
+	}
+	bCountNum, ok := b.Values["count"].(json.Number)
+	if !ok {
+		return 0
+	}
+	var (
+		aCountVal, bCountVal int64
+		err                  error
+	)
+	aCountVal, err = aCountNum.Int64()
+	if err != nil {
+		return 0
+	}
+	bCountVal, err = bCountNum.Int64()
+	if err != nil {
+		return 0
+	}
+	if aCountVal < bCountVal {
+		return 1
+	} else if aCountVal > bCountVal {
+		return -1
+	}
+	return 0
+}
+
 func extractLogEntries[LogT any](t *testing.T, loggerOutput, logTypeName string) []LogT {
 	var logEntries []LogT
 	parts := strings.Split(loggerOutput, "\n")
@@ -465,6 +501,40 @@ func extractLogEntries[LogT any](t *testing.T, loggerOutput, logTypeName string)
 		var currLogEntry LogT
 		require.NoError(t, json.Unmarshal([]byte(curr), &currLogEntry))
 		logEntries = append(logEntries, currLogEntry)
+	}
+	return logEntries
+}
+
+func getNumEntriesFromMetricLogs(metricLogEntries []logging.MetricLogV1, tagType string) int {
+	matchingMetricLogEntries := filterMatchingLogEntries(metricLogEntries, func(entry logging.MetricLogV1) bool {
+		return entry.MetricName == "logging.sls" && entry.Tags["type"] == tagType
+	})
+	slices.SortFunc(matchingMetricLogEntries, sortMetricByCountValueDescending)
+	return getMetricLogMaxCount(matchingMetricLogEntries)
+}
+
+func getMetricLogMaxCount(metricLogEntries []logging.MetricLogV1) int {
+	maxVal := int64(0)
+	for _, entry := range metricLogEntries {
+		countNum, ok := entry.Values["count"].(json.Number)
+		if !ok {
+			return 0
+		}
+		countVal, err := countNum.Int64()
+		if err != nil {
+			return 0
+		}
+		maxVal = max(maxVal, countVal)
+	}
+	return int(maxVal)
+}
+
+func filterMatchingLogEntries[LogT any](entries []LogT, matcher func(LogT) bool) []LogT {
+	var logEntries []LogT
+	for _, currLogEntry := range entries {
+		if matcher(currLogEntry) {
+			logEntries = append(logEntries, currLogEntry)
+		}
 	}
 	return logEntries
 }

--- a/witchcraft/internal/metricloggers/audit2logger.go
+++ b/witchcraft/internal/metricloggers/audit2logger.go
@@ -29,15 +29,24 @@ type audit2Logger struct {
 }
 
 func NewAudit2Logger(logger audit2log.Logger, registry metrics.Registry) audit2log.Logger {
-	return &audit2Logger{
+	return NewAudit2LoggerWithDualLogging(logger, registry, false)
+}
+
+func NewAudit2LoggerWithDualLogging(logger audit2log.Logger, registry metrics.Registry, dualLogToV3 bool) audit2log.Logger {
+	audit2logger := &audit2Logger{
 		logger:         logger,
 		audit2Recorder: newMetricRecorder(registry, audit2log.TypeValue),
-		audit3Recorder: newMetricRecorder(registry, audit3log.TypeValue),
 	}
+	if dualLogToV3 {
+		audit2logger.audit3Recorder = newMetricRecorder(registry, audit3log.TypeValue)
+	}
+	return audit2logger
 }
 
 func (m *audit2Logger) Audit(name string, result audit2log.AuditResultType, params ...audit2log.Param) {
 	m.logger.Audit(name, result, params...)
 	m.audit2Recorder.RecordSLSLog()
-	m.audit3Recorder.RecordSLSLog()
+	if m.audit3Recorder != nil {
+		m.audit3Recorder.RecordSLSLog()
+	}
 }

--- a/witchcraft/internal/metricloggers/audit3logger.go
+++ b/witchcraft/internal/metricloggers/audit3logger.go
@@ -16,24 +16,37 @@ package metricloggers
 
 import (
 	"github.com/palantir/pkg/metrics"
+	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit2log"
 	"github.com/palantir/witchcraft-go-logging/wlog/auditlog/audit3log"
 )
 
 var _ audit3log.Logger = (*audit3Logger)(nil)
 
 type audit3Logger struct {
-	logger   audit3log.Logger
-	recorder metricRecorder
+	logger         audit3log.Logger
+	audit3Recorder metricRecorder
+	audit2Recorder metricRecorder
 }
 
 func NewAudit3Logger(logger audit3log.Logger, registry metrics.Registry) audit3log.Logger {
-	return &audit3Logger{
-		logger:   logger,
-		recorder: newMetricRecorder(registry, audit3log.TypeValue),
+	return NewAudit3LoggerWithDualLogging(logger, registry, false)
+}
+
+func NewAudit3LoggerWithDualLogging(logger audit3log.Logger, registry metrics.Registry, dualLogToV2 bool) audit3log.Logger {
+	audit3logger := &audit3Logger{
+		logger:         logger,
+		audit3Recorder: newMetricRecorder(registry, audit3log.TypeValue),
 	}
+	if dualLogToV2 {
+		audit3logger.audit2Recorder = newMetricRecorder(registry, audit2log.TypeValue)
+	}
+	return audit3logger
 }
 
 func (m *audit3Logger) Audit(name string, result audit3log.AuditResultType, params ...audit3log.Param) {
 	m.logger.Audit(name, result, params...)
-	m.recorder.RecordSLSLog()
+	m.audit3Recorder.RecordSLSLog()
+	if m.audit2Recorder != nil {
+		m.audit2Recorder.RecordSLSLog()
+	}
 }

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -84,7 +84,7 @@ func (s *Server) initDefaultLoggers(useConsoleLog bool, logLevel wlog.LogLevel, 
 	} else {
 		audit2Logger = audit2log.New(logWriterFn("audit"))
 	}
-	s.audit2Logger = metricloggers.NewAudit2Logger(audit2Logger, registry)
+	s.audit2Logger = metricloggers.NewAudit2LoggerWithDualLogging(audit2Logger, registry, s.dualLogAuditV2ToAuditV3)
 
 	var audit3Logger audit3log.Logger
 	if s.dualLogAuditV3ToAuditV2 {
@@ -92,7 +92,7 @@ func (s *Server) initDefaultLoggers(useConsoleLog bool, logLevel wlog.LogLevel, 
 	} else {
 		audit3Logger = audit3log.New(logWriterFn("audit.v3"))
 	}
-	audit3Logger = metricloggers.NewAudit3Logger(audit3Logger, registry)
+	audit3Logger = metricloggers.NewAudit3LoggerWithDualLogging(audit3Logger, registry, s.dualLogAuditV3ToAuditV2)
 	s.audit3Logger.Store(&audit3Logger)
 
 	s.diagLogger = metricloggers.NewDiag1Logger(diag1log.New(logWriterFn("diagnostic")), registry)


### PR DESCRIPTION
## Before this PR
The PR that introduced `audit.3` logging caused some metrics to be incorrect:

* Logging an `audit.2` entry would always increment the metric count for an `audit.3` entry even if dual-logging was not enabled
* Logging an `audit.3` entry would not increment the metric count for an `audit.2` entry even if dual-logging was enabled (but the length of the `audit.2` entry would still be logged as a metric)

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fixes the metrics recorded for audit logs:

* An `audit.2` log entry will only increment `audit.2` log metric count if dual-logging is disabled, but will also increment `audit.3` metric count if dual-logging is enabled
* An `audit.3` log entry will only increment `audit.3` log metric count if dual-logging is disabled, but will also increment `audit.2` metric count if dual-logging is enabled
* Number of metric entries for audit 2 or audit 3 log count matches the number of entries recorded for log length
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

