### PR TITLE
Add install/runtime config validation

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+
+	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
+)
+
+const (
+	// ValidationFailureMetric is the name of the counter metric emitted when
+	// [Validator.Validate] returns an error and MetricOnFailure is enabled.
+	ValidationFailureMetric = "server.config.validation.failure"
+)
+
+// Validator is an optional interface that config structs can implement
+// to provide validation logic. If a config struct implements this interface
+// and validation is enabled via WithInstallConfigValidation or
+// WithRuntimeConfigValidation, the Validate method will be called
+// after unmarshaling the config.
+type Validator interface {
+	Validate(ctx context.Context) error
+}
+
+// InstallConfigValidationOptions configures validation behavior for install configuration.
+// Install config validation has limited options since logging, health checks, and metrics
+// all depend on install config being loaded first. Validation errors always fail at startup
+// since install config cannot be changed at runtime.
+type InstallConfigValidationOptions struct {
+	// StrictUnmarshaling enables strict YAML unmarshaling that fails on unknown fields.
+	StrictUnmarshaling bool
+}
+
+// RuntimeConfigValidationOptions configures validation behavior for runtime configuration.
+type RuntimeConfigValidationOptions struct {
+	// StrictUnmarshaling enables strict YAML unmarshaling that fails on unknown fields.
+	// Strict unmarshaling errors always fail at startup and reject reloads.
+	StrictUnmarshaling bool
+
+	// LogOnFailure logs [Validator.Validate] errors if they occur.
+	LogOnFailure bool
+
+	// MetricOnFailure emits a counter metric when [Validator.Validate] returns an error.
+	// The metric name is [ValidationFailureMetric].
+	MetricOnFailure bool
+
+	// HealthCheckOnFailure sets a health check to the specified state when
+	// [Validator.Validate] fails. If nil, no health check is affected.
+	HealthCheckOnFailure *HealthCheckOnFailure
+
+	// FailStartupOnError causes the server to fail to start if the initial runtime config
+	// validation fails. When false, the server starts even with invalid config, but other
+	// failure actions (logging, metrics, health checks) still apply if configured.
+	FailStartupOnError bool
+
+	// RejectInvalidReload causes config reloads to be rejected if validation fails,
+	// keeping the previous config. When false, invalid config is accepted on reload,
+	// but other failure actions (logging, metrics, health checks) still apply if configured.
+	RejectInvalidReload bool
+}
+
+// HealthCheckOnFailure configures health check behavior when validation fails.
+type HealthCheckOnFailure struct {
+	// HealthState is the health state to set when validation fails.
+	// This should be a non-HEALTHY state such as ERROR or WARNING.
+	// The health check will report HEALTHY when validation succeeds.
+	HealthState health.HealthState_Value
+}

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -36,6 +36,7 @@ import (
 	"github.com/palantir/pkg/refreshable/v2"
 	"github.com/palantir/pkg/signals"
 	werror "github.com/palantir/witchcraft-go-error"
+	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-health/v2/sources/window"
 	healthstatus "github.com/palantir/witchcraft-go-health/v2/status"
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
@@ -228,6 +229,14 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 	// If nil, a default health check with type "WITCHCRAFT_JOB_RUNNER" is created.
 	jobRunnerHealthCheck window.KeyedErrorHealthCheckSource
 
+	// installConfigValidation configures validation behavior for install configuration.
+	// If nil, install config will not be validated.
+	installConfigValidation *config.InstallConfigValidationOptions
+
+	// runtimeConfigValidation configures validation behavior for runtime configuration.
+	// If nil, runtime config will not be validated.
+	runtimeConfigValidation *config.RuntimeConfigValidationOptions
+
 	// loggers
 	svcLogger    svc1log.Logger
 	evtLogger    evt2log.Logger
@@ -329,6 +338,17 @@ func (s *Server[I, R]) WithInstallConfigProvider(p ConfigBytesProvider) *Server[
 	return s
 }
 
+// WithInstallConfigValidation configures validation behavior for install configuration.
+// If the config struct implements [config.Validator], the Validate method will be called
+// after unmarshaling. Note that logging, health checks, and metrics are not available
+// during install config validation since they depend on the install config being loaded first.
+//
+// See [config.InstallConfigValidationOptions] for available options.
+func (s *Server[I, R]) WithInstallConfigValidation(opts config.InstallConfigValidationOptions) *Server[I, R] {
+	s.installConfigValidation = &opts
+	return s
+}
+
 // WithRuntimeConfig configures the server to use the provided runtime configuration. The provided runtime configuration
 // must support being marshaled as YAML.
 func (s *Server[I, R]) WithRuntimeConfig(in R) *Server[I, R] {
@@ -368,6 +388,15 @@ func (s *Server[I, R]) WithRuntimeConfigFromFile(fpath string) *Server[I, R] {
 	s.runtimeConfigProvider = func(ctx context.Context) refreshable.Validated[[]byte] {
 		return refreshable.NewFileRefreshable(ctx, fpath)
 	}
+	return s
+}
+
+// WithRuntimeConfigValidation configures validation behavior for runtime configuration.
+// If the config struct implements [config.Validator], the Validate method will be called after unmarshaling.
+//
+// See [config.RuntimeConfigValidationOptions] for available options.
+func (s *Server[I, R]) WithRuntimeConfigValidation(opts config.RuntimeConfigValidationOptions) *Server[I, R] {
+	s.runtimeConfigValidation = &opts
 	return s
 }
 
@@ -629,7 +658,8 @@ const (
 	installConfigPath = "var/conf/install.yml"
 	runtimeConfigPath = "var/conf/runtime.yml"
 
-	runtimeConfigReloadCheckType = "CONFIG_RELOAD"
+	runtimeConfigReloadCheckType     = "CONFIG_RELOAD"
+	runtimeConfigValidationCheckType = "CONFIG_VALIDATION"
 )
 
 // Start begins serving HTTPS traffic and blocks until s.Close() or s.Shutdown() return.
@@ -736,11 +766,11 @@ func (s *Server[I, R]) Start() (rErr error) {
 	ctx = s.withLoggers(ctx)
 
 	// load runtime configuration
-	refreshableRuntimeCfg, configReloadHealthCheckSource, err := s.initRuntimeConfig(ctx)
+	refreshableRuntimeCfg, configHealthCheckSources, err := s.initRuntimeConfig(ctx)
 	if err != nil {
 		return err
 	}
-	internalHealthCheckSources := []healthstatus.HealthCheckSource{configReloadHealthCheckSource}
+	internalHealthCheckSources := configHealthCheckSources
 
 	// set up SERVICE_DEPENDENCY check
 	if !s.disableServiceDependencyHealth {
@@ -928,14 +958,30 @@ func (s *Server[I, R]) initInstallConfig() (zero I, _ error) {
 	if err != nil {
 		return zero, werror.Wrap(err, "Failed to decrypt install configuration bytes")
 	}
+
+	unmarshalFn := s.configYAMLUnmarshalFn
+	if s.installConfigValidation != nil && s.installConfigValidation.StrictUnmarshaling {
+		unmarshalFn = yaml.UnmarshalStrict
+	}
+
 	var installConfigStruct I
-	if err := s.configYAMLUnmarshalFn(cfgBytes, &installConfigStruct); err != nil {
+	if err := unmarshalFn(cfgBytes, &installConfigStruct); err != nil {
 		return zero, werror.Wrap(err, "Failed to unmarshal install specific configuration YAML")
 	}
+
+	// Validate config if it implements Validator and validation is enabled
+	if s.installConfigValidation != nil {
+		if validator, ok := any(installConfigStruct).(config.Validator); ok {
+			if err := validator.Validate(context.Background()); err != nil {
+				return zero, werror.Wrap(err, "Install configuration validation failed")
+			}
+		}
+	}
+
 	return installConfigStruct, nil
 }
 
-func (s *Server[I, R]) initRuntimeConfig(ctx context.Context) (rCfg refreshable.Refreshable[R], hcSrc healthstatus.HealthCheckSource, rErr error) {
+func (s *Server[I, R]) initRuntimeConfig(ctx context.Context) (rCfg refreshable.Refreshable[R], hcSrcs []healthstatus.HealthCheckSource, rErr error) {
 	if s.runtimeConfigProvider == nil {
 		// if runtime provider is not specified, use a file-based one
 		s.runtimeConfigProvider = func(ctx context.Context) refreshable.Validated[[]byte] {
@@ -947,29 +993,127 @@ func (s *Server[I, R]) initRuntimeConfig(ctx context.Context) (rCfg refreshable.
 	if _, err := runtimeConfigProvider.Validation(); err != nil {
 		return nil, nil, err
 	}
+
+	// Track validation errors for health check and whether we're at startup
+	var lastValidationErr atomic.Pointer[error]
+	var isStartup atomic.Bool
+	isStartup.Store(true)
+
 	unmarshalledRuntimeConfig, _, err := refreshable.MapWithError(runtimeConfigProvider, func(cfgBytes []byte) (R, error) {
+		startup := isStartup.Swap(false)
+
 		cfgBytes, err := s.decryptConfigBytes(cfgBytes)
 		if err != nil {
 			s.svcLogger.Warn("Failed to decrypt encrypted runtime configuration", svc1log.Stacktrace(err))
 		}
-		var runtimeCfg R
-		if err := s.configYAMLUnmarshalFn(cfgBytes, &runtimeCfg); err != nil {
-			var zero R
-			return zero, err
+
+		unmarshalFn := s.configYAMLUnmarshalFn
+		if s.runtimeConfigValidation != nil && s.runtimeConfigValidation.StrictUnmarshaling {
+			unmarshalFn = yaml.UnmarshalStrict
 		}
+
+		var runtimeCfg R
+		if err := unmarshalFn(cfgBytes, &runtimeCfg); err != nil {
+			var zero R
+			return zero, werror.Wrap(err, "Failed to unmarshal runtime configuration YAML")
+		}
+
+		// Validate config if it implements Validator and validation is enabled
+		if s.runtimeConfigValidation != nil {
+			if validator, ok := any(runtimeCfg).(config.Validator); ok {
+				if err := validator.Validate(ctx); err != nil {
+					validationErr := werror.Wrap(err, "Runtime configuration validation failed")
+					lastValidationErr.Store(&validationErr)
+					return s.handleRuntimeValidationError(ctx, runtimeCfg, validationErr, startup)
+				}
+			}
+		}
+
+		// Clear any previous validation error on success
+		lastValidationErr.Store(nil)
 		return runtimeCfg, nil
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	validatingRefreshableHealthCheckSource := refreshablehealth.NewValidatingRefreshableHealthCheckSource(
-		runtimeConfigReloadCheckType,
-		refreshablehealth.ValidationErrFunc(runtimeConfigProvider),
-		refreshablehealth.ValidationErrFunc(unmarshalledRuntimeConfig),
-	)
+	healthCheckSources := []healthstatus.HealthCheckSource{
+		refreshablehealth.NewValidatingRefreshableHealthCheckSource(
+			runtimeConfigReloadCheckType,
+			refreshablehealth.ValidationErrFunc(runtimeConfigProvider),
+			refreshablehealth.ValidationErrFunc(unmarshalledRuntimeConfig),
+		),
+	}
 
-	return unmarshalledRuntimeConfig, validatingRefreshableHealthCheckSource, nil
+	// Add CONFIG_VALIDATION health check
+	if s.runtimeConfigValidation != nil && s.runtimeConfigValidation.HealthCheckOnFailure != nil {
+		healthCheckSources = append(healthCheckSources, &configValidationHealthCheckSource{
+			lastErr:     &lastValidationErr,
+			healthState: s.runtimeConfigValidation.HealthCheckOnFailure.HealthState,
+		})
+	}
+
+	return unmarshalledRuntimeConfig, healthCheckSources, nil
+}
+
+// handleRuntimeValidationError applies configured failure actions for validation errors and returns
+// the appropriate result. This should only be called for [config.Validator] errors, not unmarshal errors.
+func (s *Server[I, R]) handleRuntimeValidationError(ctx context.Context, cfg R, err error, isStartup bool) (R, error) {
+	var zero R
+	if s.runtimeConfigValidation == nil {
+		return zero, err
+	}
+	if s.runtimeConfigValidation.LogOnFailure {
+		s.svcLogger.Warn("Runtime configuration validation error", svc1log.Stacktrace(err))
+	}
+	if s.runtimeConfigValidation.MetricOnFailure {
+		metrics.FromContext(ctx).Counter(config.ValidationFailureMetric, metrics.MustNewTag("config-type", "runtime")).Inc(1)
+	}
+	if isStartup && s.runtimeConfigValidation.FailStartupOnError {
+		return zero, err
+	}
+	if !isStartup && s.runtimeConfigValidation.RejectInvalidReload {
+		return zero, err
+	}
+	return cfg, nil
+}
+
+// configValidationHealthCheckSource provides health check status based on validation errors.
+type configValidationHealthCheckSource struct {
+	lastErr     *atomic.Pointer[error]
+	healthState health.HealthState_Value
+}
+
+func (c *configValidationHealthCheckSource) HealthStatus(ctx context.Context) health.HealthStatus {
+	checkType := health.CheckType(runtimeConfigValidationCheckType)
+	if errPtr := c.lastErr.Load(); errPtr != nil {
+		message := "Runtime configuration validation failed"
+		var params map[string]any
+		if wErr, ok := werror.Convert(*errPtr).(werror.Werror); ok {
+			message = wErr.Message()
+			params = map[string]any{
+				"error": wErr.SafeParams(),
+			}
+		}
+		return health.HealthStatus{
+			Checks: map[health.CheckType]health.HealthCheckResult{
+				checkType: {
+					Type:    checkType,
+					State:   health.New_HealthState(c.healthState),
+					Message: &message,
+					Params:  params,
+				},
+			},
+		}
+	}
+	return health.HealthStatus{
+		Checks: map[health.CheckType]health.HealthCheckResult{
+			checkType: {
+				Type:  checkType,
+				State: health.New_HealthState(health.HealthState_HEALTHY),
+			},
+		},
+	}
 }
 
 func (s *Server[I, R]) initStackTraceHandler(ctx context.Context) {

--- a/witchcraft/witchcraft_test.go
+++ b/witchcraft/witchcraft_test.go
@@ -33,6 +33,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/palantir/pkg/metrics"
 	werror "github.com/palantir/witchcraft-go-error"
 	"github.com/palantir/witchcraft-go-health/v2/conjure/witchcraft/api/health"
 	"github.com/palantir/witchcraft-go-logging/conjure/witchcraft/api/logging"
@@ -785,4 +786,576 @@ func TestServer_ForeverRunnableRunsUntilShutdown(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return runnableContextCancelled.Load()
 	}, time.Second, 10*time.Millisecond, "runnable context should have been cancelled")
+}
+
+// validatingInstallConfig implements config.Validator
+type validatingInstallConfig struct {
+	config.Install `yaml:",inline"`
+	DatabaseURL    string `yaml:"database-url"`
+}
+
+func (c *validatingInstallConfig) Validate(ctx context.Context) error {
+	if c.DatabaseURL == "" {
+		return werror.ErrorWithContextParams(ctx, "database-url is required")
+	}
+	return nil
+}
+
+// validatingRuntimeConfig implements config.Validator
+type validatingRuntimeConfig struct {
+	config.Runtime `yaml:",inline"`
+	MaxConnections int `yaml:"max-connections"`
+}
+
+func (c *validatingRuntimeConfig) Validate(ctx context.Context) error {
+	if c.MaxConnections < 1 || c.MaxConnections > 100 {
+		return werror.ErrorWithContextParams(ctx, "max-connections must be between 1 and 100",
+			werror.SafeParam("value", c.MaxConnections))
+	}
+	return nil
+}
+
+func TestServer_InstallConfigValidation(t *testing.T) {
+	t.Run("valid config succeeds", func(t *testing.T) {
+		err := witchcraft.NewServer[*validatingInstallConfig, config.Runtime]().
+			WithInstallConfig(&validatingInstallConfig{
+				DatabaseURL: "test-DB-URL",
+			}).
+			WithRuntimeConfig(config.Runtime{}).
+			WithInstallConfigValidation(config.InstallConfigValidationOptions{}).
+			WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+			WithDisableGoRuntimeMetrics().
+			WithSelfSignedCertificate().
+			WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo[*validatingInstallConfig, config.Runtime]) (func(), error) {
+				assert.Equal(t, "test-DB-URL", info.InstallConfig.DatabaseURL)
+				return nil, werror.Error("expected error to stop server")
+			}).
+			Start()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected error to stop server")
+	})
+
+	t.Run("invalid config errors", func(t *testing.T) {
+		err := witchcraft.NewServer[*validatingInstallConfig, config.Runtime]().
+			WithInstallConfig(&validatingInstallConfig{
+				DatabaseURL: "", // empty is invalid
+			}).
+			WithRuntimeConfig(config.Runtime{}).
+			WithInstallConfigValidation(config.InstallConfigValidationOptions{}).
+			WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+			WithDisableGoRuntimeMetrics().
+			WithSelfSignedCertificate().
+			Start()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Install configuration validation failed")
+	})
+}
+
+func TestServer_InstallConfigValidation_NoValidationWithoutOptions(t *testing.T) {
+	// WithInstallConfigValidation is not configured, so validation should not be run despite invalid config
+	err := witchcraft.NewServer[*validatingInstallConfig, config.Runtime]().
+		WithInstallConfig(&validatingInstallConfig{
+			DatabaseURL: "", // empty is invalid
+		}).
+		WithRuntimeConfig(config.Runtime{}).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate().
+		WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo[*validatingInstallConfig, config.Runtime]) (func(), error) {
+			return nil, werror.Error("expected error to stop server")
+		}).
+		Start()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected error to stop server")
+}
+
+func TestServer_InstallConfigValidation_StrictUnmarshaling(t *testing.T) {
+	// Create a temp file with unknown field
+	tmpDir := t.TempDir()
+	installPath := tmpDir + "/install.yml"
+	err := os.WriteFile(installPath, []byte(`
+database-url: "test-DB-URL"
+unknown-field: "should cause error"
+`), 0644)
+	require.NoError(t, err)
+
+	err = witchcraft.NewServer[*validatingInstallConfig, config.Runtime]().
+		WithInstallConfigFromFile(installPath).
+		WithRuntimeConfig(config.Runtime{}).
+		WithInstallConfigValidation(config.InstallConfigValidationOptions{
+			StrictUnmarshaling: true,
+		}).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate().
+		Start()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to unmarshal install specific configuration YAML")
+}
+
+func TestServer_RuntimeConfigValidation_ErrorOnFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	// Valid runtime config should succeed
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfig(&validatingRuntimeConfig{
+			MaxConnections: 50, // Valid
+		}).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			FailStartupOnError:  true,
+			RejectInvalidReload: true,
+		}).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	defer func() { _ = server.Close() }()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		serverErrChan <- server.Start()
+	}()
+
+	// Wait for server to be ready
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Shutdown
+	require.NoError(t, server.Close())
+}
+
+func TestServer_RuntimeConfigValidation_WithHealthCheck(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	tmpDir := t.TempDir()
+	runtimePath := tmpDir + "/runtime.yml"
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 50
+`), 0644)
+	require.NoError(t, err)
+
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfigFromFile(runtimePath).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			LogOnFailure: true,
+			HealthCheckOnFailure: &config.HealthCheckOnFailure{
+				HealthState: health.HealthState_WARNING,
+			},
+		}).
+		WithLoggerStdoutWriter(io.Discard).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	defer func() { _ = server.Close() }()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		serverErrChan <- server.Start()
+	}()
+
+	// Wait for server to be ready
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Verify the CONFIG_VALIDATION check is healthy
+	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var healthStatus health.HealthStatus
+	require.NoError(t, json.Unmarshal(body, &healthStatus))
+	configValidationCheck, ok := healthStatus.Checks[health.CheckType("CONFIG_VALIDATION")]
+	require.True(t, ok, "expected CONFIG_VALIDATION health check to be present, got: %v", healthStatus.Checks)
+	assert.Equal(t, health.New_HealthState(health.HealthState_HEALTHY), configValidationCheck.State)
+
+	// Now update config to be invalid
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 500
+`), 0644)
+	require.NoError(t, err)
+
+	// Wait for config reload and check health again
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var status health.HealthStatus
+		if err := json.Unmarshal(body, &status); err != nil {
+			return false
+		}
+		check, ok := status.Checks[health.CheckType("CONFIG_VALIDATION")]
+		if !ok {
+			return false
+		}
+		return check.State.Value() == health.HealthState_WARNING
+	}, 10*time.Second, 500*time.Millisecond, "CONFIG_VALIDATION health check should be WARNING after invalid config")
+
+	// Shutdown
+	require.NoError(t, server.Close())
+}
+
+func TestServer_RuntimeConfigValidation_HealthCheckRecovery(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	tmpDir := t.TempDir()
+	runtimePath := tmpDir + "/runtime.yml"
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 50
+`), 0644)
+	require.NoError(t, err)
+
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfigFromFile(runtimePath).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			HealthCheckOnFailure: &config.HealthCheckOnFailure{
+				HealthState: health.HealthState_ERROR,
+			},
+		}).
+		WithLoggerStdoutWriter(io.Discard).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	defer func() { _ = server.Close() }()
+
+	go func() {
+		_ = server.Start()
+	}()
+
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+
+	// Wait for server to be ready with HEALTHY config
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Verify initially healthy
+	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.NoError(t, err)
+	var healthStatus health.HealthStatus
+	require.NoError(t, json.Unmarshal(body, &healthStatus))
+	configCheck := healthStatus.Checks[health.CheckType("CONFIG_VALIDATION")]
+	assert.Equal(t, health.HealthState_HEALTHY, configCheck.State.Value())
+
+	// Update to invalid config
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 500
+`), 0644)
+	require.NoError(t, err)
+
+	// Wait for health check to show ERROR
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var status health.HealthStatus
+		if err := json.Unmarshal(body, &status); err != nil {
+			return false
+		}
+		check := status.Checks[health.CheckType("CONFIG_VALIDATION")]
+		return check.State.Value() == health.HealthState_ERROR
+	}, 10*time.Second, 500*time.Millisecond, "CONFIG_VALIDATION should be ERROR after invalid config")
+
+	// Update back to valid config
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 75
+`), 0644)
+	require.NoError(t, err)
+
+	// Wait for health check to recover to HEALTHY
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		defer func() { _ = resp.Body.Close() }()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var status health.HealthStatus
+		if err := json.Unmarshal(body, &status); err != nil {
+			return false
+		}
+		check := status.Checks[health.CheckType("CONFIG_VALIDATION")]
+		return check.State.Value() == health.HealthState_HEALTHY
+	}, 10*time.Second, 500*time.Millisecond, "CONFIG_VALIDATION should recover to HEALTHY after valid config")
+
+	require.NoError(t, server.Close())
+}
+
+func TestServer_RuntimeConfigValidation_StrictUnmarshaling(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	tmpDir := t.TempDir()
+	runtimePath := tmpDir + "/runtime.yml"
+	// Create config with unknown field
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 50
+unknown-field: "should cause error"
+`), 0644)
+	require.NoError(t, err)
+
+	// server should fail to start
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfigFromFile(runtimePath).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			StrictUnmarshaling:  true,
+			FailStartupOnError:  true,
+			RejectInvalidReload: true,
+		}).
+		WithLoggerStdoutWriter(io.Discard).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	err = server.Start()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed to unmarshal runtime configuration YAML")
+}
+
+func TestServer_RuntimeConfigValidation_LogOnFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	tmpDir := t.TempDir()
+	runtimePath := tmpDir + "/runtime.yml"
+	// Create invalid config
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 500
+`), 0644)
+	require.NoError(t, err)
+
+	logOutputBuffer := &bytes.Buffer{}
+
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfigFromFile(runtimePath).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			LogOnFailure:        true,
+			FailStartupOnError:  false, // Allow server to start despite validation failure
+			RejectInvalidReload: false,
+		}).
+		WithLoggerStdoutWriter(logOutputBuffer).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	defer func() { _ = server.Close() }()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		serverErrChan <- server.Start()
+	}()
+
+	// Wait for server to be ready
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Verify validation error was logged
+	assert.Contains(t, logOutputBuffer.String(), "Runtime configuration validation error")
+
+	// Shutdown
+	require.NoError(t, server.Close())
+}
+
+func TestServer_RuntimeConfigValidation_NoValidationWithoutOptions(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	// WithRuntimeConfigValidation is not set so Validate() should not be run
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfig(&validatingRuntimeConfig{
+			MaxConnections: 500, // Invalid value
+		}).
+		WithLoggerStdoutWriter(io.Discard).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate()
+
+	defer func() { _ = server.Close() }()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		serverErrChan <- server.Start()
+	}()
+
+	// Wait for server to be ready - should succeed because validation is not enabled
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Shutdown
+	require.NoError(t, server.Close())
+}
+
+func TestServer_RuntimeConfigValidation_MetricOnFailure(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	tmpDir := t.TempDir()
+	runtimePath := tmpDir + "/runtime.yml"
+	// Create invalid config
+	err = os.WriteFile(runtimePath, []byte(`
+max-connections: 500
+`), 0644)
+	require.NoError(t, err)
+
+	var metricRegistry metrics.Registry
+
+	server := witchcraft.NewServer[config.Install, *validatingRuntimeConfig]().
+		WithInstallConfig(config.Install{
+			Server:        config.Server{Address: "127.0.0.1", Port: port},
+			UseConsoleLog: true,
+		}).
+		WithRuntimeConfigFromFile(runtimePath).
+		WithRuntimeConfigValidation(config.RuntimeConfigValidationOptions{
+			MetricOnFailure:     true,
+			FailStartupOnError:  false, // Allow server to start despite validation failure
+			RejectInvalidReload: false,
+		}).
+		WithLoggerStdoutWriter(io.Discard).
+		WithECVKeyProvider(witchcraft.ECVKeyNoOp()).
+		WithDisableGoRuntimeMetrics().
+		WithSelfSignedCertificate().
+		WithInitFunc(func(ctx context.Context, info witchcraft.InitInfo[config.Install, *validatingRuntimeConfig]) (cleanup func(), rErr error) {
+			metricRegistry = metrics.FromContext(ctx)
+			return nil, nil
+		})
+
+	defer func() { _ = server.Close() }()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		serverErrChan <- server.Start()
+	}()
+
+	// Wait for server to be ready
+	client := &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}}
+	require.Eventually(t, func() bool {
+		resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/status/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 100*time.Millisecond, "server did not become ready")
+
+	// Validate metric is incremented
+	var configValidationMetricCount int64
+	metricRegistry.Each(func(name string, tags metrics.Tags, value metrics.MetricVal) {
+		if name == config.ValidationFailureMetric {
+			configValidationMetricCount = value.Value("count").(int64)
+		}
+	})
+	assert.Equal(t, int64(1), configValidationMetricCount)
+
+	// Shutdown
+	require.NoError(t, server.Close())
 }


### PR DESCRIPTION
## Before this PR
There was no built-in way to run validation for install/runtime config types

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add optional config validation support for install and runtime configs

Validation can be enabled via `WithInstallConfigValidation` and `WithRuntimeConfigValidation`. When enabled, if the config type implements the `config.Validator` interface, the `Validate` method is called after unmarshaling. Runtime config validation supports configurable failure behaviors including logging, metrics, health check, startup failure, and reload rejection. A `StrictUnmarshaling` option is also available for both install/runtime config to fail on unknown YAML fields at deserialization time.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

