### PR TITLE
improvement: Expose a AddMustSucceedRunnable to the RunnableManager interface

### DIFF
--- a/witchcraft/runnable_manager.go
+++ b/witchcraft/runnable_manager.go
@@ -34,6 +34,8 @@ type RunnableManager interface {
 	// background task. The provided context should be the server's context, which will be used
 	// for cancellation propagation and logging.
 	AddForeverRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
+
+	AddMustSucceedRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
 }
 
 type defaultRunnableManager struct {
@@ -48,11 +50,20 @@ func NewRunnableManager(serverShutdown func(ctx context.Context)) RunnableManage
 
 func (d *defaultRunnableManager) AddForeverRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable) {
 	for _, runnable := range namedRunnables {
-		d.startRunnable(ctx, runnable)
+		d.startRunnable(ctx, runnable, true)
 	}
 }
 
-func (d *defaultRunnableManager) startRunnable(ctx context.Context, runnableArg function.NamedRunnable) {
+func (d *defaultRunnableManager) AddMustSucceedRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable) {
+	for _, runnable := range namedRunnables {
+		d.startRunnable(ctx, runnable, false)
+	}
+}
+
+func (d *defaultRunnableManager) startRunnable(
+	ctx context.Context,
+	runnableArg function.NamedRunnable,
+	errorOnNilRunnableError bool) {
 	finalRunnable := runnable.WithWrappers(
 		runnable.WithServiceLogging(),
 		runnable.WithFatalLogging(),
@@ -64,9 +75,10 @@ func (d *defaultRunnableManager) startRunnable(ctx context.Context, runnableArg 
 			d.serverShutdown(ctx)
 			return
 		}
-		svc1log.FromContext(ctx).Error("Terminal runnable unexpectedly terminated, shutting down server")
-		d.serverShutdown(ctx)
+		if errorOnNilRunnableError {
+			svc1log.FromContext(ctx).Error("Terminal runnable unexpectedly terminated, shutting down server")
+			d.serverShutdown(ctx)
+		}
 		return
 	}()
-
 }

--- a/witchcraft/runnable_manager.go
+++ b/witchcraft/runnable_manager.go
@@ -35,6 +35,13 @@ type RunnableManager interface {
 	// for cancellation propagation and logging.
 	AddForeverRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
 
+	// AddMustSucceedRunnable registers one or more NamedRunnables that must complete successfully
+	// but are not expected to run indefinitely. Each runnable is started in its own goroutine and
+	// wrapped with service logging and fatal error handling. If any runnable returns an error,
+	// the server will be shut down. However, unlike AddForeverRunnable, if a runnable completes
+	// successfully (returns nil), no shutdown is triggered. This is useful for one-time initialization
+	// tasks or background jobs that are expected to complete. The provided context should be the
+	// server's context, which will be used for cancellation propagation and logging.
 	AddMustSucceedRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
 }
 

--- a/witchcraft/runnable_manager_test.go
+++ b/witchcraft/runnable_manager_test.go
@@ -98,3 +98,38 @@ func TestRunnableManager_AddForeverRunnable_EmptyRunnables(t *testing.T) {
 	manager.AddForeverRunnable(ctx)
 	assert.False(t, shutdownCalled.Load(), "serverShutdown should not be called when no runnables are added")
 }
+
+func TestRunnableManager_AddMustSucceedRunnable_RunnableSucceeds_NoShutdown(t *testing.T) {
+	var shutdownCalled atomic.Bool
+	serverShutdown := func(ctx context.Context) {
+		shutdownCalled.Store(true)
+	}
+	manager := NewRunnableManager(serverShutdown)
+	ctx := context.Background()
+	var runnableRan atomic.Bool
+	testRunnable := runnable.New("test-runnable", func(ctx context.Context) error {
+		runnableRan.Store(true)
+		return nil
+	})
+	manager.AddMustSucceedRunnable(ctx, testRunnable)
+	require.Eventually(t, func() bool {
+		return runnableRan.Load()
+	}, time.Second, 10*time.Millisecond, "runnable should have run")
+	assert.False(t, shutdownCalled.Load(), "serverShutdown should not be called when runnable succeeds")
+}
+
+func TestRunnableManager_AddMustSucceedRunnable_RunnableReturnsError_CallsShutdown(t *testing.T) {
+	var shutdownCalled atomic.Bool
+	serverShutdown := func(ctx context.Context) {
+		shutdownCalled.Store(true)
+	}
+	manager := NewRunnableManager(serverShutdown)
+	ctx := context.Background()
+	testRunnable := runnable.New("error-runnable", func(ctx context.Context) error {
+		return werror.Error("runnable error")
+	})
+	manager.AddMustSucceedRunnable(ctx, testRunnable)
+	require.Eventually(t, func() bool {
+		return shutdownCalled.Load()
+	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when runnable returns error")
+}

--- a/witchcraft/task_manager.go
+++ b/witchcraft/task_manager.go
@@ -45,3 +45,7 @@ func (d *defaultTaskManager) AddJobs(ctx context.Context, jobsArg ...jobs.Job) {
 func (d *defaultTaskManager) AddForeverRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable) {
 	d.runnableManager.AddForeverRunnable(ctx, namedRunnables...)
 }
+
+func (d *defaultTaskManager) AddMustSucceedRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable) {
+	d.runnableManager.AddMustSucceedRunnable(ctx, namedRunnables...)
+}


### PR DESCRIPTION
- Expose a AddMustSucceedRunnable to the RunnableManager interface
```
	// AddMustSucceedRunnable registers one or more NamedRunnables that must complete successfully
	// but are not expected to run indefinitely. Each runnable is started in its own goroutine and
	// wrapped with service logging and fatal error handling. If any runnable returns an error,
	// the server will be shut down. However, unlike AddForeverRunnable, if a runnable completes
	// successfully (returns nil), no shutdown is triggered. This is useful for one-time initialization
	// tasks or background jobs that are expected to complete. The provided context should be the
	// server's context, which will be used for cancellation propagation and logging.
```