### PR TITLE
Improvement: Add option for specifying IP and DNS SANs in self-signed certificate

### DIFF
--- a/witchcraft/server_run.go
+++ b/witchcraft/server_run.go
@@ -43,6 +43,7 @@ func (s *Server) newServer(
 	return newServerStartShutdownFns(
 		serverConfig,
 		s.useSelfSignedServerCertificate,
+		s.selfSignedCertificateSANs,
 		s.clientAuth,
 		productName,
 		s.svcLogger,
@@ -56,6 +57,7 @@ func (s *Server) newMgmtServer(productName string, serverConfig config.Server, h
 	_, start, shutdown, err := newServerStartShutdownFns(
 		serverConfig,
 		s.useSelfSignedServerCertificate,
+		s.selfSignedCertificateSANs,
 		tls.NoClientCert,
 		productName+"-management",
 		s.svcLogger,
@@ -68,13 +70,14 @@ func (s *Server) newMgmtServer(productName string, serverConfig config.Server, h
 func newServerStartShutdownFns(
 	serverConfig config.Server,
 	useSelfSignedServerCertificate bool,
+	selfSignedCertificateSANs selfSignedCertificateSANs,
 	clientAuthType tls.ClientAuthType,
 	serverName string,
 	svcLogger svc1log.Logger,
 	handler http.Handler,
 	connStateFunc func(net.Conn, http.ConnState),
 ) (rHTTPServer *http.Server, start func() error, shutdown func(context.Context) error, rErr error) {
-	tlsConfig, err := newTLSConfig(serverConfig, useSelfSignedServerCertificate, clientAuthType)
+	tlsConfig, err := newTLSConfig(serverConfig, useSelfSignedServerCertificate, selfSignedCertificateSANs, clientAuthType)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -103,7 +106,7 @@ func newServerStartShutdownFns(
 	}, httpServer.Shutdown, nil
 }
 
-func newTLSConfig(serverConfig config.Server, useSelfSignedServerCertificate bool, clientAuthType tls.ClientAuthType) (*tls.Config, error) {
+func newTLSConfig(serverConfig config.Server, useSelfSignedServerCertificate bool, selfSignedCertificateSANs selfSignedCertificateSANs, clientAuthType tls.ClientAuthType) (*tls.Config, error) {
 	if !useSelfSignedServerCertificate && (serverConfig.KeyFile == "" || serverConfig.CertFile == "") {
 		var msg string
 		if serverConfig.KeyFile == "" && serverConfig.CertFile == "" {
@@ -117,7 +120,7 @@ func newTLSConfig(serverConfig config.Server, useSelfSignedServerCertificate boo
 	}
 
 	tlsConfig, err := tlsconfig.NewServerConfig(
-		newTLSCertProvider(useSelfSignedServerCertificate, serverConfig.CertFile, serverConfig.KeyFile),
+		newTLSCertProvider(useSelfSignedServerCertificate, selfSignedCertificateSANs, serverConfig.CertFile, serverConfig.KeyFile),
 		tlsconfig.ServerClientCAFiles(serverConfig.ClientCAFiles...),
 		tlsconfig.ServerClientAuthType(clientAuthType),
 		tlsconfig.ServerNextProtos("h2"),
@@ -128,10 +131,10 @@ func newTLSConfig(serverConfig config.Server, useSelfSignedServerCertificate boo
 	return tlsConfig, nil
 }
 
-func newTLSCertProvider(useSelfSignedServerCertificate bool, certFile, keyFile string) tlsconfig.TLSCertProvider {
+func newTLSCertProvider(useSelfSignedServerCertificate bool, selfSignedCertificateSANs selfSignedCertificateSANs, certFile, keyFile string) tlsconfig.TLSCertProvider {
 	if useSelfSignedServerCertificate {
 		return func() (tls.Certificate, error) {
-			return newSelfSignedCertificate()
+			return newSelfSignedCertificate(selfSignedCertificateSANs)
 		}
 	}
 	return tlsconfig.TLSCertFromFiles(certFile, keyFile)
@@ -140,7 +143,7 @@ func newTLSCertProvider(useSelfSignedServerCertificate bool, certFile, keyFile s
 // newSelfSignedCertificate creates a new self-signed certificate that can be used for TLS. The generated certificate is
 // quite minimal: it has a hard-coded serial number, is valid for 1 year and does NOT have a common name or IP SANs
 // set.
-func newSelfSignedCertificate() (tls.Certificate, error) {
+func newSelfSignedCertificate(selfSignedCertificateSANs selfSignedCertificateSANs) (tls.Certificate, error) {
 	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return tls.Certificate{}, err
@@ -157,6 +160,8 @@ func newSelfSignedCertificate() (tls.Certificate, error) {
 			CommonName:   "localhost",
 			Organization: []string{"Palantir"},
 		},
+		DNSNames:    selfSignedCertificateSANs.DNSNames,
+		IPAddresses: selfSignedCertificateSANs.IPAddresses,
 	}
 	certDERBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privKey.PublicKey, privKey)
 	if err != nil {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -84,6 +84,10 @@ type Server struct {
 	// If false, the key material at the paths specified in serverConfig.CertFile and serverConfig.KeyFile is used.
 	useSelfSignedServerCertificate bool
 
+	// selfSignedCertificateSANs specifies an optional set of IP and DNS sans which should be included in the generated
+	// self-signed certificate for TLS. This field is only consumed when useSelfSignedServerCertificate is true.
+	selfSignedCertificateSANs selfSignedCertificateSANs
+
 	// manages storing and retrieving server state (idle, initializing, running)
 	stateManager serverStateManager
 
@@ -244,6 +248,11 @@ type Server struct {
 	shutdownFinished chan struct{}
 }
 
+type selfSignedCertificateSANs struct {
+	IPAddresses []net.IP
+	DNSNames    []string
+}
+
 // InitFunc is a function type used to initialize a server. ctx is a context configured with loggers and is valid for
 // the duration of the server. Refer to the documentation of InitInfo for its fields.
 //
@@ -388,6 +397,15 @@ func (s *Server) WithRuntimeConfigFromFile(fpath string) *Server {
 // using separate external mechanisms.
 func (s *Server) WithSelfSignedCertificate() *Server {
 	s.useSelfSignedServerCertificate = true
+	return s
+}
+
+// WithSelfSignedCertificateSANs configures the server to add the specified IP addresses and / or DNS names as SANs to
+// the generated self-signed certificate for TLS authentication. This setting is a noop unless WithSelfSignedCertificate
+// is also set.
+func (s *Server) WithSelfSignedCertificateSANs(ips []net.IP, dnsNames []string) *Server {
+	s.selfSignedCertificateSANs.IPAddresses = ips
+	s.selfSignedCertificateSANs.DNSNames = dnsNames
 	return s
 }
 


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add option for specifying IP and DNS SANs in self-signed certificate
==COMMIT_MSG==

