### PR TITLE
Add a setter for the server IDs extractor

### DIFF
--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -608,6 +608,13 @@ func (s *Server[I, R]) WithJobRunnerHealthCheck(jobRunnerHealthCheck window.Keye
 	return s
 }
 
+// WithIDsExtractor configures the server to use the specified extractor for extracting identifiers (such as UID, SID, TokenID)
+// from requests for request logging and middleware. If not set, uses extractor.NewDefaultIDsExtractor().
+func (s *Server[I, R]) WithIDsExtractor(idsExtractor extractor.IDsFromRequest) *Server[I, R] {
+	s.idsExtractor = idsExtractor
+	return s
+}
+
 // WithEnableDualLogAuditV3ToAuditV2 enables dual-writing audit v3 logs to audit v2 logs.
 // This is an experimental feature: the functionality or function itself may be removed in the future.
 func (s *Server[I, R]) WithEnableDualLogAuditV3ToAuditV2() *Server[I, R] {


### PR DESCRIPTION
## Before this PR
The server did not allow configuration of the logic that extracted IDs from requests for inclusion in logs. For servers that use e.g. TLS client auth rather than JWT auth logs wouldn't have all of the information they could.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Added a `Server.WithIDsExtractor` method.
==COMMIT_MSG==
