### PR TITLE
improvement: Move healthCheckSources to be a refreshable and allow multiple invocations of `WithHealth` 

### DIFF
--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -43,14 +43,19 @@ import (
 func TestAddHealthCheckSources(t *testing.T) {
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
-	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, nil, io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
-		return createTestServer(t, initFn, installCfg, logOutputBuffer).
-			WithHealth(healthCheckWithType{typ: "BAZ"}).
-			WithHealth(
-				healthCheckWithType{typ: "FOO"},
-				healthCheckWithType{typ: "BAR"},
-			)
-	})
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+		func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+			info.Router.WithHealth(healthCheckWithType{typ: "INIT_CHECK"})
+			return nil, nil
+		},
+		io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+			return createTestServer(t, initFn, installCfg, logOutputBuffer).
+				WithHealth(healthCheckWithType{typ: "BAZ"}).
+				WithHealth(
+					healthCheckWithType{typ: "FOO"},
+					healthCheckWithType{typ: "BAR"},
+				)
+		})
 
 	defer func() {
 		require.NoError(t, server.Close())
@@ -82,6 +87,12 @@ func TestAddHealthCheckSources(t *testing.T) {
 			},
 			health.CheckType("BAZ"): {
 				Type:    health.CheckType("BAZ"),
+				State:   health.New_HealthState(health.HealthState_HEALTHY),
+				Message: nil,
+				Params:  make(map[string]interface{}),
+			},
+			health.CheckType("INIT_CHECK"): {
+				Type:    health.CheckType("INIT_CHECK"),
 				State:   health.New_HealthState(health.HealthState_HEALTHY),
 				Message: nil,
 				Params:  make(map[string]interface{}),

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -45,7 +45,8 @@ func TestAddHealthCheckSources(t *testing.T) {
 	require.NoError(t, err)
 	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
 		func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
-			info.Router.WithHealth(healthCheckWithType{typ: "INIT_CHECK"})
+			info.Router.WithHealth(healthCheckWithType{typ: "INIT_CHECK_1"})
+			info.Router.WithHealth(healthCheckWithType{typ: "INIT_CHECK_2"})
 			return nil, nil
 		},
 		io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
@@ -91,8 +92,14 @@ func TestAddHealthCheckSources(t *testing.T) {
 				Message: nil,
 				Params:  make(map[string]interface{}),
 			},
-			health.CheckType("INIT_CHECK"): {
-				Type:    health.CheckType("INIT_CHECK"),
+			health.CheckType("INIT_CHECK_1"): {
+				Type:    health.CheckType("INIT_CHECK_1"),
+				State:   health.New_HealthState(health.HealthState_HEALTHY),
+				Message: nil,
+				Params:  make(map[string]interface{}),
+			},
+			health.CheckType("INIT_CHECK_2"): {
+				Type:    health.CheckType("INIT_CHECK_2"),
 				State:   health.New_HealthState(health.HealthState_HEALTHY),
 				Message: nil,
 				Params:  make(map[string]interface{}),

--- a/integration/health_test.go
+++ b/integration/health_test.go
@@ -44,7 +44,12 @@ func TestAddHealthCheckSources(t *testing.T) {
 	port, err := httpserver.AvailablePort()
 	require.NoError(t, err)
 	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port, nil, io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
-		return createTestServer(t, initFn, installCfg, logOutputBuffer).WithHealth(healthCheckWithType{typ: "FOO"}, healthCheckWithType{typ: "BAR"})
+		return createTestServer(t, initFn, installCfg, logOutputBuffer).
+			WithHealth(healthCheckWithType{typ: "BAZ"}).
+			WithHealth(
+				healthCheckWithType{typ: "FOO"},
+				healthCheckWithType{typ: "BAR"},
+			)
 	})
 
 	defer func() {
@@ -71,6 +76,12 @@ func TestAddHealthCheckSources(t *testing.T) {
 			},
 			health.CheckType("BAR"): {
 				Type:    health.CheckType("BAR"),
+				State:   health.New_HealthState(health.HealthState_HEALTHY),
+				Message: nil,
+				Params:  make(map[string]interface{}),
+			},
+			health.CheckType("BAZ"): {
+				Type:    health.CheckType("BAZ"),
 				State:   health.New_HealthState(health.HealthState_HEALTHY),
 				Message: nil,
 				Params:  make(map[string]interface{}),

--- a/integration/liveness_and_readiness_test.go
+++ b/integration/liveness_and_readiness_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2018 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/palantir/pkg/httpserver"
+	healthstatus "github.com/palantir/witchcraft-go-health/v2/status"
+	"github.com/palantir/witchcraft-go-server/v3/config"
+	"github.com/palantir/witchcraft-go-server/v3/status"
+	"github.com/palantir/witchcraft-go-server/v3/witchcraft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddLivenessSource verifies that custom liveness sources can be configured both via
+// WithLiveness on the server and via info.Router.WithLiveness in the init function,
+// and that the later call overrides the earlier one.
+func TestAddLivenessSource(t *testing.T) {
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+		func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+			return nil, nil
+		},
+		io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+			return createTestServer(t, initFn, installCfg, logOutputBuffer).
+				WithLiveness(customLivenessSource{statusCode: http.StatusOK, metadata: map[string]string{"source": "server"}})
+		})
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	resp, err := testServerClient().Get(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.LivenessEndpoint))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestAddReadinessSource verifies that custom readiness sources can be configured both via
+// WithReadiness on the server and via info.Router.WithReadiness in the init function,
+// and that the later call overrides the earlier one.
+func TestAddReadinessSource(t *testing.T) {
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+		func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+			return nil, nil
+		},
+		io.Discard, func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+			return createTestServer(t, initFn, installCfg, logOutputBuffer).
+				WithReadiness(customReadinessSource{statusCode: http.StatusOK, metadata: map[string]string{"source": "server"}})
+		})
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	resp, err := testServerClient().Get(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.ReadinessEndpoint))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestLivenessAndReadinessNotReady verifies that custom liveness and readiness sources
+// can report non-OK status codes.
+func TestLivenessAndReadinessNotReady(t *testing.T) {
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+		func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+			info.Router.WithLiveness(customLivenessSource{statusCode: http.StatusServiceUnavailable, metadata: map[string]string{"reason": "not live"}})
+			info.Router.WithReadiness(customReadinessSource{statusCode: http.StatusServiceUnavailable, metadata: map[string]string{"reason": "not ready"}})
+			return nil, nil
+		},
+		io.Discard, createTestServer)
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+
+	livenessResp, err := testServerClient().Get(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.LivenessEndpoint))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, livenessResp.StatusCode)
+
+	readinessResp, err := testServerClient().Get(fmt.Sprintf("https://localhost:%d/%s/%s", port, basePath, status.ReadinessEndpoint))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, readinessResp.StatusCode)
+
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+type customLivenessSource struct {
+	statusCode int
+	metadata   map[string]string
+}
+
+func (c customLivenessSource) Status() (respStatus int, metadata interface{}) {
+	return c.statusCode, c.metadata
+}
+
+var _ healthstatus.Source = customLivenessSource{}
+
+type customReadinessSource struct {
+	statusCode int
+	metadata   map[string]string
+}
+
+func (c customReadinessSource) Status() (respStatus int, metadata interface{}) {
+	return c.statusCode, c.metadata
+}
+
+var _ healthstatus.Source = customReadinessSource{}

