### PR TITLE
Break: Use inclusive language to block specific metrics

### DIFF
--- a/integration/metrics_test.go
+++ b/integration/metrics_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 // TestEmitMetrics verifies that metrics are printed periodically by a Witchcraft server and that the emitted values
-// respect the default blacklist. We verify both custom metrics set in the InitFunc (with tags) and server.response
+// respect the default blocklist. We verify both custom metrics set in the InitFunc (with tags) and server.response
 // metrics from the metrics middleware.
 func TestEmitMetrics(t *testing.T) {
 	logOutputBuffer := &bytes.Buffer{}
@@ -125,7 +125,7 @@ func TestEmitMetrics(t *testing.T) {
 			assert.NotNil(t, metricLog.Values["p95"])
 			assert.NotNil(t, metricLog.Values["p99"])
 
-			// keys are part of the default blacklist and should thus be nil
+			// keys are part of the default blocklist and should thus be nil
 			assert.Nil(t, metricLog.Values["1m"])
 			assert.Nil(t, metricLog.Values["5m"])
 			assert.Nil(t, metricLog.Values["15m"])
@@ -142,7 +142,7 @@ func TestEmitMetrics(t *testing.T) {
 			assert.NotNil(t, metricLog.Values["p99"])
 			assert.NotNil(t, metricLog.Values["count"])
 
-			// keys are part of the default blacklist and should thus be nil
+			// keys are part of the default blocklist and should thus be nil
 			assert.Nil(t, metricLog.Values["min"])
 			assert.Nil(t, metricLog.Values["mean"])
 			assert.Nil(t, metricLog.Values["stddev"])
@@ -155,7 +155,7 @@ func TestEmitMetrics(t *testing.T) {
 			assert.NotNil(t, metricLog.Values["p99"])
 			assert.NotNil(t, metricLog.Values["count"])
 
-			// keys are part of the default blacklist and should thus be nil
+			// keys are part of the default blocklist and should thus be nil
 			assert.Nil(t, metricLog.Values["min"])
 			assert.Nil(t, metricLog.Values["mean"])
 			assert.Nil(t, metricLog.Values["stddev"])
@@ -165,7 +165,7 @@ func TestEmitMetrics(t *testing.T) {
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
 			assert.NotNil(t, metricLog.Values["count"])
 
-			// keys are part of the default blacklist and should thus be nil
+			// keys are part of the default blocklist and should thus be nil
 			assert.Nil(t, metricLog.Values["1m"])
 			assert.Nil(t, metricLog.Values["5m"])
 			assert.Nil(t, metricLog.Values["15m"])
@@ -299,7 +299,7 @@ func TestEmitMetricsZeroValue(t *testing.T) {
 			assert.NotNil(t, metricLog.Values["p95"])
 			assert.NotNil(t, metricLog.Values["p99"])
 
-			// keys are part of the default blacklist and should thus be nil
+			// keys are part of the default blocklist and should thus be nil
 			assert.Nil(t, metricLog.Values["1m"])
 			assert.Nil(t, metricLog.Values["5m"])
 			assert.Nil(t, metricLog.Values["15m"])
@@ -409,10 +409,10 @@ func TestMetricWriter(t *testing.T) {
 	}
 }
 
-// TestEmitMetricsEmptyBlacklist verifies that metrics are printed periodically by a Witchcraft server and that, if the
-// blacklist is empty, all values are emitted. We verify both custom metrics set in the InitFunc (with tags) and
+// TestEmitMetricsEmptyBlocklist verifies that metrics are printed periodically by a Witchcraft server and that, if the
+// blocklist is empty, all values are emitted. We verify both custom metrics set in the InitFunc (with tags) and
 // server.response metrics from the metrics middleware.
-func TestEmitMetricsEmptyBlacklist(t *testing.T) {
+func TestEmitMetricsEmptyBlocklist(t *testing.T) {
 	logOutputBuffer := &bytes.Buffer{}
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 		}))
 	}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
 		installCfg.MetricsEmitFrequency = 100 * time.Millisecond
-		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithMetricTypeValuesBlacklist(map[string]map[string]struct{}{})
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithMetricTypeValuesBlocklist(map[string]map[string]struct{}{})
 	})
 	defer func() {
 		require.NoError(t, server.Close())
@@ -494,7 +494,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			seenResponseTimer = true
 			assert.Equal(t, "timer", metricLog.MetricType, "server.response metric had incorrect type")
 
-			// blacklist is set to empty, so all keys should be non-nil
+			// blocklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["count"])
 			assert.NotNil(t, metricLog.Values["1m"])
 			assert.NotNil(t, metricLog.Values["5m"])
@@ -511,7 +511,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
 
-			// blacklist is set to empty, so all keys should be non-nil
+			// blocklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
 			assert.NotNil(t, metricLog.Values["mean"])
@@ -524,7 +524,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
 
-			// blacklist is set to empty, so all keys should be non-nil
+			// blocklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["min"])
 			assert.NotNil(t, metricLog.Values["max"])
 			assert.NotNil(t, metricLog.Values["mean"])
@@ -537,7 +537,7 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 			seenResponseError = true
 			assert.Equal(t, "meter", metricLog.MetricType, "server.response metric had incorrect type")
 
-			// blacklist is set to empty, so all keys should be non-nil
+			// blocklist is set to empty, so all keys should be non-nil
 			assert.NotNil(t, metricLog.Values["count"])
 			assert.NotNil(t, metricLog.Values["1m"])
 			assert.NotNil(t, metricLog.Values["5m"])
@@ -575,9 +575,9 @@ func TestEmitMetricsEmptyBlacklist(t *testing.T) {
 	}
 }
 
-// TestMetricTypeValueBlacklist tests that if a metric type value is blacklisted, all metric of that type does not
-// contain any of the blacklisted keys.
-func TestMetricTypeValueBlacklist(t *testing.T) {
+// TestMetricTypeValueBlocklist tests that if a metric type value is blocklisted, all metric of that type does not
+// contain any of the blocklisted keys.
+func TestMetricTypeValueBlocklist(t *testing.T) {
 	logOutputBuffer := &bytes.Buffer{}
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
@@ -592,7 +592,7 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		}))
 	}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
 		installCfg.MetricsEmitFrequency = 100 * time.Millisecond
