### PR TITLE
fix: Respect runnables that have a graceful exit to context being canceled 

### DIFF
--- a/witchcraft/runnable_manager.go
+++ b/witchcraft/runnable_manager.go
@@ -29,19 +29,21 @@ import (
 type RunnableManager interface {
 	// AddForeverRunnable registers one or more NamedRunnables that are expected to run indefinitely
 	// for the lifetime of the server. Each runnable is started in its own goroutine and wrapped with
-	// service logging and fatal error handling. If any runnable returns (with or without an error),
-	// the server will be shut down, as this indicates an unexpected termination of a critical
-	// background task. The provided context should be the server's context, which will be used
-	// for cancellation propagation and logging.
+	// service logging and fatal error handling. If any runnable returns with an error, the server
+	// will be shut down. If a runnable returns nil without an error, the server will be shut down
+	// unless the context was canceled, as a nil return without context cancellation indicates an
+	// unexpected termination of a critical background task. The provided context should be the
+	// server's context, which will be used for cancellation propagation and logging.
 	AddForeverRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
 
 	// AddMustSucceedRunnable registers one or more NamedRunnables that must complete successfully
 	// but are not expected to run indefinitely. Each runnable is started in its own goroutine and
 	// wrapped with service logging and fatal error handling. If any runnable returns an error,
 	// the server will be shut down. However, unlike AddForeverRunnable, if a runnable completes
-	// successfully (returns nil), no shutdown is triggered. This is useful for one-time initialization
-	// tasks or background jobs that are expected to complete. The provided context should be the
-	// server's context, which will be used for cancellation propagation and logging.
+	// successfully (returns nil), no shutdown is triggered regardless of context state. This is
+	// useful for one-time initialization tasks or background jobs that are expected to complete.
+	// The provided context should be the server's context, which will be used for cancellation
+	// propagation and logging.
 	AddMustSucceedRunnable(ctx context.Context, namedRunnables ...function.NamedRunnable)
 }
 
@@ -83,9 +85,12 @@ func (d *defaultRunnableManager) startRunnable(
 			return
 		}
 		if errorOnNilRunnableError {
+			if ctx.Err() != nil {
+				svc1log.FromContext(ctx).Info("Terminal runnable terminated due to context cancellation")
+				return
+			}
 			svc1log.FromContext(ctx).Error("Terminal runnable unexpectedly terminated, shutting down server")
 			d.serverShutdown(ctx)
 		}
-		return
 	}()
 }

--- a/witchcraft/runnable_manager_test.go
+++ b/witchcraft/runnable_manager_test.go
@@ -133,3 +133,42 @@ func TestRunnableManager_AddMustSucceedRunnable_RunnableReturnsError_CallsShutdo
 		return shutdownCalled.Load()
 	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when runnable returns error")
 }
+
+func TestRunnableManager_AddMustSucceedRunnable_RunnablePanics_CallsShutdown(t *testing.T) {
+	var shutdownCalled atomic.Bool
+	serverShutdown := func(ctx context.Context) {
+		shutdownCalled.Store(true)
+	}
+	manager := NewRunnableManager(serverShutdown)
+	ctx := context.Background()
+	testRunnable := runnable.New("panic-runnable", func(ctx context.Context) error {
+		panic("test panic")
+	})
+	manager.AddMustSucceedRunnable(ctx, testRunnable)
+	require.Eventually(t, func() bool {
+		return shutdownCalled.Load()
+	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when runnable panics")
+}
+
+func TestRunnableManager_AddForeverRunnable_ContextCanceled_CallsShutdown(t *testing.T) {
+	var shutdownCalled atomic.Bool
+	serverShutdown := func(ctx context.Context) {
+		shutdownCalled.Store(true)
+	}
+	manager := NewRunnableManager(serverShutdown)
+	ctx, cancel := context.WithCancel(context.Background())
+	var runnableRan atomic.Bool
+	testRunnable := runnable.New("context-runnable", func(ctx context.Context) error {
+		runnableRan.Store(true)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	manager.AddForeverRunnable(ctx, testRunnable)
+	require.Eventually(t, func() bool {
+		return runnableRan.Load()
+	}, time.Second, 10*time.Millisecond, "runnable should have started")
+	cancel()
+	require.Eventually(t, func() bool {
+		return shutdownCalled.Load()
+	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when context is canceled")
+}

--- a/witchcraft/runnable_manager_test.go
+++ b/witchcraft/runnable_manager_test.go
@@ -150,25 +150,23 @@ func TestRunnableManager_AddMustSucceedRunnable_RunnablePanics_CallsShutdown(t *
 	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when runnable panics")
 }
 
-func TestRunnableManager_AddForeverRunnable_ContextCanceled_CallsShutdown(t *testing.T) {
+func TestRunnableManager_AddForeverRunnable_ContextCanceled_NoShutdown(t *testing.T) {
 	var shutdownCalled atomic.Bool
 	serverShutdown := func(ctx context.Context) {
 		shutdownCalled.Store(true)
 	}
 	manager := NewRunnableManager(serverShutdown)
 	ctx, cancel := context.WithCancel(context.Background())
-	var runnableRan atomic.Bool
+	var runnableFinished atomic.Bool
 	testRunnable := runnable.New("context-runnable", func(ctx context.Context) error {
-		runnableRan.Store(true)
 		<-ctx.Done()
-		return ctx.Err()
+		runnableFinished.Store(true)
+		return nil
 	})
 	manager.AddForeverRunnable(ctx, testRunnable)
-	require.Eventually(t, func() bool {
-		return runnableRan.Load()
-	}, time.Second, 10*time.Millisecond, "runnable should have started")
 	cancel()
 	require.Eventually(t, func() bool {
-		return shutdownCalled.Load()
-	}, time.Second, 10*time.Millisecond, "serverShutdown should be called when context is canceled")
+		return runnableFinished.Load()
+	}, time.Second, 10*time.Millisecond, "runnable should have finished")
+	assert.False(t, shutdownCalled.Load(), "serverShutdown should not be called when context is canceled")
 }


### PR DESCRIPTION
- Respect runnables that have a graceful exit to context being canceled
- Add a new test to ensure that panics are caught