### PR TITLE
Feature: Add runtime config option to control audit.2 log emission

### DIFF
--- a/config/runtime.go
+++ b/config/runtime.go
@@ -49,10 +49,10 @@ type AuditConfig struct {
 
 	Environment string `yaml:"environment,omitempty"`
 
-	// ProduceAuditV2Logs controls whether audit.2 logs are emitted.
+	// ProduceAudit2Logs controls whether audit.2 logs are emitted.
 	// If false, all audit.2 log output is suppressed, including dual-logging from audit.3.
 	// If not set or set to true, audit.2 logs are emitted.
-	ProduceAuditV2Logs *bool `yaml:"produce-audit2-logs,omitempty"`
+	ProduceAudit2Logs *bool `yaml:"produce-audit2-logs,omitempty"`
 }
 
 // BaseRuntimeConfig implements the BaseRuntimeConfig interface.

--- a/config/runtime.go
+++ b/config/runtime.go
@@ -48,6 +48,11 @@ type AuditConfig struct {
 	Service string `yaml:"service,omitempty"`
 
 	Environment string `yaml:"environment,omitempty"`
+
+	// ProduceAuditV2Logs controls whether audit.2 logs are emitted.
+	// If false, all audit.2 log output is suppressed, including dual-logging from audit.3.
+	// If not set or set to true, audit.2 logs are emitted.
+	ProduceAuditV2Logs *bool `yaml:"produce-audit2-logs,omitempty"`
 }
 
 // BaseRuntimeConfig implements the BaseRuntimeConfig interface.

--- a/integration/audit_test.go
+++ b/integration/audit_test.go
@@ -218,6 +218,174 @@ func TestAuditLogRuntimeConfigLiveReloaded(t *testing.T) {
 	}
 }
 
