### PR TITLE
Feature: Add whttpservemux wrouter adapter backed by http.ServeMux

### DIFF
--- a/wrouter/router_test.go
+++ b/wrouter/router_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/v3/wrouter"
 	"github.com/palantir/witchcraft-go-server/v3/wrouter/wgorillamux"
 	"github.com/palantir/witchcraft-go-server/v3/wrouter/whttprouter"
+	"github.com/palantir/witchcraft-go-server/v3/wrouter/whttpservemux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +40,7 @@ func TestRouterImpls(t *testing.T) {
 	}{
 		{"wgorillamux", wgorillamux.New()},
 		{"whttprouter", whttprouter.New()},
+		{"whttpservemux", whttpservemux.New()},
 	} {
 		// create router
 		r := wrouter.New(tc.impl, nil)
@@ -114,6 +116,7 @@ func TestRouterImplSmoke(t *testing.T) {
 	}{
 		{"wgorillamux", wgorillamux.New()},
 		{"whttprouter", whttprouter.New()},
+		{"whttpservemux", whttpservemux.New()},
 	} {
 		func() {
 			// create router
@@ -272,6 +275,7 @@ func TestRouterImplRouteHandling(t *testing.T) {
 		}{
 			{"wgorillamux", wgorillamux.New()},
 			{"whttprouter", whttprouter.New()},
+			{"whttpservemux", whttpservemux.New()},
 		} {
 			func() {
 				// create router

--- a/wrouter/whttpservemux/routerimpl.go
+++ b/wrouter/whttpservemux/routerimpl.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whttpservemux
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/palantir/witchcraft-go-server/v3/wrouter"
+)
+
+// New returns a wrouter.RouterImpl backed by a new http.ServeMux configured using the provided parameters.
+func New(params ...Param) wrouter.RouterImpl {
+	r := &router{
+		mux: http.NewServeMux(),
+	}
+	for _, p := range params {
+		p.apply(r)
+	}
+	return r
+}
+
+// Param is a parameter that configures the behavior of a router.
+type Param interface {
+	apply(*router)
+}
+
+type paramFunc func(*router)
+
+func (f paramFunc) apply(r *router) {
+	f(r)
+}
+
+// NotFoundHandler configures the handler used for requests that do not match any registered route.
+func NotFoundHandler(h http.Handler) Param {
+	return paramFunc(func(r *router) {
+		r.notFoundHandler = h
+	})
+}
+
+type router struct {
+	mux             *http.ServeMux
+	notFoundHandler http.Handler
+}
+
+func (r *router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	_, pattern := r.mux.Handler(req)
+	if pattern == "" {
+		if r.notFoundHandler != nil {
+			r.notFoundHandler.ServeHTTP(w, req)
+			return
+		}
+	}
+	r.mux.ServeHTTP(w, req)
+}
+
+func (r *router) Register(method string, pathSegments []wrouter.PathSegment, handler http.Handler) {
+	r.mux.Handle(convertPathSegments(method, pathSegments), handler)
+}
+
+func (r *router) RegisterNotFoundHandler(handler http.Handler) {
+	r.notFoundHandler = handler
+}
+
+func (r *router) PathParams(req *http.Request, pathVarNames []string) map[string]string {
+	if len(pathVarNames) == 0 {
+		return nil
+	}
+	params := make(map[string]string)
+	for _, name := range pathVarNames {
+		params[name] = req.PathValue(name)
+	}
+	return params
+}
+
+// convertPathSegments converts wrouter path segments and an HTTP method into an http.ServeMux pattern string.
+func convertPathSegments(method string, pathSegments []wrouter.PathSegment) string {
+	pathParts := make([]string, len(pathSegments))
+	for i, segment := range pathSegments {
+		switch segment.Type {
+		case wrouter.PathParamSegment:
+			pathParts[i] = "{" + segment.Value + "}"
+		case wrouter.TrailingPathParamSegment:
+			pathParts[i] = "{" + segment.Value + "...}"
+		default:
+			pathParts[i] = segment.Value
+		}
+	}
+	path := "/" + strings.Join(pathParts, "/")
+	// Append {$} when path ends with "/" to prevent subtree matching.
+	// This is critical for the root path "/" which would otherwise match all requests.
+	if strings.HasSuffix(path, "/") {
+		path += "{$}"
+	}
+	return method + " " + path
+}

--- a/wrouter/whttpservemux/routerimpl_test.go
+++ b/wrouter/whttpservemux/routerimpl_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package whttpservemux_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/palantir/witchcraft-go-server/v3/wrouter"
+	"github.com/palantir/witchcraft-go-server/v3/wrouter/whttpservemux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	handlerCalled := false
+	router := whttpservemux.New()
+	router.Register(http.MethodGet, []wrouter.PathSegment{
+		{
+			Type:  wrouter.LiteralSegment,
+			Value: "hello",
+		},
+	}, http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+	}))
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	_, err := http.Get(server.URL + "/hello")
+	require.NoError(t, err)
+
+	assert.True(t, handlerCalled)
+}
+
+func TestNotFoundHandler(t *testing.T) {
+	handlerCalled := false
+	router := whttpservemux.New(whttpservemux.NotFoundHandler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+	})))
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	_, err := http.Get(server.URL + "/hello")
+	require.NoError(t, err)
+
+	assert.True(t, handlerCalled)
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add whttpservemux wrouter adapter backed by http.ServeMux
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

