### PR TITLE
improvement: Add DelegatingDiagnosticHandler for instances in which the DiagnosticWriter isn't knowable at server startup

### DIFF
--- a/witchcraft/wdebug/delegating_diagnostic_handler.go
+++ b/witchcraft/wdebug/delegating_diagnostic_handler.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wdebug
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+
+	werror "github.com/palantir/witchcraft-go-error"
+)
+
+// DiagnosticWriter is the interface that resource-specific diagnostic implementations must satisfy.
+type DiagnosticWriter interface {
+	WriteDiagnostic(ctx context.Context, w io.Writer) error
+}
+
+// DelegatingDiagnosticHandler extends DiagnosticHandler with the ability to lazily set
+// the underlying writer after construction.
+type DelegatingDiagnosticHandler interface {
+	DiagnosticHandler
+	SetWriter(writer DiagnosticWriter)
+}
+
+// DiagnosticHandlerConfig holds the static metadata for a diagnostic handler.
+type DiagnosticHandlerConfig struct {
+	DiagnosticType DiagnosticType
+	Documentation  string
+	ContentType    string
+	SafeLoggable   bool
+	Extension      string
+}
+
+// diagnosticHandler is the concrete implementation of DelegatingDiagnosticHandler.
+type diagnosticHandler struct {
+	config DiagnosticHandlerConfig
+	writer atomic.Pointer[DiagnosticWriter]
+}
+
+var _ DelegatingDiagnosticHandler = &diagnosticHandler{}
+
+// NewDelegatingDiagnosticHandler creates a new DelegatingDiagnosticHandler with the given configuration.
+// Call SetWriter once the resource-specific dependencies are available.
+func NewDelegatingDiagnosticHandler(config DiagnosticHandlerConfig) DelegatingDiagnosticHandler {
+	return &diagnosticHandler{
+		config: config,
+	}
+}
+
+// SetWriter sets the resource-specific writer that handles WriteDiagnostic calls.
+func (h *diagnosticHandler) SetWriter(writer DiagnosticWriter) {
+	h.writer.Store(&writer)
+}
+
+func (h *diagnosticHandler) Type() DiagnosticType {
+	return h.config.DiagnosticType
+}
+
+func (h *diagnosticHandler) Documentation() string {
+	return h.config.Documentation
+}
+
+func (h *diagnosticHandler) ContentType() string {
+	return h.config.ContentType
+}
+
+func (h *diagnosticHandler) SafeLoggable() bool {
+	return h.config.SafeLoggable
+}
+
+func (h *diagnosticHandler) Extension() string {
+	return h.config.Extension
+}
+
+func (h *diagnosticHandler) WriteDiagnostic(ctx context.Context, w io.Writer) error {
+	writer := h.writer.Load()
+	if writer == nil {
+		return werror.ErrorWithContextParams(ctx, "diagnostic writer not yet initialized")
+	}
+	return (*writer).WriteDiagnostic(ctx, w)
+}

--- a/witchcraft/wdebug/delegating_diagnostic_handler_test.go
+++ b/witchcraft/wdebug/delegating_diagnostic_handler_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wdebug
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockDiagnosticWriter struct {
+	writeFn func(ctx context.Context, w io.Writer) error
+}
+
+func (m *mockDiagnosticWriter) WriteDiagnostic(ctx context.Context, w io.Writer) error {
+	return m.writeFn(ctx, w)
+}
+
+func TestNewDelegatingDiagnosticHandler_ReturnsConfigValues(t *testing.T) {
+	handler := NewDelegatingDiagnosticHandler(DiagnosticHandlerConfig{
+		DiagnosticType: "test.type.v1",
+		Documentation:  "test documentation",
+		ContentType:    "text/plain",
+		SafeLoggable:   false,
+		Extension:      "txt",
+	})
+	assert.Equal(t, DiagnosticType("test.type.v1"), handler.Type())
+	assert.Equal(t, "test documentation", handler.Documentation())
+	assert.Equal(t, "text/plain", handler.ContentType())
+	assert.False(t, handler.SafeLoggable())
+	assert.Equal(t, "txt", handler.Extension())
+}
+
+func TestDelegatingDiagnosticHandler_WriteDiagnostic_BeforeSetWriter(t *testing.T) {
+	handler := NewDelegatingDiagnosticHandler(DiagnosticHandlerConfig{
+		DiagnosticType: "test.type.v1",
+		Documentation:  "test",
+		ContentType:    "application/json",
+		Extension:      "json",
+	})
+	var buf bytes.Buffer
+	err := handler.WriteDiagnostic(context.Background(), &buf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "diagnostic writer not yet initialized")
+}
+
+func TestDelegatingDiagnosticHandler_WriteDiagnostic_DelegatesToWriter(t *testing.T) {
+	handler := NewDelegatingDiagnosticHandler(DiagnosticHandlerConfig{
+		DiagnosticType: "test.type.v1",
+		Documentation:  "test",
+		ContentType:    "application/json",
+		Extension:      "json",
+	})
+	handler.SetWriter(&mockDiagnosticWriter{
+		writeFn: func(ctx context.Context, w io.Writer) error {
+			return nil
+		},
+	})
+	var buf bytes.Buffer
+	err := handler.WriteDiagnostic(context.Background(), &buf)
+	assert.NoError(t, err)
+}
+
+func TestDelegatingDiagnosticHandler_WriteDiagnostic_PropagatesWriterError(t *testing.T) {
+	handler := NewDelegatingDiagnosticHandler(DiagnosticHandlerConfig{
+		DiagnosticType: "test.type.v1",
+		Documentation:  "test",
+		ContentType:    "application/json",
+		Extension:      "json",
+	})
+	handler.SetWriter(&mockDiagnosticWriter{
+		writeFn: func(ctx context.Context, w io.Writer) error {
+			return errors.New("writer error")
+		},
+	})
+	var buf bytes.Buffer
+	err := handler.WriteDiagnostic(context.Background(), &buf)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "writer error")
+}


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