+// TestAudit_LogProduceAuditV2LogsConfig verifies that the ProduceAuditV2Logs runtime config field controls audit.2
+// log output suppression, including via dual-logging from audit.3, and supports live reload.
+func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		produceAuditV2    *bool
+		logAuditV3        bool
+		enableDualV3ToV2  bool
+		wantAudit2Entries int
+	}{
+		{
+			name:              "nil ProduceAuditV2Logs emits audit.2 logs",
+			produceAuditV2:    nil,
+			wantAudit2Entries: 1,
+		},
+		{
+			name:              "true ProduceAuditV2Logs emits audit.2 logs",
+			produceAuditV2:    toPtr(true),
+			wantAudit2Entries: 1,
+		},
+		{
+			name:              "false ProduceAuditV2Logs suppresses audit.2 logs",
+			produceAuditV2:    toPtr(false),
+			wantAudit2Entries: 0,
+		},
+		{
+			name:              "false ProduceAuditV2Logs suppresses dual-logged audit.3-to-audit.2 entries",
+			produceAuditV2:    toPtr(false),
+			logAuditV3:        true,
+			enableDualV3ToV2:  true,
+			wantAudit2Entries: 0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var logOutputBuffer bytes.Buffer
+			port, err := httpserver.AvailablePort()
+			require.NoError(t, err)
+
+			runtimeCfg := config.Runtime{
+				LoggerConfig: &config.LoggerConfig{Level: wlog.InfoLevel},
+				AuditConfig: &config.AuditConfig{
+					Deployment:         "test-deployment",
+					Product:            productName,
+					ProductVersion:     productVersion,
+					ProduceAuditV2Logs: tc.produceAuditV2,
+				},
+			}
+			runtimeCfgYML, err := yaml.Marshal(runtimeCfg)
+			require.NoError(t, err)
+
+			server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+				func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+					return nil, info.Router.Register("GET", "/testAuditLog", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if tc.logAuditV3 {
+							audit3log.FromContext(r.Context()).Audit("LogToAudit3", audit3log.AuditResultSuccess)
+						} else {
+							audit2log.FromContext(r.Context()).Audit("LogToAudit2", audit2log.AuditResultSuccess)
+						}
+						w.WriteHeader(http.StatusOK)
+					}))
+				},
+				&logOutputBuffer,
+				func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+					srv := createTestServerWithRuntimeConfigProvider(initFn, installCfg, logOutputBuffer, refreshable.New(runtimeCfgYML))
+					if tc.enableDualV3ToV2 {
+						srv = srv.WithEnableDualLogAuditV3ToAuditV2()
+					}
+					return srv
+				},
+			)
+			defer func() { require.NoError(t, server.Close()) }()
+			defer cleanup()
+
+			client := testServerClient()
+			request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/testAuditLog", port, basePath), nil)
+			require.NoError(t, err)
+			_, err = client.Do(request)
+			require.NoError(t, err)
+
+			audit2LogEntries := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
+			assert.Equal(t, tc.wantAudit2Entries, len(audit2LogEntries), "unexpected number of audit.2 log entries")
+
+			select {
+			case err := <-serverErr:
+				require.NoError(t, err)
+			default:
+			}
+		})
+	}
+
+	t.Run("live reload toggles audit.2 emission", func(t *testing.T) {
+		var logOutputBuffer bytes.Buffer
+		port, err := httpserver.AvailablePort()
+		require.NoError(t, err)
+
+		tmpDir := t.TempDir()
+		runtimeCfg := config.Runtime{
+			LoggerConfig: &config.LoggerConfig{Level: wlog.InfoLevel},
+			AuditConfig: &config.AuditConfig{
+				Deployment:         "test-deployment",
+				Product:            productName,
+				ProductVersion:     productVersion,
+				ProduceAuditV2Logs: nil, // audit.2 logs should be emitted by default
+			},
+		}
+		runtimeCfgYML, err := yaml.Marshal(runtimeCfg)
+		require.NoError(t, err)
+
+		runtimeConfigPath := filepath.Join(tmpDir, "runtime.yml")
+		err = os.WriteFile(runtimeConfigPath, runtimeCfgYML, 0644)
+		require.NoError(t, err)
+
+		fileRefreshable := refreshable.NewFileRefreshable(context.Background(), runtimeConfigPath)
+		_, err = fileRefreshable.Validation()
+		require.NoError(t, err)
+
+		server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+			func(ctx context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+				return nil, info.Router.Register("GET", "/testAuditLog", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					audit2log.FromContext(r.Context()).Audit("LogToAudit2", audit2log.AuditResultSuccess)
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			&logOutputBuffer,
+			func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+				return createTestServerWithRuntimeConfigProvider(initFn, installCfg, logOutputBuffer, fileRefreshable)
+			},
+		)
+		defer func() { require.NoError(t, server.Close()) }()
+		defer cleanup()
+
+		client := testServerClient()
+
+		// First request: audit.2 enabled
+		request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/testAuditLog", port, basePath), nil)
+		require.NoError(t, err)
+		_, err = client.Do(request)
+		require.NoError(t, err)
+
+		audit2LogEntries := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
+		assert.Equal(t, 1, len(audit2LogEntries), "audit.2 should be emitted when ProduceAuditV2Logs is nil")
+
+		// Update runtime config to disable audit.2 logs
+		produceAuditV2False := false
+		runtimeCfg.AuditConfig.ProduceAuditV2Logs = &produceAuditV2False
+		runtimeCfgYML, err = yaml.Marshal(runtimeCfg)
+		require.NoError(t, err)
+		err = os.WriteFile(runtimeConfigPath, runtimeCfgYML, 0644)
+		require.NoError(t, err)
+
+		// Wait for runtime config to reload
+		time.Sleep(1000 * time.Millisecond)
+
+		// Second request: audit.2 should now be suppressed
+		_, err = client.Do(request)
+		require.NoError(t, err)
+
+		audit2LogEntriesAfter := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
+		assert.Equal(t, 1, len(audit2LogEntriesAfter), "audit.2 should be suppressed after ProduceAuditV2Logs set to false")
+
+		select {
+		case err := <-serverErr:
+			require.NoError(t, err)
+		default:
+		}
+	})
+}
+
 // Helper function that starts a server, logs audit entries, and verifies the log output based on the provided
 // parameters.
 func testAuditLogHelper(t *testing.T, logAuditV2, dualLogAuditV2ToAuditV3, logAuditV3, dualLogAuditV3ToV2, inServerInit bool) {

--- a/integration/audit_test.go
+++ b/integration/audit_test.go
@@ -218,34 +218,34 @@ func TestAuditLogRuntimeConfigLiveReloaded(t *testing.T) {
 	}
 }
 
