### PR TITLE
fix: Fix race condition in which InitInfo handler to CustomDiagnosticHandlers would not be respected if done after registration 

### DIFF
--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -173,12 +173,12 @@ func TestServer_DiagnosticRegisteredInInitGoroutineNotFound(t *testing.T) {
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "builder-registered diagnostic should return 200")
-	// InitInfo goroutine-registered diagnostic should NOT be served (proves the bug)
+	// InitInfo goroutine-registered diagnostic should also be served (refreshable picks up late registrations)
 	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/debug/diagnostic/%s", port, basePath, "custom.initinfo.v1"), nil)
 	require.NoError(t, err)
 	resp, err = client.Do(req)
 	require.NoError(t, err)
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "initInfo goroutine-registered diagnostic should return 400 because it was registered after addRoutes snapshot")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "initInfo goroutine-registered diagnostic should return 200 because customDiagnosticHandlers is a refreshable")
 	select {
 	case err := <-serverErr:
 		require.NoError(t, err)

--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -15,16 +15,19 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/palantir/pkg/httpserver"
 	"github.com/palantir/witchcraft-go-server/v3/config"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft"
+	"github.com/palantir/witchcraft-go-server/v3/witchcraft/wdebug"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +37,20 @@ const (
 	tmpDir             = "/tmp"
 	tmpFilePath        = "/tmp/tmpFile"
 )
+
+type testDiagnosticHandler struct {
+	diagnosticType wdebug.DiagnosticType
+}
+
+func (h testDiagnosticHandler) Type() wdebug.DiagnosticType                          { return h.diagnosticType }
+func (h testDiagnosticHandler) Documentation() string                                 { return "test diagnostic" }
+func (h testDiagnosticHandler) ContentType() string                                   { return "text/plain" }
+func (h testDiagnosticHandler) SafeLoggable() bool                                    { return true }
+func (h testDiagnosticHandler) Extension() string                                     { return "txt" }
+func (h testDiagnosticHandler) WriteDiagnostic(_ context.Context, w io.Writer) error {
+	_, err := w.Write([]byte("ok"))
+	return err
+}
 
 func TestServer_DiagnosticsSharedSecret(t *testing.T) {
 	tests := []struct {
@@ -116,5 +133,55 @@ func TestServer_DiagnosticsSharedSecret(t *testing.T) {
 			default:
 			}
 		})
+	}
+}
+
+// TestServer_DiagnosticRegisteredInInitGoroutineNotFound proves that diagnostic handlers
+// registered via InitInfo.Router.WithCustomDiagnosticHandlers inside a goroutine (simulating
+// an async initialization) are not available on the server. The handler registered on the
+// builder before Start is served, but the one registered asynchronously in the init function
+// returns 400 because addRoutes snapshots the handlers before the goroutine runs.
+func TestServer_DiagnosticRegisteredInInitGoroutineNotFound(t *testing.T) {
+	builderHandler := testDiagnosticHandler{diagnosticType: "custom.builder.v1"}
+	initInfoHandler := testDiagnosticHandler{diagnosticType: "custom.initinfo.v1"}
+	port, err := httpserver.AvailablePort()
+	require.NoError(t, err)
+	server, serverErr, cleanup := createAndRunCustomTestServer(t, port, port,
+		func(_ context.Context, info witchcraft.InitInfo[config.Install, config.Runtime]) (func(), error) {
+			go func() {
+				time.Sleep(1 * time.Second)
+				info.Router.WithCustomDiagnosticHandlers(initInfoHandler)
+			}()
+			return nil, nil
+		},
+		io.Discard,
+		func(t *testing.T, initFn witchcraft.InitFunc[config.Install, config.Runtime], installCfg config.Install, logOutputBuffer io.Writer) *witchcraft.Server[config.Install, config.Runtime] {
+			return createTestServer(t, initFn, installCfg, logOutputBuffer).
+				WithCustomDiagnosticHandlers(builderHandler)
+		},
+	)
+	defer func() {
+		require.NoError(t, server.Close())
+	}()
+	defer cleanup()
+	// Wait for the goroutine to have registered its handler
+	time.Sleep(2 * time.Second)
+	client := testServerClient()
+	// Builder-registered diagnostic should be served
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/debug/diagnostic/%s", port, basePath, "custom.builder.v1"), nil)
+	require.NoError(t, err)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "builder-registered diagnostic should return 200")
+	// InitInfo goroutine-registered diagnostic should NOT be served (proves the bug)
+	req, err = http.NewRequest(http.MethodGet, fmt.Sprintf("https://localhost:%d/%s/debug/diagnostic/%s", port, basePath, "custom.initinfo.v1"), nil)
+	require.NoError(t, err)
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode, "initInfo goroutine-registered diagnostic should return 400 because it was registered after addRoutes snapshot")
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	default:
 	}
 }