--- a/status/routes/routes.go
+++ b/status/routes/routes.go
@@ -25,11 +25,11 @@ import (
 	"github.com/palantir/witchcraft-go-server/v3/wrouter"
 )
 
-func AddLivenessRoutes(resource wresource.Resource, source healthstatus.Source) error {
+func AddLivenessRoutes(resource wresource.Resource, source refreshable.Refreshable[healthstatus.Source]) error {
 	return resource.Get("liveness", status.LivenessEndpoint, handler(source), wrouter.DisableTelemetry())
 }
 
-func AddReadinessRoutes(resource wresource.Resource, source healthstatus.Source) error {
+func AddReadinessRoutes(resource wresource.Resource, source refreshable.Refreshable[healthstatus.Source]) error {
 	return resource.Get("readiness", status.ReadinessEndpoint, handler(source), wrouter.DisableTelemetry())
 }
 
@@ -40,9 +40,9 @@ func AddHealthRoutes(resource wresource.Resource, source healthstatus.HealthChec
 // handler returns an HTTP handler that writes a response based on the provided source. The status code of the response
 // is determined based on the status reported by the source and the status metadata returned by the source is written as
 // JSON in the response body.
-func handler(source healthstatus.Source) http.Handler {
+func handler(source refreshable.Refreshable[healthstatus.Source]) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		respCode, metadata := source.Status()
+		respCode, metadata := source.Current().Status()
 
 		// if metadata is nil, create an empty json object instead of returning 'null' which http-remoting rejects.
 		if metadata == nil {

--- a/status/routes/routes_test.go
+++ b/status/routes/routes_test.go
@@ -43,7 +43,7 @@ func TestAddStatusRoutes(t *testing.T) {
 
 	for i, tc := range []struct {
 		endpoint  string
-		routeFunc func(resource wresource.Resource, source healthstatus.Source) error
+		routeFunc func(resource wresource.Resource, source refreshable.Refreshable[healthstatus.Source]) error
 		status    int
 		metadata  testMetadata
 	}{
@@ -69,9 +69,9 @@ func TestAddStatusRoutes(t *testing.T) {
 		func() {
 			r := wrouter.New(whttprouter.New(), nil)
 			resource := wresource.New("test", r)
-			err := tc.routeFunc(resource, statusFunc(func() (int, interface{}) {
+			err := tc.routeFunc(resource, refreshable.New[healthstatus.Source](statusFunc(func() (int, interface{}) {
 				return tc.status, tc.metadata
-			}))
+			})))
 			require.NoError(t, err, "Case %d", i)
 
 			server := httptest.NewServer(r)

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -64,9 +64,11 @@ func (s *Server[I, R]) addRoutes(ctx context.Context, mgmtRouterWithContextPath 
 	healthSharedSecret := refreshable.MapContext(ctx, runtimeCfg, func(cfg R) string {
 		return cfg.BaseRuntimeConfig().HealthChecks.SharedSecret
 	})
+	// And attach the stateManager endpoint
+	s.WithHealth(&s.stateManager)
 	if err := routes.AddHealthRoutes(
 		statusResource,
-		healthstatus.NewCombinedHealthCheckSource(append(s.healthCheckSources, &s.stateManager)...),
+		healthstatus.NewCombinedHealthCheckSourceWithRefresh(s.healthCheckSources),
 		healthSharedSecret,
 		s.healthStatusChangeHandlers,
 	); err != nil {

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -77,7 +77,7 @@ func (s *Server[I, R]) addRoutes(ctx context.Context, mgmtRouterWithContextPath 
 
 	// add liveness endpoints
 	if s.livenessSource == nil {
-		s.livenessSource = &s.stateManager
+		s.livenessSource = refreshable.New[healthstatus.Source](&s.stateManager)
 	}
 	if err := routes.AddLivenessRoutes(statusResource, s.livenessSource); err != nil {
 		return werror.Wrap(err, "failed to register liveness routes")
@@ -85,7 +85,7 @@ func (s *Server[I, R]) addRoutes(ctx context.Context, mgmtRouterWithContextPath 
 
 	// add readiness endpoints
 	if s.readinessSource == nil {
-		s.readinessSource = &s.stateManager
+		s.readinessSource = refreshable.New[healthstatus.Source](&s.stateManager)
 	}
 	if err := routes.AddReadinessRoutes(statusResource, s.readinessSource); err != nil {
 		return werror.Wrap(err, "failed to register readiness routes")

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -113,11 +113,11 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 
 	// specifies the source used to provide the readiness information for the server. If nil, a default value that uses
 	// the server's status is used.
-	readinessSource healthstatus.Source
+	readinessSource refreshable.Updatable[healthstatus.Source]
 
 	// specifies the source used to provide the liveness information for the server. If nil, a default value that uses
 	// the server's status is used.
-	livenessSource healthstatus.Source
+	livenessSource refreshable.Updatable[healthstatus.Source]
 
 	// specifies the sources that are used to determine the health of this service.
 	// This is a refreshable to allow health checks to be added dynamically after server startup.
@@ -404,6 +404,9 @@ func (s *Server[I, R]) WithHealth(healthSources ...healthstatus.HealthCheckSourc
 
 // WithReadiness configures the server to use the specified source to report readiness.
 func (s *Server[I, R]) WithReadiness(readiness healthstatus.Source) *Server[I, R] {
+	if s.readinessSource == nil {
+
+	}
 	s.readinessSource = readiness
 	return s
 }

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -119,8 +119,9 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 	// the server's status is used.
 	livenessSource healthstatus.Source
 
-	// specifies the sources that are used to determine the health of this service
-	healthCheckSources []healthstatus.HealthCheckSource
+	// specifies the sources that are used to determine the health of this service.
+	// This is a refreshable to allow health checks to be added dynamically after server startup.
+	healthCheckSources refreshable.Updatable[[]healthstatus.HealthCheckSource]
 
 	// specifies the handlers to invoke upon health status changes. The LoggingHealthStatusChangeHandler is added by default.
 	healthStatusChangeHandlers []status.HealthStatusChangeHandler
@@ -394,7 +395,10 @@ func (s *Server[I, R]) WithClientAuth(clientAuth tls.ClientAuthType) *Server[I, 
 // healthSource's results have the same key, the result from the latest entry in healthSources will be used. These
 // results are combined with the server's built-in health source, which uses the `SERVER_STATUS` key.
 func (s *Server[I, R]) WithHealth(healthSources ...healthstatus.HealthCheckSource) *Server[I, R] {
-	s.healthCheckSources = healthSources
+	if s.healthCheckSources == nil {
+		s.healthCheckSources = refreshable.New([]healthstatus.HealthCheckSource{})
+	}
+	s.healthCheckSources.Update(append(s.healthCheckSources.Current(), healthSources...))
 	return s
 }
 
@@ -804,7 +808,7 @@ func (s *Server[I, R]) Start() (rErr error) {
 	}
 
 	// add all internally defined health check sources to the user supplied ones after running the initFn.
-	s.healthCheckSources = append(s.healthCheckSources, internalHealthCheckSources...)
+	s.WithHealth(internalHealthCheckSources...)
 
 	// add routes for health, liveness and readiness. Must be done after initFn to ensure that any
 	// health/liveness/readiness configuration updated by initFn is applied.

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -405,15 +405,20 @@ func (s *Server[I, R]) WithHealth(healthSources ...healthstatus.HealthCheckSourc
 // WithReadiness configures the server to use the specified source to report readiness.
 func (s *Server[I, R]) WithReadiness(readiness healthstatus.Source) *Server[I, R] {
 	if s.readinessSource == nil {
-
+		s.readinessSource = refreshable.New(readiness)
+	} else {
+		s.readinessSource.Update(readiness)
 	}
-	s.readinessSource = readiness
 	return s
 }
 
 // WithLiveness configures the server to use the specified source to report liveness.
 func (s *Server[I, R]) WithLiveness(liveness healthstatus.Source) *Server[I, R] {
-	s.livenessSource = liveness
+	if s.livenessSource == nil {
+		s.livenessSource = refreshable.New(liveness)
+	} else {
+		s.livenessSource.Update(liveness)
+	}
 	return s
 }
 


### PR DESCRIPTION
- Move healthCheckSources, liveness source, and readiness source to be a refreshable
- This allows all management targets to be updateable even after the server has started. This is needed for built in leader-election
- Allow multiple invocations of WithHealth Fixes a bug in which health checks are dropped by users that call `WithHealth` multiple times 
- Used in https://github.com/palantir/witchcraft-go-server/pull/1051