### PR TITLE
Update naming for audit dual logging functions

### DIFF
--- a/integration/audit_test.go
+++ b/integration/audit_test.go
@@ -279,10 +279,10 @@ func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAu
 			installCfg.MetricsEmitFrequency = 25 * time.Millisecond
 			server := createTestServer(t, initFn, installCfg, logOutputBuffer)
 			if dualLogAuditV2ToAuditV3 {
-				server = server.ExperimentalWithEnableDualLogAuditV2ToAuditV3()
+				server = server.WithEnableDualLogAuditV2ToAuditV3()
 			}
 			if dualLogAuditV3ToV2 {
-				server = server.ExperimentalWithEnableDualLogAuditV3ToAuditV2()
+				server = server.WithEnableDualLogAuditV3ToAuditV2()
 			}
 			return server
 		})

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -593,16 +593,16 @@ func (s *Server) WithCustomDiagnosticHandlers(handlers ...wdebug.DiagnosticHandl
 	return s
 }
 
-// ExperimentalWithEnableDualLogAuditV2ToAuditV3 enables dual-writing audit v2 logs to audit v3 logs.
+// WithEnableDualLogAuditV2ToAuditV3 enables dual-writing audit v2 logs to audit v3 logs.
 // This is an experimental feature: the functionality or function itself may be removed in the future.
-func (s *Server) ExperimentalWithEnableDualLogAuditV2ToAuditV3() *Server {
+func (s *Server) WithEnableDualLogAuditV2ToAuditV3() *Server {
 	s.dualLogAuditV2ToAuditV3 = true
 	return s
 }
 
-// ExperimentalWithEnableDualLogAuditV3ToAuditV2 enables dual-writing audit v3 logs to audit v2 logs.
+// WithEnableDualLogAuditV3ToAuditV2 enables dual-writing audit v3 logs to audit v2 logs.
 // This is an experimental feature: the functionality or function itself may be removed in the future.
-func (s *Server) ExperimentalWithEnableDualLogAuditV3ToAuditV2() *Server {
+func (s *Server) WithEnableDualLogAuditV3ToAuditV2() *Server {
 	s.dualLogAuditV3ToAuditV2 = true
 	return s
 }


### PR DESCRIPTION
Remove "experimental" from the name since there may be production services that use these functions.