--- a/integration/diagnostics_test.go
+++ b/integration/diagnostics_test.go
@@ -42,11 +42,11 @@ type testDiagnosticHandler struct {
 	diagnosticType wdebug.DiagnosticType
 }
 
-func (h testDiagnosticHandler) Type() wdebug.DiagnosticType                          { return h.diagnosticType }
-func (h testDiagnosticHandler) Documentation() string                                 { return "test diagnostic" }
-func (h testDiagnosticHandler) ContentType() string                                   { return "text/plain" }
-func (h testDiagnosticHandler) SafeLoggable() bool                                    { return true }
-func (h testDiagnosticHandler) Extension() string                                     { return "txt" }
+func (h testDiagnosticHandler) Type() wdebug.DiagnosticType { return h.diagnosticType }
+func (h testDiagnosticHandler) Documentation() string       { return "test diagnostic" }
+func (h testDiagnosticHandler) ContentType() string         { return "text/plain" }
+func (h testDiagnosticHandler) SafeLoggable() bool          { return true }
+func (h testDiagnosticHandler) Extension() string           { return "txt" }
 func (h testDiagnosticHandler) WriteDiagnostic(_ context.Context, w io.Writer) error {
 	_, err := w.Write([]byte("ok"))
 	return err

--- a/witchcraft/internal/wdebug/resource.go
+++ b/witchcraft/internal/wdebug/resource.go
@@ -35,18 +35,16 @@ const (
 
 type debugResource struct {
 	SharedSecret             refreshable.Refreshable[string]
-	customDiagnosticHandlers map[wdebug.DiagnosticType]wdebug.DiagnosticHandler
+	customDiagnosticHandlers refreshable.Refreshable[map[wdebug.DiagnosticType]wdebug.DiagnosticHandler]
 }
 
-func RegisterRoute(ctx context.Context, router wrouter.Router, sharedSecret refreshable.Refreshable[string], customDiagnosticHandlers ...wdebug.DiagnosticHandler) error {
-	customHandlersByType := make(map[wdebug.DiagnosticType]wdebug.DiagnosticHandler, len(customDiagnosticHandlers))
-	for _, handler := range customDiagnosticHandlers {
+func RegisterRoute(ctx context.Context, router wrouter.Router, sharedSecret refreshable.Refreshable[string], customDiagnosticHandlers refreshable.Refreshable[map[wdebug.DiagnosticType]wdebug.DiagnosticHandler]) error {
+	for _, handler := range customDiagnosticHandlers.Current() {
 		if err := handler.Type().Validate(); err != nil {
 			return werror.WrapWithContextParams(ctx, err, "failed to register WitchcraftDebugService")
 		}
-		customHandlersByType[handler.Type()] = handler
 	}
-	r := &debugResource{SharedSecret: sharedSecret, customDiagnosticHandlers: customHandlersByType}
+	r := &debugResource{SharedSecret: sharedSecret, customDiagnosticHandlers: customDiagnosticHandlers}
 	if err := wresource.New("witchcraftdebugservice", router).
 		Get("GetDiagnostic", "/debug/diagnostic/{diagnosticType}",
 			httpserver.NewJSONHandler(r.ServeHTTP, httpserver.StatusCodeMapper, httpserver.ErrHandler),
@@ -93,6 +91,6 @@ func (r *debugResource) resolveHandlerForType(diagnosticType wdebug.DiagnosticTy
 	if ok {
 		return handler, true
 	}
-	handler, ok = r.customDiagnosticHandlers[diagnosticType]
+	handler, ok = r.customDiagnosticHandlers.Current()[diagnosticType]
 	return handler, ok
 }

--- a/witchcraft/internal/wdebug/resource_test.go
+++ b/witchcraft/internal/wdebug/resource_test.go
@@ -35,7 +35,7 @@ func TestDebugResource(t *testing.T) {
 	ctx := context.Background()
 	r := wrouter.New(whttprouter.New())
 	secret := refreshable.New("secret1")
-	err := RegisterRoute(ctx, r, secret)
+	err := RegisterRoute(ctx, r, secret, refreshable.New(map[wdebug.DiagnosticType]wdebug.DiagnosticHandler{}))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)

--- a/witchcraft/server_routes.go
+++ b/witchcraft/server_routes.go
@@ -31,6 +31,7 @@ import (
 	"github.com/palantir/witchcraft-go-server/v3/status/routes"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/middleware"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/internal/wdebug"
+	wdebugapi "github.com/palantir/witchcraft-go-server/v3/witchcraft/wdebug"
 	"github.com/palantir/witchcraft-go-server/v3/witchcraft/wresource"
 	"github.com/palantir/witchcraft-go-server/v3/wrouter"
 	"github.com/palantir/witchcraft-go-tracing/wtracing"
@@ -54,7 +55,10 @@ func (s *Server[I, R]) addRoutes(ctx context.Context, mgmtRouterWithContextPath 
 	if err != nil {
 		return err
 	}
-	if err := wdebug.RegisterRoute(ctx, mgmtRouterWithContextPath, secretRefreshable, s.customDiagnosticHandlers...); err != nil {
+	if s.customDiagnosticHandlers == nil {
+		s.customDiagnosticHandlers = refreshable.New(map[wdebugapi.DiagnosticType]wdebugapi.DiagnosticHandler{})
+	}
+	if err := wdebug.RegisterRoute(ctx, mgmtRouterWithContextPath, secretRefreshable, s.customDiagnosticHandlers); err != nil {
 		return err
 	}
 

--- a/witchcraft/witchcraft.go
+++ b/witchcraft/witchcraft.go
@@ -129,7 +129,7 @@ type Server[I config.BaseInstallConfig, R config.BaseRuntimeConfig] struct {
 	// specifies the handlers to invoke upon health status changes. The LoggingHealthStatusChangeHandler is added by default.
 	healthStatusChangeHandlers []status.HealthStatusChangeHandler
 
-	customDiagnosticHandlers []wdebug.DiagnosticHandler
+	customDiagnosticHandlers refreshable.Updatable[map[wdebug.DiagnosticType]wdebug.DiagnosticHandler]
 
 	// if true, disables the SERVICE_DEPENDENCY health check.
 	disableServiceDependencyHealth bool
@@ -622,8 +622,18 @@ func (s *Server[I, R]) WithHealthStatusChangeHandlers(handlers ...status.HealthS
 
 // WithCustomDiagnosticHandlers configures the application's custom diagnostic handlers.
 // This adds to the default diagnostic handlers provided by the server.
+// Handlers can be added before or after server startup and will be available immediately.
 func (s *Server[I, R]) WithCustomDiagnosticHandlers(handlers ...wdebug.DiagnosticHandler) *Server[I, R] {
-	s.customDiagnosticHandlers = append(s.customDiagnosticHandlers, handlers...)
+	if s.customDiagnosticHandlers == nil {
+		s.customDiagnosticHandlers = refreshable.New(map[wdebug.DiagnosticType]wdebug.DiagnosticHandler{})
+	}
+	current := s.customDiagnosticHandlers.Current()
+	updated := make(map[wdebug.DiagnosticType]wdebug.DiagnosticHandler, len(current)+len(handlers))
+	maps.Copy(updated, current)
+	for _, h := range handlers {
+		updated[h.Type()] = h
+	}
+	s.customDiagnosticHandlers.Update(updated)
 	return s
 }
 


### PR DESCRIPTION
- Fix race condition in which InitInfo handler to CustomDiagnosticHandlers would not be respected if done after registration 
- We expose this functionality on InitInfo, however if it is registered before the handlers are passed into `witchcraft/internal/wdebug/resource.go` than the stale handlers are used
- This fixes this by moving it to a refreshable like all the other fields on  `InitInfo`
- Add an integration test that confirmed the break and the fix
