### PR TITLE
Break: Remove deprecated /debug/pprof endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,6 @@ specifies the encoding and format of the response. The following types are curre
 * `metric.names.v1`: Records all metric names and tag sets in the process's metric registry.
 * `os.system.clock.v1`: Plaintext string representing the current time as measured by the process in the RFC 3339 Nano format.
 
-#### \[Deprecated] Pprof routes
-The following routes are registered on the management server (if enabled) to aid in debugging
-and telemetry collection. These are generally deprecated in favor of the diagnostic routes described above.
-* `/debug/pprof`: Provides an HTML index of the other endpoints at this route.
-* `/debug/pprof/profile`: Returns the pprof-formatted cpu profile. See [pprof.Profile](https://golang.org/pkg/net/http/pprof/#Profile).
-* `/debug/pprof/heap`: Returns the pprof-formatted heap profile as of the last GC. See [pprof.Profile](https://golang.org/pkg/runtime/pprof/#Profile).
-* `/debug/pprof/cmdline`: Returns the process's command line invocation as `text/plain`. See [pprof.Cmdline](https://golang.org/pkg/net/http/pprof/#Cmdline).
-* `/debug/pprof/symbol`: Looks up the program counters listed in the request, responding with a table mapping program counters to function names See [pprof.Symbol](https://golang.org/pkg/net/http/pprof/#Symbol).
-* `/debug/pprof/trace`: Returns the execution trace in binary form. See [pprof.Trace](https://golang.org/pkg/net/http/pprof/#Trace).
-
 ### Context path
 If `context-path` is specified in the install configuration, all of the routes registered on the server will be prefixed
 with the specified `context-path`.

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -16,10 +16,7 @@ package witchcraft
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	netpprof "net/http/pprof"
-	"runtime/pprof"
 
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-contract/errors"
 	"github.com/palantir/conjure-go-runtime/v2/conjure-go-server/httpserver"
@@ -130,39 +127,6 @@ func createRouter(routerImpl wrouter.RouterImpl, ctxPath string) wrouter.Router 
 		routerWithContextPath = routerHandler.Subrouter(ctxPath)
 	}
 	return routerWithContextPath
-}
-
-func addPprofRoutes(router wrouter.Router) error {
-	debugger := wresource.New("debug", router.Subrouter("/debug"))
-	if err := debugger.Get("pprofIndex", "/pprof/", http.HandlerFunc(netpprof.Index)); err != nil {
-		return err
-	}
-	if err := debugger.Get("pprofCmdLine", "/pprof/cmdline", http.HandlerFunc(netpprof.Cmdline)); err != nil {
-		return err
-	}
-	if err := debugger.Get("pprofCpuProfile", "/pprof/profile", http.HandlerFunc(netpprof.Profile)); err != nil {
-		return err
-	}
-	if err := debugger.Get("pprofSymbol", "/pprof/symbol", http.HandlerFunc(netpprof.Symbol)); err != nil {
-		return err
-	}
-	if err := debugger.Get("pprofTrace", "/pprof/trace", http.HandlerFunc(netpprof.Trace)); err != nil {
-		return err
-	}
-	return debugger.Get("pprofHeapProfile", "/pprof/heap", http.HandlerFunc(heap))
-}
-
-// heap responds with the pprof-formatted heap profile.
-func heap(w http.ResponseWriter, _ *http.Request) {
-	// Set Content Type assuming WriteHeapProfile will work,
-	// because if it does it starts writing.
-	w.Header().Set("Content-Type", "application/octet-stream")
-	if err := pprof.WriteHeapProfile(w); err != nil {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = fmt.Fprintf(w, "Could not dump heap: %s\n", err)
-		return
-	}
 }
 
 func getSecretRefreshable(ctx context.Context, diagnosticsConfig config.RefreshableDiagnosticsConfig) (refreshable.String, error) {

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -773,10 +773,6 @@ func (s *Server) Start() (rErr error) {
 	if mgmtRouter != router {
 		// add middleware to management router as well if it is distinct
 		s.addMiddleware(mgmtRouter.RootRouter(), metricsRegistry, endpoint500s, s.getManagementTracingOptions(baseInstallCfg))
-		// add debugging endpoints to management router
-		if err := addPprofRoutes(mgmtRouter); err != nil {
-			return werror.Wrap(err, "failed to register debugging routes")
-		}
 	}
 
 	// handle built-in runtime config changes


### PR DESCRIPTION
## Before this PR
`/debug/pprof` endpoints are registered on the management server to allow for debugging and telemetry collection, however these have been superseded by the `/debug/diagnostic/{diagnosticType}` endpoints. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove deprecated `/debug/pprof` endpoints

The `/debug/diagnostic/{diagnosticType}` endpoints can be used to retrieve most of the same information that was previously retrieved by the `/debug/pprof/*` endpoints
==COMMIT_MSG==

Part of #1026 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