-		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithMetricTypeValuesBlacklist(map[string]map[string]struct{}{
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithMetricTypeValuesBlocklist(map[string]map[string]struct{}{
 			"histogram": {"count": {}},
 		})
 	})
@@ -667,12 +667,12 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 		case "server.request.size":
 			seenRequestSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			// there should be no value for "count" because it is blacklisted for the histogram type
+			// there should be no value for "count" because it is blocklisted for the histogram type
 			assert.Nil(t, metricLog.Values["count"])
 		case "server.response.size":
 			seenResponseSize = true
 			assert.Equal(t, "histogram", metricLog.MetricType, "server.response metric had incorrect type")
-			// there should be no value for "count" because it is blacklisted for the histogram type
+			// there should be no value for "count" because it is blocklisted for the histogram type
 			assert.Nil(t, metricLog.Values["count"])
 		case "server.response.error":
 			seenResponseError = true
@@ -711,8 +711,8 @@ func TestMetricTypeValueBlacklist(t *testing.T) {
 	}
 }
 
-// TestMetricsBlacklist verifies that blacklisted metrics are not emitted.
-func TestMetricsBlacklist(t *testing.T) {
+// TestMetricsBlocklist verifies that blocklisted metrics are not emitted.
+func TestMetricsBlocklist(t *testing.T) {
 	logOutputBuffer := &bytes.Buffer{}
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
@@ -725,7 +725,7 @@ func TestMetricsBlacklist(t *testing.T) {
 	}, logOutputBuffer, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
 		installCfg.MetricsEmitFrequency = 100 * time.Millisecond
 		server := createTestServer(t, initFn, installCfg, logOutputBuffer)
-		server.WithMetricsBlacklist(map[string]struct{}{
+		server.WithMetricsBlocklist(map[string]struct{}{
 			"my-counter":          {},
 			"logging.sls":         {},
 			"logging.sls.length":  {},

--- a/witchcraft/server_metrics.go
+++ b/witchcraft/server_metrics.go
@@ -31,7 +31,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/v2/config"
 )
 
-func defaultMetricTypeValuesBlacklist() map[string]map[string]struct{} {
+func defaultMetricTypeValuesBlocklist() map[string]map[string]struct{} {
 	return map[string]map[string]struct{}{
 		"histogram": {
 			"min":    {},
@@ -86,8 +86,8 @@ func (s *Server[I, R]) initMetrics(ctx context.Context, installCfg config.Instal
 		}
 	}
 
-	if s.metricTypeValuesBlacklist == nil {
-		s.metricTypeValuesBlacklist = defaultMetricTypeValuesBlacklist()
+	if s.metricTypeValuesBlocklist == nil {
+		s.metricTypeValuesBlocklist = defaultMetricTypeValuesBlocklist()
 	}
 
 	// seenMetrics tracks the metrics that have been seen so far. Uses a lock to protect access because emitFn that
@@ -167,16 +167,16 @@ func (s *Server[I, R]) collectMetricValues(metricName string, metricVal metrics.
 }
 
 // visitMetricValues calls the provided visit function for each key in the provided metric value.
-// If the metric with the provided metricID is in the metrics blacklist, the visit function is not called for any keys.
-// The visit function is not called for keys that are in the metric type value blacklist for the type.
+// If the metric with the provided metricID is in the metrics blocklist, the visit function is not called for any keys.
+// The visit function is not called for keys that are in the metric type value blocklist for the type.
 func (s *Server[I, R]) visitMetricValues(metricID string, metricVal metrics.MetricVal, visit func(key string)) {
-	if _, blackListed := s.metricsBlacklist[metricID]; blackListed {
-		// skip emitting metric if it is blacklisted
+	if _, blocklisted := s.metricsBlocklist[metricID]; blocklisted {
+		// skip emitting metric if it is blocklisted
 		return
 	}
 	for key := range metricVal.Keys() {
-		if s.metricTypeValuesBlacklist != nil {
-			if disallowedKeysForType, ok := s.metricTypeValuesBlacklist[metricVal.Type()]; ok {
+		if s.metricTypeValuesBlocklist != nil {
+			if disallowedKeysForType, ok := s.metricTypeValuesBlocklist[metricVal.Type()]; ok {
 				if _, disallowed := disallowedKeysForType[key]; disallowed {
 					continue
 				}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -19,6 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -152,13 +153,13 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 	// seconds if an interval is not specified in configuration).
 	disableGoRuntimeMetrics bool
 
-	// metricsBlacklist specifies the set of metrics that should not be emitted by the metric logger.
-	metricsBlacklist map[string]struct{}
+	// metricsBlocklist specifies the set of metrics that should not be emitted by the metric logger.
+	metricsBlocklist map[string]struct{}
 
-	// metricTypeValuesBlacklist specifies the values for a metric type that should be omitted from metric output. For
+	// metricTypeValuesBlocklist specifies the values for a metric type that should be omitted from metric output. For
 	// example, if the map is set to {"timer":{"5m":{}}}, then the value for "5m" will be omitted from all timer metric
-	// output. If nil, the default value is the map returned by defaultMetricTypeValuesBlacklist().
-	metricTypeValuesBlacklist map[string]map[string]struct{}
+	// output. If nil, the default value is the map returned by defaultMetricTypeValuesBlocklist().
+	metricTypeValuesBlocklist map[string]map[string]struct{}
 
 	// endpoint500sHealthCheckFunc builds the ENDPOINT_FIVE_HUNDREDS health check source. If nil, the check is disabled.
 	// The health check source is enabled by default.
@@ -513,31 +514,29 @@ func (s *Server[I, R]) WithDisableServiceDependencyHealth() *Server[I, R] {
 	return s
 }
 
-// WithMetricsBlacklist sets the metric blacklist to the provided set of metrics. The provided metrics should be the
-// name of the metric (for example, "server.response.size"). The blacklist only supports blacklisting at the metric
-// level: blacklisting an individual metric value (such as "server.response.size.count") will not have any effect. The
+// WithMetricsBlocklist sets the metric blocklist to the provided set of metrics. The provided metrics should be the
+// name of the metric (for example, "server.response.size"). The blocklist only supports blocklisting at the metric
+// level: blocklisting an individual metric value (such as "server.response.size.count") will not have any effect. The
 // provided input is copied.
-func (s *Server[I, R]) WithMetricsBlacklist(blacklist map[string]struct{}) *Server[I, R] {
-	metricsBlacklist := make(map[string]struct{})
-	for k, v := range blacklist {
-		metricsBlacklist[k] = v
-	}
-	s.metricsBlacklist = metricsBlacklist
+func (s *Server[I, R]) WithMetricsBlocklist(blocklist map[string]struct{}) *Server[I, R] {
+	metricsBlocklist := make(map[string]struct{})
+	maps.Copy(metricsBlocklist, blocklist)
+	s.metricsBlocklist = metricsBlocklist
 	return s
 }
 
-// WithMetricTypeValuesBlacklist sets the value of the metric type value blacklist to be the same as the provided value
+// WithMetricTypeValuesBlocklist sets the value of the metric type value blocklist to be the same as the provided value
 // (the content is copied).
-func (s *Server[I, R]) WithMetricTypeValuesBlacklist(blacklist map[string]map[string]struct{}) *Server[I, R] {
-	newBlacklist := make(map[string]map[string]struct{}, len(blacklist))
-	for k, v := range blacklist {
+func (s *Server[I, R]) WithMetricTypeValuesBlocklist(blocklist map[string]map[string]struct{}) *Server[I, R] {
+	newBlocklist := make(map[string]map[string]struct{}, len(blocklist))
+	for k, v := range blocklist {
 		newVal := make(map[string]struct{}, len(v))
 		for kk := range v {
 			newVal[kk] = struct{}{}
 		}
-		newBlacklist[k] = newVal
+		newBlocklist[k] = newVal
 	}
-	s.metricTypeValuesBlacklist = newBlacklist
+	s.metricTypeValuesBlocklist = newBlocklist
 	return s
 }
 

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -146,7 +146,7 @@ func TestFatalErrorLogging(t *testing.T) {
 				WithLoggerStdoutWriter(logOutputBuffer).
 				WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
 				WithDisableGoRuntimeMetrics().
-				WithMetricsBlacklist(map[string]struct{}{"server.uptime": {}}).
+				WithMetricsBlocklist(map[string]struct{}{"server.uptime": {}}).
 				WithSelfSignedCertificate().
 				Start()
 
@@ -246,7 +246,7 @@ func TestServer_WithOriginFromCallLine(t *testing.T) {
 				WithLoggerStdoutWriter(logOutputBuffer).
 				WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
 				WithDisableGoRuntimeMetrics().
-				WithMetricsBlacklist(map[string]struct{}{"server.uptime": {}}).
+				WithMetricsBlocklist(map[string]struct{}{"server.uptime": {}}).
 				WithSelfSignedCertificate().
 				Start()
 
@@ -415,7 +415,7 @@ func TestServer_WithWrappedLoggers(t *testing.T) {
 				WithLoggerStdoutWriter(logOutputBuffer).
 				WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
 				WithDisableGoRuntimeMetrics().
-				WithMetricsBlacklist(map[string]struct{}{"server.uptime": {}, "logging.sls": {}, "logging.sls.length": {}}).
+				WithMetricsBlocklist(map[string]struct{}{"server.uptime": {}, "logging.sls": {}, "logging.sls.length": {}}).
 				WithSelfSignedCertificate().
 				Start()
 


### PR DESCRIPTION
## Before this PR
`WithMetricsBlacklist` and `WithMetricTypeValuesBlacklist` were used to deny specific metrics, but the language is not inclusive. Instead we can use `blocklist`.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Use inclusive language to block specific metrics

`WithMetricsBlocklist` and `WithMetricTypeValuesBlocklist` replace usages of`WithMetricsBlacklist` and `WithMetricTypeValuesBlacklist` respectively.
==COMMIT_MSG==

Part of #1026 

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