-// TestAudit_LogProduceAuditV2LogsConfig verifies that the ProduceAuditV2Logs runtime config field controls audit.2
+// TestAuditLog_ProduceAudit2LogsConfig verifies that the ProduceAudit2Logs runtime config field controls audit.2
 // log output suppression, including via dual-logging from audit.3, and supports live reload.
-func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
+func TestAuditLog_ProduceAudit2LogsConfig(t *testing.T) {
 	for _, tc := range []struct {
 		name              string
-		produceAuditV2    *bool
+		produceAudit2     *bool
 		logAuditV3        bool
 		enableDualV3ToV2  bool
 		wantAudit2Entries int
 	}{
 		{
-			name:              "nil ProduceAuditV2Logs emits audit.2 logs",
-			produceAuditV2:    nil,
+			name:              "nil ProduceAudit2Logs emits audit.2 logs",
+			produceAudit2:     nil,
 			wantAudit2Entries: 1,
 		},
 		{
-			name:              "true ProduceAuditV2Logs emits audit.2 logs",
-			produceAuditV2:    toPtr(true),
+			name:              "true ProduceAudit2Logs emits audit.2 logs",
+			produceAudit2:     toPtr(true),
 			wantAudit2Entries: 1,
 		},
 		{
-			name:              "false ProduceAuditV2Logs suppresses audit.2 logs",
-			produceAuditV2:    toPtr(false),
+			name:              "false ProduceAudit2Logs suppresses audit.2 logs",
+			produceAudit2:     toPtr(false),
 			wantAudit2Entries: 0,
 		},
 		{
-			name:              "false ProduceAuditV2Logs suppresses dual-logged audit.3-to-audit.2 entries",
-			produceAuditV2:    toPtr(false),
+			name:              "false ProduceAudit2Logs suppresses dual-logged audit.3-to-audit.2 entries",
+			produceAudit2:     toPtr(false),
 			logAuditV3:        true,
 			enableDualV3ToV2:  true,
 			wantAudit2Entries: 0,
@@ -259,10 +259,10 @@ func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
 			runtimeCfg := config.Runtime{
 				LoggerConfig: &config.LoggerConfig{Level: wlog.InfoLevel},
 				AuditConfig: &config.AuditConfig{
-					Deployment:         "test-deployment",
-					Product:            productName,
-					ProductVersion:     productVersion,
-					ProduceAuditV2Logs: tc.produceAuditV2,
+					Deployment:        "test-deployment",
+					Product:           productName,
+					ProductVersion:    productVersion,
+					ProduceAudit2Logs: tc.produceAudit2,
 				},
 			}
 			runtimeCfgYML, err := yaml.Marshal(runtimeCfg)
@@ -317,10 +317,10 @@ func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
 		runtimeCfg := config.Runtime{
 			LoggerConfig: &config.LoggerConfig{Level: wlog.InfoLevel},
 			AuditConfig: &config.AuditConfig{
-				Deployment:         "test-deployment",
-				Product:            productName,
-				ProductVersion:     productVersion,
-				ProduceAuditV2Logs: nil, // audit.2 logs should be emitted by default
+				Deployment:        "test-deployment",
+				Product:           productName,
+				ProductVersion:    productVersion,
+				ProduceAudit2Logs: nil, // audit.2 logs should be emitted by default
 			},
 		}
 		runtimeCfgYML, err := yaml.Marshal(runtimeCfg)
@@ -358,11 +358,11 @@ func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		audit2LogEntries := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
-		assert.Equal(t, 1, len(audit2LogEntries), "audit.2 should be emitted when ProduceAuditV2Logs is nil")
+		assert.Equal(t, 1, len(audit2LogEntries), "audit.2 should be emitted when ProduceAudit2Logs is nil")
 
 		// Update runtime config to disable audit.2 logs
-		produceAuditV2False := false
-		runtimeCfg.AuditConfig.ProduceAuditV2Logs = &produceAuditV2False
+		produceAudit2False := false
+		runtimeCfg.AuditConfig.ProduceAudit2Logs = &produceAudit2False
 		runtimeCfgYML, err = yaml.Marshal(runtimeCfg)
 		require.NoError(t, err)
 		err = os.WriteFile(runtimeConfigPath, runtimeCfgYML, 0644)
@@ -376,7 +376,7 @@ func TestAuditLog_ProduceAuditV2LogsConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		audit2LogEntriesAfter := extractLogEntries[logging.AuditLogV2](t, logOutputBuffer.String(), "audit.2")
-		assert.Equal(t, 1, len(audit2LogEntriesAfter), "audit.2 should be suppressed after ProduceAuditV2Logs set to false")
+		assert.Equal(t, 1, len(audit2LogEntriesAfter), "audit.2 should be suppressed after ProduceAudit2Logs set to false")
 
 		select {
 		case err := <-serverErr:

--- a/witchcraft/internal/metricloggers/writer.go
+++ b/witchcraft/internal/metricloggers/writer.go
@@ -16,6 +16,7 @@ package metricloggers
 
 import (
 	"io"
+	"sync/atomic"
 
 	"github.com/palantir/pkg/metrics"
 )
@@ -47,4 +48,30 @@ func (m *metricWriter) Write(p []byte) (int, error) {
 		m.recorder.RecordSLSLogLength(n)
 	}
 	return n, err
+}
+
+var _ io.Writer = (*ToggleableWriter)(nil)
+
+// ToggleableWriter is an io.Writer that can be atomically enabled or disabled at runtime.
+// When disabled, Write calls return len(p), nil without writing anything.
+type ToggleableWriter struct {
+	w       io.Writer
+	enabled atomic.Bool
+}
+
+func NewToggleableWriter(w io.Writer) *ToggleableWriter {
+	t := &ToggleableWriter{w: w}
+	t.enabled.Store(true)
+	return t
+}
+
+func (t *ToggleableWriter) Write(p []byte) (n int, err error) {
+	if t.enabled.Load() {
+		return t.w.Write(p)
+	}
+	return len(p), nil
+}
+
+func (t *ToggleableWriter) SetEnabled(enabled bool) {
+	t.enabled.Store(enabled)
 }

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -182,7 +182,7 @@ func resolveHostName() (string, error) {
 func (s *Server[I, R]) updateAuditLoggerConfig(auditConfig *config.AuditConfig) {
 	// Update audit.2 log emission independent of the audit3 logger state
 	if s.toggleableAudit2Writer != nil {
-		enabled := auditConfig == nil || auditConfig.ProduceAuditV2Logs == nil || *auditConfig.ProduceAuditV2Logs
+		enabled := auditConfig == nil || auditConfig.ProduceAudit2Logs == nil || *auditConfig.ProduceAudit2Logs
 		s.toggleableAudit2Writer.SetEnabled(enabled)
 	}
 

--- a/witchcraft/loggers.go
+++ b/witchcraft/loggers.go
@@ -78,17 +78,23 @@ func (s *Server[I, R]) initDefaultLoggers(useConsoleLog bool, logLevel wlog.LogL
 	s.trcLogger = metricloggers.NewTrc1Logger(
 		trc1log.New(logWriterFn("trace")), registry)
 
+	// Shared toggleable writer for all audit.2 output (direct and dual-logged)
+	audit2BaseWriter := newDefaultLogOutputWriter("audit", useConsoleLog, loggerStdoutWriter)
+	s.toggleableAudit2Writer = metricloggers.NewToggleableWriter(
+		metricloggers.NewMetricWriter(audit2BaseWriter, registry, "audit"),
+	)
+
 	var audit2Logger audit2log.Logger
 	if s.dualLogAuditV2ToAuditV3 {
-		audit2Logger = audit2log.NewDualLogger(logWriterFn("audit"), logWriterFn("audit.v3"))
+		audit2Logger = audit2log.NewDualLogger(s.toggleableAudit2Writer, logWriterFn("audit.v3"))
 	} else {
-		audit2Logger = audit2log.New(logWriterFn("audit"))
+		audit2Logger = audit2log.New(s.toggleableAudit2Writer)
 	}
 	s.audit2Logger = metricloggers.NewAudit2LoggerWithDualLogging(audit2Logger, registry, s.dualLogAuditV2ToAuditV3)
 
 	var audit3Logger audit3log.Logger
 	if s.dualLogAuditV3ToAuditV2 {
-		audit3Logger = audit3log.NewDualLogger(logWriterFn("audit.v3"), logWriterFn("audit"))
+		audit3Logger = audit3log.NewDualLogger(logWriterFn("audit.v3"), s.toggleableAudit2Writer)
 	} else {
 		audit3Logger = audit3log.New(logWriterFn("audit.v3"))
 	}
@@ -142,8 +148,11 @@ func (s *Server[I, R]) initWrappedLoggers(useConsoleLog bool, productName, produ
 		wrapped1log.New(logWriterFn("metrics"), logLevel, productName, productVersion).Metric(), registry)
 	s.trcLogger = metricloggers.NewTrc1Logger(
 		wrapped1log.New(logWriterFn("trace"), logLevel, productName, productVersion).Trace(), registry)
+	audit2BaseWriter := newDefaultLogOutputWriter("audit", useConsoleLog, loggerStdoutWriter)
+	s.toggleableAudit2Writer = metricloggers.NewToggleableWriter(
+		metricloggers.NewMetricWriter(audit2BaseWriter, registry, "audit"))
 	s.audit2Logger = metricloggers.NewAudit2Logger(
-		wrapped1log.New(logWriterFn("audit"), logLevel, productName, productVersion).Audit(), registry)
+		wrapped1log.New(s.toggleableAudit2Writer, logLevel, productName, productVersion).Audit(), registry)
 	audit3Logger := metricloggers.NewAudit3Logger(
 		wrapped1log.New(logWriterFn("audit.v3"), logLevel, productName, productVersion).AuditV3(), registry)
 	s.audit3Logger.Store(&audit3Logger)
@@ -171,6 +180,12 @@ func resolveHostName() (string, error) {
 }
 
 func (s *Server[I, R]) updateAuditLoggerConfig(auditConfig *config.AuditConfig) {
+	// Update audit.2 log emission independent of the audit3 logger state
+	if s.toggleableAudit2Writer != nil {
+		enabled := auditConfig == nil || auditConfig.ProduceAuditV2Logs == nil || *auditConfig.ProduceAuditV2Logs
+		s.toggleableAudit2Writer.SetEnabled(enabled)
+	}
+
 	audit3Logger := *s.audit3Logger.Load()
 	if audit3Logger == nil {
 		return

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -54,6 +54,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/v3/config"
 	"github.com/palantir/witchcraft-go-server/v3/status"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/dependencyhealth"
+	"github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/metricloggers"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/middleware"
 	refreshablehealth "github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/refreshable"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/wdebug"
@@ -224,6 +225,10 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 	// if true, initializes loggers such that any entry written to the "audit.3" logger
 	// is also dual-logged to the "audit.2" logger.
 	dualLogAuditV3ToAuditV2 bool
+
+	// toggleableAudit2Writer is the shared toggleable writer for all "audit" (v2) file output.
+	// Disabling it suppresses all audit.2 output, including dual-logged entries from the audit.3 logger.
+	toggleableAudit2Writer *metricloggers.ToggleableWriter
 
 	// jobRunnerHealthCheck is the health check source used by the JobManager to report job execution health.
 	// If nil, a default health check with type "WITCHCRAFT_JOB_RUNNER" is created.


### PR DESCRIPTION
## Before this PR
No ability to dynamically control whether audit.2 logs are emitted or not.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add runtime config option to control audit.2 log emission

`Runtime.AuditConfig.ProduceAuditV2Logs` controls whether audit.2 logs are emitted. When false, all audit.2 output is suppressed, including entries dual-logged from the audit.3 logger. Defaults to enabled when unset.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

